### PR TITLE
docs: reconcile docs with as-built repo + harden CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  go:
+    name: Go (vet + test)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
+      - name: go vet
+        run: go vet ./...
+      - name: go test
+        run: go test ./...
+
+  web:
+    name: Web (build + test)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+      - run: npm ci
+      - run: npm run build
+      - run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   go:
-    name: Go (vet + test)
+    name: Go (fmt + vet + test)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -20,6 +20,8 @@ jobs:
         with:
           go-version-file: go.mod
           cache-dependency-path: go.sum
+      - name: gofmt
+        run: test -z "$(gofmt -l .)"
       - name: go vet
         run: go vet ./...
       - name: go test
@@ -41,3 +43,34 @@ jobs:
       - run: npm ci
       - run: npm run build
       - run: npm test
+
+  contract:
+    name: Contract parity (Python <-> Go)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install redis
+      - name: live.py <-> Go contract self-check
+        run: python check_live_contract.py
+        working-directory: ingest
+
+  docs-links:
+    name: Docs link check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: lycheeverse/lychee-action@v2
+        with:
+          args: "--no-progress --exclude-loopback README.md CONTEXT.md docs/*.md docs/adr/**/*.md"
+          fail: true
+
+  docker:
+    name: Docker build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: docker compose build
+        run: docker compose build

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,87 @@
+# Context — F1 Race Tracker glossary
+
+The shared vocabulary of this project. Use these terms exactly; avoid the listed
+synonyms. This file is a glossary, not a spec — no implementation details.
+
+## Lane
+
+One independent stream of race state, identified by a **session key**, with its own
+snapshot and frame channel. A lane is fed by exactly one **writer** at a time. The
+running lanes are **replay** (the default Monza clip), **live** (the Python-fed
+lane), and the two **compare** lanes (same circuit, two seasons, played in phase).
+
+- _Use_ "lane", not "channel", "feed", or "stream" when you mean this whole unit.
+- Lanes never touch each other's state.
+
+## Writer
+
+The single process publishing state to a given lane. In the **replay** lane the Go
+replay player is the writer; in the **live** lane the Python ingester is the writer.
+
+- Exactly one writer per lane at any moment — never two.
+- _Use_ "writer", not "producer" or "publisher" for the role.
+
+## The seam
+
+Redis — the one piece of shared state and the only thing Python and Go agree on.
+They never call each other; they exchange the **event model** as JSON over Redis.
+
+- _Use_ "the seam" for this decoupling point. It is language-agnostic by design.
+
+## Gateway
+
+The Go process that reads a lane from the seam, holds the current **snapshot** in
+memory, serves the React app, and fans **frames** out over WebSocket. It only reads
+and serves — it is never a writer.
+
+- The system runs **one** gateway today; the design allows more (see
+  `docs/adr/0001-single-gateway-deferred-multigateway.md`).
+
+## Event model
+
+The normalised contract — **CarState**, **Snapshot**, **Frame** — shared identically
+by Python and Go. Positions come first; the running order falls out of the same data.
+
+- _Use_ "event model" or "the contract"; the canonical definition is the Go types.
+
+## Snapshot
+
+The full current state of a lane, served to a newly-connected or reconnecting client
+as its first message. The **source of truth** — any missed frame is healed by the
+next snapshot.
+
+## Frame
+
+A per-tick update published to clients. For a track map nearly every car moves every
+frame, so a frame in practice carries (almost) all cars — it is not a sparse diff.
+
+## Rev
+
+One global, monotonic revision number owned by the active **writer**. It must never
+reset — not across a replay loop, not across a live↔replay switch. Clients ignore any
+**Rev** at or below the one they already applied (idempotent resume).
+
+- _Use_ "Rev"; do not call it "version", "sequence", or "tick".
+
+## Session key
+
+The string identifying a **lane** (e.g. `replay`, `live`, `compare-monza-2024`).
+Names the Redis keys for that lane and selects it in `/ws?session=<key>`.
+
+## Live / Replay
+
+The two interchangeable **sources** behind one pipeline. **Replay** loops a committed
+clip and is the always-on default. **Live** is the real-session source — best-effort,
+and in the default demo it streams a clip through Python to exercise **the seam**
+rather than connecting to a real session.
+
+- _Use_ "source" for the live-vs-replay choice; the operator switches it via a toggle.
+
+## Compare
+
+The cross-year view: the same circuit across two seasons shown as two maps side by
+side, kept in phase. It is the single-map view rendered twice over two **compare
+lanes** — no new data type.
+
+- _Use_ "compare" / "comparison", not "diff" or "overlay" (the computed delta overlay
+  is a separate, deferred Phase 4 concept).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 natcat38
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/docs/F1_Race_Tracker_Product_Scope.md
+++ b/docs/F1_Race_Tracker_Product_Scope.md
@@ -26,7 +26,7 @@ A **real-time F1 race visualisation**: a Python ingestion layer feeds normalised
 - An **animated track map**: cars moving around the circuit in real time, the **track outline drawn from the position data itself** (no per-circuit map files needed).
 - A **minimal standings list** beside the map (running order), which comes "for free" from the same data.
 - **Live or replay**, with a **manual toggle** to switch between them. The replay loops cleanly and is the default "always looks alive" mode.
-- **Cross-year comparison:** the same circuit across two seasons (e.g. **2025 vs 2026**) shown as **two maps side by side, aligned**, so you can watch how the racing differed. Built *last* in Phase 1, on top of the working single map.
+- **Cross-year comparison:** the same circuit across two seasons (e.g. **2023 vs 2024**) shown as **two maps side by side, aligned**, so you can watch how the racing differed. Built *last* in Phase 1, on top of the working single map.
 - New visitors **joining mid-session immediately see the current state** (a snapshot), then live updates. **Reconnects** re-sync automatically.
 
 **Phase 2 — Pit-Wall Timing Dashboard (later):**
@@ -62,7 +62,7 @@ A **real-time F1 race visualisation**: a Python ingestion layer feeds normalised
 | Python | **1c:** Live feed (FastF1 live → Redis) + manual live/replay toggle | 2 d | Ingest |
 | Both | **1d:** Cross-year comparison (two maps side by side, lap-aligned) | 2.5 d | Comparison |
 | Ops | Curated downsampled clips (incl. same-track two-year pair) | 0.5 d | Data |
-| Both | `docker-compose` (Python + Redis + N Go gateways) | 1 d | Shell/Ops |
+| Both | `docker-compose` (Python + Redis + Go gateway) | 1 d | Shell/Ops |
 | Go | Hub convergence integration test | 0.5 d | Realtime |
 | Ops | Load test + benchmark + README + demo recording | 1.5 d | Ops |
 | | **Phase 1 total** | **~23–25 d** | |
@@ -90,12 +90,12 @@ A **real-time F1 race visualisation**: a Python ingestion layer feeds normalised
 - A compact list beside the map showing the **running order** (position, driver code, team colour). The detailed timing screen (gaps, tyres, sectors) is **Phase 2**, not here.
 
 ### 4.3 Live / replay toggle (Phase 1)
-- A control to **switch the source**: play a recorded replay, or connect to the **live** session. The switch is server-side (the active *writer* changes); all connected viewers converge to the new source.
+- A control to **switch the source**: play a recorded replay, or switch to the **live** lane. The switch is server-side (the active *writer* changes); all connected viewers converge to the new source. The live lane is best-effort: a real F1 session is only available on race weekends, so **out of the box the live lane streams a clip through the Python writer** — this exercises the polyglot seam (Python publishing the identical contract the Go writer uses) rather than literal live data. The real live-timing client exists and is used during actual sessions.
 - Because the deployment is local and single-operator, the toggle is **open** — no login. (There is no anonymous public site to protect.)
 - The replay **loops cleanly** — a brief `↻ replay restarting` beat covers the reset so it never snaps jarringly from finish back to lap 1.
 
 ### 4.4 Cross-year comparison (Phase 1, built last)
-- Pick the **same circuit across two seasons** (e.g. Monza 2025 and Monza 2026). The view shows **two maps side by side**, playback **aligned** so you can watch the same phase of the race in both years at once. It is literally the single-map view **rendered twice** — no new data type.
+- Pick the **same circuit across two seasons** (e.g. Monza 2023 and Monza 2024). The view shows **two maps side by side**, playback **aligned** so you can watch the same phase of the race in both years at once. It is literally the single-map view **rendered twice** — no new data type.
 
 ### 4.5 Joining mid-session & connection states
 A visitor who connects after playback started **immediately sees the current car positions** (from the latest snapshot), then live updates. Connection rules:
@@ -133,9 +133,9 @@ A visitor who connects after playback started **immediately sees the current car
 > This replaces the original "always-on hosted site." There is **no required hosting** and **no cost**.
 
 - **Primary artifact (what most people see):** a polished **README** with the architecture diagram, a recorded **GIF/video** of the map animating and the two-year comparison, and the **benchmark numbers**.
-- **Hands-on reviewer:** **`docker-compose up`** runs the *full real system* locally — Python ingestion + Redis + **multiple** Go gateways — so a serious reviewer sees the actual distributed architecture, not a simplified version.
+- **Hands-on reviewer:** **`docker-compose up`** runs the *full real system* locally — Python ingestion + Redis + the Go gateway — so a serious reviewer sees the actual polyglot architecture, not a simplified version. The gateway is stateless by design (so it *could* run as multiple replicas), but the system currently runs and is benchmarked as a single gateway — see `docs/adr/0001-single-gateway-deferred-multigateway.md`.
 - **Hosted live link:** *optional and deferred.* Deploy instructions are included so it can go live in ~20 minutes, but running it 24/7 is never a requirement or a maintenance burden.
-- **The benchmark** (thousands of concurrent WebSocket connections, p50/p99 latency) is run on demand and published in `BENCHMARKS.md` — this is where the horizontal-scale claim is *proven*, with the multi-gateway + Redis configuration.
+- **The benchmark** (concurrent WebSocket connections, p50/p99 fan-out latency) is run on demand and published in `BENCHMARKS.md` — it measures how a **single gateway** holds up as concurrent viewers climb (a lower bound, since the load generator shares the host). The stateless-gateway + Redis seam is what *would* make a multi-gateway tier a config change; building and benchmarking that tier is future work (see ADR-0001).
 
 ---
 

--- a/docs/F1_Race_Tracker_Tech_Scope.md
+++ b/docs/F1_Race_Tracker_Tech_Scope.md
@@ -306,6 +306,9 @@ Architecture diagram (§2.1), GIF of the map + the two-year comparison, `docker 
   `docs/adr/0001-single-gateway-deferred-multigateway.md`. As of this writing the
   benchmark is **designed but not yet implemented** (no `cmd/loadtest`, `bench/`, or
   `BENCHMARKS.md` exist yet).
-- **CI:** `.github/workflows/ci.yml` runs `go vet` + `go test` and the web build + test;
-  `.github/workflows/okf.yml` separately validates the `knowledge/` bundle. (`npm run lint`
-  is intentionally not gated yet — there are pre-existing lint errors to clear first.)
+- **CI:** `.github/workflows/ci.yml` gates every PR with: `gofmt` + `go vet` + `go test`;
+  the web build + test; the Python↔Go contract self-check (`ingest/check_live_contract.py`);
+  a markdown link check over `README`/`CONTEXT`/`docs/` (lychee); and a `docker compose build`
+  smoke test. `.github/workflows/okf.yml` separately validates the `knowledge/` bundle.
+  (`npm run lint` and `go test -race` are intentionally not gated yet — lint has pre-existing
+  errors to clear first.)

--- a/docs/F1_Race_Tracker_Tech_Scope.md
+++ b/docs/F1_Race_Tracker_Tech_Scope.md
@@ -61,7 +61,7 @@ Referenced by all tasks. Define it once here. This section *is* the system-desig
 
 - **Exactly one writer publishes at a time.** In **replay** mode the Go replay player is the writer; in **live** mode the Python live client is the writer. The manual toggle (Task 10) starts one and stops the other — never both on the `featured` channel at once.
 - **Redis is the language-agnostic seam.** Python and Go never call each other; they agree only on the JSON event contract (§2.2) over Redis. ⚠️ This decoupling is the headline — say it in the README.
-- **Gateways only read + serve.** Subscribe to `frames:{s}`, keep an in-memory snapshot, serve the React app + WebSockets. Stateless, so you scale them horizontally (the benchmark, Task 14).
+- **Gateways only read + serve.** Subscribe to `frames:{s}`, keep an in-memory snapshot, serve the React app + WebSockets. Stateless *by design*, so the tier could scale out to multiple gateways — though the system as built runs a single gateway and the benchmark (Task 14) measures that one (see the as-built addendum and ADR-0001).
 - ⚠️ **One global, monotonic `Rev`, owned by whichever writer is active.** It must **never reset** — not across a replay loop, not across a live↔replay switch. If a fresh source restarted at `Rev=1`, clients holding a higher rev would reject its snapshot and the map would freeze. On every source switch, publish a full fresh snapshot at the next rev.
 
 ### 2.2 The normalised model — positions first
@@ -264,7 +264,48 @@ Architecture diagram (§2.1), GIF of the map + the two-year comparison, `docker 
 - **Draw the track from data, not files** (§2.4) — scale coordinates to a unit box at record time.
 - **Build order is load-bearing:** plain dots end-to-end (Task 7) before the polished map (Task 8); comparison (Task 11) only after a single map works live + replay. Cut order if schedule slips: comparison first, then the live toggle (keep replay-only core + benchmark).
 - **Live is best-effort and Python-side** (Task 10) — verify FastF1's live behaviour early; never let live-hardening eat the schedule, since replay is the demo.
-- **No required hosting / no cost:** `docker compose up` runs the full real system locally (Python + Redis + N gateways); the multi-gateway + Redis benchmark is where scale is proven. Deploy is an optional ~20-min bonus.
+- **No required hosting / no cost:** `docker compose up` runs the full real system locally (Python + Redis + the Go gateway); the benchmark measures the single gateway's fan-out under load. A multi-gateway tier is designed-for but unbuilt (ADR-0001). Deploy is an optional ~20-min bonus.
 - **Free data only:** FastF1 (historical + free live client); OpenF1 historical as a fallback. ⚠️ OpenF1 *live* now needs a paid tier and is rate-limited — prefer FastF1 for live.
 - **Presentable repo:** `main` branch, README with the §2.1 diagram + GIF + `BENCHMARKS.md` headline, MIT `LICENSE`, green CI, Conventional Commits.
 - **Out-of-scope guardrails:** Phase 1 is the map + standings + comparison only. Pit-wall timing (Phase 2), team radio (Phase 3), and the computed ghost-overlay (Phase 4) are deferred and reuse this pipeline.
+
+---
+
+## Built differently than planned (as-built deltas)
+
+> This section reconciles the plan above (written pre-build) with the code as it
+> actually shipped. The task table and file paths above are kept as the historical
+> plan; where reality diverged, the truth is here. The living architecture docs are
+> the [README](../README.md) and the [`knowledge/`](../knowledge/index.md) bundle.
+
+- **Gateway entrypoint** is `cmd/server/main.go` (the plan said `cmd/gateway/main.go`).
+  Gateway wiring lives under `internal/app/`.
+- **The source-toggle control endpoint** (`GET`/`POST /control/source`) lives in
+  `internal/app/gateway.go`, not the planned `internal/api/control.go`.
+- **The Python side of the contract is inline** in `ingest/live.py` (and
+  `ingest/record.py`) — there is no separate `ingest/model.py` or `ingest/normalise.py`.
+  The Go types in `internal/model/model.go` are the canonical contract; the Python
+  writer emits the byte-identical JSON shape directly.
+- **Track drawing and smoothing live in the frontend components**, not a `web/src/track/`
+  module: the circuit is drawn in `web/src/components/Map.tsx` and inter-frame motion is
+  smoothed in `web/src/hooks/useSmoothedCars.ts`.
+- **`cmd/genclip`** (Go) is an as-built clip baker/normaliser that produces the
+  committed `data/replays/*.jsonl` clips; it isn't named in the plan's task table.
+- **Tests** landed as `internal/ws/hub_test.go` plus an end-to-end
+  `internal/app/integration_test.go` (the plan named `internal/ws/hub_integration_test.go`).
+- **Compose runs lane services, not one `ingest`.** `docker-compose.yml` has `redis`,
+  `replay` (Go writer, Monza), `live` (Python writer, currently a clip — the polyglot
+  seam demo), `compare-2023` + `compare-2024` (the two phased comparison lanes), and
+  `gateway`. The plan's Task 6.2 described a single `ingest` service.
+- **Committed clips** are Monza 2023, Monza 2024, and Silverstone 2024 (the plan's
+  `2025`/`2026` examples were placeholders).
+- **Task 14 (load test + benchmark) was re-scoped** to a single-gateway, client-side
+  latency measurement (`now − frame.T`) — no `/metrics` endpoint and no multi-gateway
+  setup, neither of which M1–M3 built. See
+  `docs/superpowers/specs/2026-06-19-f1-m4-loadtest-benchmark-design.md` and
+  `docs/adr/0001-single-gateway-deferred-multigateway.md`. As of this writing the
+  benchmark is **designed but not yet implemented** (no `cmd/loadtest`, `bench/`, or
+  `BENCHMARKS.md` exist yet).
+- **CI:** `.github/workflows/ci.yml` runs `go vet` + `go test` and the web build + test;
+  `.github/workflows/okf.yml` separately validates the `knowledge/` bundle. (`npm run lint`
+  is intentionally not gated yet — there are pre-existing lint errors to clear first.)

--- a/docs/adr/0001-single-gateway-deferred-multigateway.md
+++ b/docs/adr/0001-single-gateway-deferred-multigateway.md
@@ -1,0 +1,54 @@
+# 1. Single gateway for now; multi-gateway deferred
+
+Date: 2026-06-21
+
+## Status
+
+Accepted
+
+## Context
+
+The project's headline system-design story is horizontal scale: a stateless Go
+fan-out tier sitting behind Redis, scaled out to *many* gateway processes, with a
+benchmark proving sustained concurrent WebSocket viewers. The scope docs, the
+README, and the `knowledge/` bundle all leaned on that "multiple gateways,
+horizontally scalable, proven by benchmark" framing.
+
+The repo as built runs **one** `gateway` process. The pieces that *make* horizontal
+scale possible are in place — gateways are stateless (subscribe to `frames:{s}`,
+keep an in-memory snapshot, serve the SPA + WebSockets), Redis pub/sub is the
+language-agnostic seam, and the `/ws?session=<key>` hub registry routes lanes — but
+no second gateway, load balancer, or multi-gateway benchmark was ever built. The M4
+load-test work (`docs/superpowers/specs/2026-06-19-f1-m4-loadtest-benchmark-design.md`)
+re-scoped the benchmark to measure a **single** gateway and explicitly listed the
+multi-gateway tier as future work.
+
+So the documentation claimed something the code did not deliver. We had to choose
+between making the docs true (build the tier) and making the claim honest (correct
+the docs).
+
+## Decision
+
+Keep the architecture *designed for* horizontal scale, but stop claiming it is
+*built or proven*. Concretely:
+
+- Run and benchmark **one** gateway. The benchmark measures how a single gateway's
+  fan-out latency and drop-rate behave as concurrent viewers climb, framed as a
+  lower bound (load generator and server share one host).
+- Frame the stateless-gateway + Redis-seam + hub-registry design as the thing that
+  *would* make multi-gateway scaling real — the deliberate seam, not a delivered tier.
+- Treat the multi-gateway tier (N replicas behind a load balancer, cross-gateway
+  benchmark) as explicit future work, not a Phase 1 deliverable.
+
+## Consequences
+
+- The docs become honest: a reviewer reading "horizontally scalable" now sees a
+  measured single-gateway curve plus a clearly-marked path to multi-gateway, instead
+  of an unbacked claim.
+- The strongest portfolio talking point shifts from "I proved horizontal scale" to
+  "I built the seam that makes horizontal scale a config change, and measured the
+  single-node ceiling honestly." This is a smaller but defensible claim.
+- If the multi-gateway tier is built later, this ADR should be superseded by one that
+  records the load-balancer choice and the cross-gateway benchmark method.
+- All scale language across `README.md`, both scope docs, and the `knowledge/`
+  bundle was softened to match (see the reconciliation pass dated 2026-06-21).

--- a/docs/superpowers/specs/2026-06-19-f1-m4-loadtest-benchmark-design.md
+++ b/docs/superpowers/specs/2026-06-19-f1-m4-loadtest-benchmark-design.md
@@ -1,0 +1,127 @@
+# F1 Race Tracker — M4 (part 2): Load Test + Benchmark — Design
+
+**Status:** Approved (brainstorming) · **Date:** 2026-06-19 · **Milestone:** Phase 1 / M4 (second of three M4 pieces)
+
+## Context
+
+M1–M3 built the real-time pipeline (Python/Go publishers → Redis → switchable Go gateway → React), and M4 part 1 added cross-year comparison. This is the **second** of three M4 deliverables; the third (README / demo-video polish) follows separately.
+
+This piece was always flagged as needing **re-scoping against the as-built reality** before planning, because the original Phase-1 plan assumed observability that M1–M3 never built. The re-scope below reflects what actually exists:
+
+- **No `/metrics` endpoint, no `clients:total` counter, no on-page health strip.** The gateway exposes only `/ws`, `/control/source`, `/healthz`, and `/` (static SPA). All server-side instrumentation from the original plan is absent.
+- **Single gateway only.** No multi-gateway tier, no load balancer. The `/ws?session=<key>` hub registry (M4 part 1) is the reusable seam that *would* make horizontal scaling real, but only one gateway process exists.
+- **`model.Frame` already carries `T int64` — publish wall-time in unix ms** (`internal/feed/replay/play.go:119,157` stamps `fr.T = time.Now().UnixMilli()` at emit; the writer publishes immediately after). This is the load-bearing fact: a client can compute true end-to-end fan-out latency as `now − T` per frame received, with **no server-side instrumentation**. The load harness itself is the measurement instrument.
+
+## Goal
+
+Produce a **load curve** that turns "horizontally scalable" from a claim into a measured engineering result: how a single gateway's fan-out latency and dropped-connection rate behave as concurrent WebSocket viewers climb from ~100 to a few thousand, alongside the gateway container's CPU/memory at each level. The deliverable is a committed `BENCHMARKS.md` containing a results table, a chart image, and one quotable headline sentence.
+
+The load curve is chosen (over a single fixed-load number or a bare concurrency ceiling) because it is the most portfolio-credible: a chart that is "flat and fast until ~X clients, then climbs" demonstrates understanding of *where* the system degrades, and it naturally contains the other two framings (the flat region is the comfortable fixed-load number; the end of the curve is the ceiling).
+
+## Scope
+
+**In scope**
+- A Go WebSocket load harness (`cmd/loadtest`) that hammers one load level and reports client-measured metrics as a single JSON row.
+- A Python orchestrator (`bench/run.py`) that sweeps load levels, samples the gateway container's CPU/memory via `docker stats`, collects results into a CSV, and renders a chart PNG.
+- `BENCHMARKS.md`: headline, methodology with honest caveats, results table, embedded chart, short interpretation.
+- Committed artifacts: `bench/results.csv`, `bench/results.png`.
+- Go unit tests for the pure pieces (histogram percentile math; envelope-frame → latency parse).
+- A README pointer to the benchmark headline.
+
+**Out of scope (explicitly deferred)**
+- Any new server-side instrumentation: `/metrics`, Prometheus, a `clients:total` counter, or an on-page health strip. The whole point of the re-scope is to measure from the client side without touching the gateway.
+- A multi-gateway / load-balancer tier. Noted as future work in the write-up; not built.
+- Running the benchmark in CI. The sweep needs the full Docker stack and a quiet machine; it is run by hand and its CSV/PNG committed. Only the pure unit tests are CI-gated.
+- Distributed/multi-machine load generation (e.g. k6 across hosts). Single-machine is the honest no-hosting reality.
+
+## Design decisions (from brainstorming)
+
+1. **Load curve**, not a single number — richest, most credible story; contains the other framings.
+2. **Capture gateway CPU/mem** at each level (via `docker stats`), not client-side metrics only — shows how hard the server was actually working.
+3. **Table + committed chart image** in `BENCHMARKS.md`, not table-only — a reader sees the knee of the curve at a glance.
+4. **Polyglot split:** Go does the high-concurrency hammering (goroutine-per-connection — the language's core pitch); Python does orchestration + plotting (matplotlib, already in the stack via the ingester). Reinforces the polyglot-seam framing.
+5. **Single machine, same-host clock.** Clients and gateway share the box. This is stated as a caveat, and it cuts the honest way: the server's *true* ceiling is higher than measured because the harness competes for CPU, and `now − T` latency is exact because there is no clock skew.
+
+## Architecture
+
+```
+ bench/run.py  ──spawns──►  cmd/loadtest (Go)  ──N WS conns──►  gateway (docker)
+ (orchestrator)              one load level,                      replay lane @ 10 Hz
+   • sweeps levels           goroutine-per-client,
+   • samples docker stats    measures (now − frame.T),
+   • writes results.csv      prints one JSON row
+   • renders results.png
+```
+
+The harness runs **one level per invocation** (single responsibility: hammer at N clients, report a row). The sweep, resource sampling, and plotting live in the orchestrator. This keeps the Go tool small and focused, and puts orchestration where Python is strongest.
+
+### Component 1 — `cmd/loadtest` (Go): one load level
+
+- **Flags (with defaults):**
+  - `-url` (default `ws://localhost:8080/ws?session=replay`) — the replay lane runs continuously at 10 Hz.
+  - `-clients N` (default 100) — number of concurrent WS connections.
+  - `-duration 30s` — total run length.
+  - `-ramp 5s` — connection dials are staggered evenly across this window to avoid a thundering-herd connect storm skewing results.
+  - `-warmup 3s` — latency samples before this point (relative to run start, after ramp) are discarded so only steady-state is measured.
+- Spawns N goroutines; each dials a WS connection (reuses `github.com/coder/websocket`, already in `go.mod`), then loops reading messages.
+- For each message it unmarshals a minimal local envelope `{type, data}`. It **skips `snapshot`** (no `T` field) and, for each `frame`, unmarshals `data` into `model.Frame` and records `now − fr.T` (ms) into a histogram — but only once the steady-state window has begun.
+- **Histogram:** fixed-bucket (1 ms buckets up to a few seconds, plus an overflow bucket), O(1) memory regardless of sample count — avoids storing 1M+ raw samples at high client counts. Yields p50/p95/p99/max.
+- **Drop accounting:** a connection the server closes before the run's scheduled end counts as a drop (this is the gateway's backpressure valve in `internal/ws/client.go` firing — a real, intended signal, distinct from a dial failure, which is counted separately as a connect error).
+- **Output:** one JSON object to stdout, e.g.
+  `{"clients":2000,"connected":2000,"framesPerSec":19980,"p50":4,"p95":11,"p99":23,"max":140,"drops":0,"connectErrors":0}`
+- Logs (progress, errors) go to stderr so stdout stays a clean single JSON line for the orchestrator to parse.
+
+### Component 2 — `bench/run.py` (Python): the sweep + chart
+
+- **Default levels:** `100, 500, 1000, 2000, 4000` (CLI-overridable). We find the knee and trim the top end to what the machine actually holds.
+- **Per level:**
+  1. Start a background `docker stats` sampler for the gateway container (`docker stats --no-stream --format '{{.CPUPerc}} {{.MemUsage}}'` polled a few times across the steady window).
+  2. Run `cmd/loadtest` with the level's `-clients` (via `go run ./cmd/loadtest` or a prebuilt binary), capturing its stdout JSON row.
+  3. Average the CPU%/mem samples; merge into the row.
+  4. Append the row to `bench/results.csv`.
+- **After the sweep:** render `bench/results.png` with matplotlib — latency percentiles (p50/p95/p99) and drop-rate vs client count on a shared x-axis (the knee-of-the-curve chart) — and print the markdown results table for pasting/embedding into `BENCHMARKS.md`.
+- The gateway container name is discovered from `docker compose ps` (or passed as a flag) so the script is not pinned to a hardcoded name.
+
+### `BENCHMARKS.md` structure
+
+1. **Headline** — one sentence, e.g. "A single gateway sustained N concurrent WebSocket viewers at 10 Hz with p99 fan-out latency under X ms and zero dropped clients, on one developer laptop."
+2. **Methodology** — what was run (replay lane @ 10 Hz, the sweep levels, duration/ramp/warmup), and the honest caveats (single machine; same-host clock; one gateway).
+3. **Results table** — clients, connected, frames/s, p50/p95/p99/max latency (ms), drops, gateway CPU%, gateway mem.
+4. **Chart** — embedded `results.png`.
+5. **Interpretation** — a short "what the curve shows": where it stays flat, where the knee is, what dropped first (latency creep vs backpressure drops), and what the next scaling step would be (the multi-gateway tier the registry seam enables).
+
+## Components / files
+
+| File | Change |
+|------|--------|
+| `cmd/loadtest/main.go` | New: WS load harness — flags, goroutine-per-client, steady-state latency capture, JSON row out. |
+| `cmd/loadtest/hist.go` | New: fixed-bucket latency histogram with percentile queries. |
+| `cmd/loadtest/hist_test.go` | New: percentile math + envelope-frame → latency parse unit tests. |
+| `bench/run.py` | New: sweep orchestrator, `docker stats` sampling, CSV writer, matplotlib chart. |
+| `bench/requirements.txt` | New: `matplotlib`. |
+| `bench/results.csv` | New (committed artifact): the measured rows. |
+| `bench/results.png` | New (committed artifact): the load-curve chart. |
+| `BENCHMARKS.md` | New: the write-up. |
+| `README.md` | Add a one-line pointer to the benchmark headline / `BENCHMARKS.md`. |
+
+No changes to any existing Go package, the gateway, the model, or the frontend — the harness is purely a new reader of the existing public contract.
+
+## Testing
+
+- **Go unit tests (pure, CI-friendly):**
+  - Histogram: feed known latency values, assert p50/p95/p99/max land in the right buckets, including the overflow bucket and empty-histogram edge cases.
+  - Latency parse: given an envelope JSON of `type:"frame"` with a known `T`, and an injected "now", assert the computed latency; assert a `type:"snapshot"` envelope is skipped (contributes no sample).
+- **Manual benchmark run (not CI):** `docker compose up --build -d`, then `python bench/run.py`. Verify it produces `results.csv` with one row per level, a readable `results.png`, and a printed markdown table. Sanity-check that low levels show low, flat latency and that the curve degrades (latency climb and/or drops) at the top end. Trim the top level if the machine can't reach it.
+- **Smoke (optional, local):** `go run ./cmd/loadtest -clients 5 -duration 3s` against a running stack prints a plausible JSON row (low latency, 5 connected, 0 drops).
+
+## Risks / notes
+
+- **Self-competition for CPU:** clients and gateway share one machine, so the harness steals CPU from the server. Consequence (stated in the write-up): the measured ceiling is a *lower bound* on the real one. Acceptable and honest for a no-hosting portfolio piece.
+- **Clock:** `now − T` is only meaningful because harness and writer share a clock. True here (same host). If the harness were ever moved to another machine, this metric would need a clock-sync caveat — noted so the number is never misread.
+- **High-N file descriptors on Windows:** thousands of WS connections from one process may hit OS handle limits. If the top level fails to fully connect, the harness reports `connected < clients` (visible, not silent), and the level is trimmed. No special tuning assumed.
+- **`docker stats` format portability:** parsed defensively (split on whitespace, strip `%` and units); if a field is missing the row records CPU/mem as null rather than failing the whole sweep.
+- **Benchmark numbers are machine- and run-specific.** The committed CSV/PNG are a snapshot of one run on the dev machine, clearly dated and captioned — not a claim of universal performance.
+
+## Decomposition reminder
+
+After this ships, the remaining M4 piece — README / demo-video polish — is brainstormed + planned separately. That piece can fold this benchmark's headline number into the README's scale story.

--- a/internal/bus/redis.go
+++ b/internal/bus/redis.go
@@ -11,7 +11,7 @@ import (
 	"github.com/natcat38/f1-race-tracker/internal/model"
 )
 
-func snapshotKey(s string) string { return "snapshot:" + s }
+func snapshotKey(s string) string   { return "snapshot:" + s }
 func framesChannel(s string) string { return "frames:" + s }
 
 type Bus struct{ rdb *redis.Client }

--- a/knowledge/components/redis-pubsub.md
+++ b/knowledge/components/redis-pubsub.md
@@ -19,8 +19,10 @@ only on the [event model](/domain/event-model.md) JSON over Redis.
 - **The snapshot is the source of truth; frames are an optimisation** — any missed frame is
   healed by the next snapshot, which is why lossy pub/sub is safe.
 
-Gateways are stateless (subscribe + serve only), so they scale horizontally — the headline of
-the [WebSocket protocol](/components/websocket-protocol.md) benchmark.
+Gateways are stateless (subscribe + serve only), so the design *can* scale horizontally to
+multiple gateways behind a load balancer. The system currently runs and is benchmarked as a
+**single** gateway; the multi-gateway tier is deferred — see
+[ADR-0001](../../docs/adr/0001-single-gateway-deferred-multigateway.md).
 
 # Citations
 

--- a/knowledge/components/websocket-protocol.md
+++ b/knowledge/components/websocket-protocol.md
@@ -20,7 +20,10 @@ Each gateway serves the React SPA and a WebSocket endpoint from the same origin.
   `Rev` ≤ current are ignored. Guarantees convergence after any disconnect.
 
 The hub convergence integration test (late-joiner + slow-client) is the evidence for these
-system-design claims; the load test proves horizontal scale over [Redis](/components/redis-pubsub.md).
+system-design claims; the load test measures a **single gateway's** fan-out latency as
+concurrent viewers climb. Scaling out to multiple gateways over [Redis](/components/redis-pubsub.md)
+is what the stateless design enables but is not yet built — see
+[ADR-0001](../../docs/adr/0001-single-gateway-deferred-multigateway.md).
 
 # Citations
 

--- a/web/embed.go
+++ b/web/embed.go
@@ -9,6 +9,7 @@ import (
 // The all: prefix includes dotfiles, so a clean checkout (where dist holds only
 // .gitkeep, the built SPA being gitignored) still compiles. Docker builds the real
 // SPA into dist before `go build`, so production embeds the actual assets.
+//
 //go:embed all:dist
 var dist embed.FS
 

--- a/web/embed.go
+++ b/web/embed.go
@@ -6,7 +6,10 @@ import (
 	"io/fs"
 )
 
-//go:embed dist
+// The all: prefix includes dotfiles, so a clean checkout (where dist holds only
+// .gitkeep, the built SPA being gitignored) still compiles. Docker builds the real
+// SPA into dist before `go build`, so production embeds the actual assets.
+//go:embed all:dist
 var dist embed.FS
 
 // FS returns the built SPA as a filesystem rooted at dist/.


### PR DESCRIPTION
## Why

Audited the repo against its source-of-truth docs (the two scope docs + `knowledge/` bundle) to confirm reality matches what's documented and nothing is unaccounted for. Found several divergences — one load-bearing (the multi-gateway scale claim), plus a tail of doc drift and missing artifacts — and closed the CI gaps that let drift creep back in.

## Documentation reconciliation

- **ADR-0001** records the real decision: run a **single gateway** now, defer the multi-gateway tier. The repo is single-gateway, but the docs/README/knowledge bundle headlined "multiple gateways, horizontal scale proven by benchmark."
- **Softened the horizontal-scale claims** across both scope docs and `knowledge/` (redis-pubsub, websocket-protocol) to "designed-for, not proven."
- **Corrected the live-lane framing**: the demo's `live` lane streams a Python-fed *clip* exercising the polyglot seam, not literal live data (the real SignalR client exists and is best-effort).
- **Added an "as-built deltas" addendum** to the tech scope (entrypoint is `cmd/server`, control endpoint in `internal/app/gateway.go`, inline Python contract, `cmd/genclip`, 6-service compose, Task 14 re-scope).
- Added **`CONTEXT.md`** glossary and **MIT `LICENSE`** (both prescribed/promised, neither existed).
- Fixed example seasons to the committed Monza 2023/2024 clips.

## CI

Previously CI (`okf.yml`) only validated the `knowledge/` bundle — it never built or tested the code. This PR adds `ci.yml` gating every PR with:

- **gofmt + go vet + go test**
- **web build + test** (vitest)
- **contract parity** — runs `ingest/check_live_contract.py`, asserting the Python writer's JSON keys match the Go `model.go` contract (the seam a mismatch breaks silently)
- **markdown link check** (lychee) over `README`/`CONTEXT`/`docs/`
- **`docker compose build`** smoke test (the documented reviewer experience)

`npm run lint` (6 pre-existing errors) and `go test -race` are intentionally left ungated for now.

## Verified locally

- `go vet` + `go test` pass; web build + 2 tests pass
- contract self-check prints "PASSED"
- committed Go is LF, so the gofmt gate is green on Ubuntu

🤖 Generated with [Claude Code](https://claude.com/claude-code)