### PR TITLE
fix(web): clear lint errors and gate eslint in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
           cache: npm
           cache-dependency-path: web/package-lock.json
       - run: npm ci
+      - run: npm run lint -- --max-warnings 0
       - run: npm run build
       - run: npm test
 

--- a/docs/F1_Race_Tracker_Tech_Scope.md
+++ b/docs/F1_Race_Tracker_Tech_Scope.md
@@ -307,8 +307,7 @@ Architecture diagram (§2.1), GIF of the map + the two-year comparison, `docker 
   benchmark is **designed but not yet implemented** (no `cmd/loadtest`, `bench/`, or
   `BENCHMARKS.md` exist yet).
 - **CI:** `.github/workflows/ci.yml` gates every PR with: `gofmt` + `go vet` + `go test`;
-  the web build + test; the Python↔Go contract self-check (`ingest/check_live_contract.py`);
-  a markdown link check over `README`/`CONTEXT`/`docs/` (lychee); and a `docker compose build`
-  smoke test. `.github/workflows/okf.yml` separately validates the `knowledge/` bundle.
-  (`npm run lint` and `go test -race` are intentionally not gated yet — lint has pre-existing
-  errors to clear first.)
+  the web lint (`--max-warnings 0`) + build + test; the Python↔Go contract self-check
+  (`ingest/check_live_contract.py`); a markdown link check over `README`/`CONTEXT`/`docs/`
+  (lychee); and a `docker compose build` smoke test. `.github/workflows/okf.yml` separately
+  validates the `knowledge/` bundle. (`go test -race` is not gated yet.)

--- a/web/src/hooks/useSmoothedCars.ts
+++ b/web/src/hooks/useSmoothedCars.ts
@@ -1,4 +1,4 @@
-import { useEffect, useReducer, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { Car, RaceState, Point } from '../state/race';
 
 // Returns cars with positions interpolated at display refresh rate.
@@ -9,7 +9,13 @@ export function useSmoothedCars(state: RaceState): Car[] {
   const to = useRef<Record<number, Point>>({});
   const tFrom = useRef(0);
   const tTo = useRef(0);
-  const [, tick] = useReducer((x: number) => x + 1, 0);
+  const stateRef = useRef(state);
+  const [smoothed, setSmoothed] = useState<Car[]>(() => Object.values(state.cars));
+
+  // Keep the latest state reachable from the animation loop without restarting it.
+  useEffect(() => {
+    stateRef.current = state;
+  }, [state]);
 
   // When a new frame/snapshot arrives (rev changes), snapshot from→to.
   useEffect(() => {
@@ -22,24 +28,26 @@ export function useSmoothedCars(state: RaceState): Car[] {
     tTo.current = now;
   }, [state.rev]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Drive re-renders at display refresh rate.
+  // Interpolate at display refresh rate. Refs are read inside the rAF callback
+  // (not during render), which the react-hooks rules require; the result is
+  // published to state so the component re-renders ~60 fps with smooth motion.
   useEffect(() => {
     let raf = 0;
     const loop = () => {
-      tick();
+      const now = performance.now();
+      const dur = Math.max(16, tTo.current - tFrom.current);
+      const t = Math.min(1, (now - tTo.current) / dur);
+      const cars = Object.values(stateRef.current.cars).map((c) => {
+        const a = from.current[c.driverNum] ?? c.p;
+        const b = to.current[c.driverNum] ?? c.p;
+        return { ...c, p: { x: a.x + (b.x - a.x) * t, y: a.y + (b.y - a.y) * t } };
+      });
+      setSmoothed(cars);
       raf = requestAnimationFrame(loop);
     };
     raf = requestAnimationFrame(loop);
     return () => cancelAnimationFrame(raf);
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, []);
 
-  const now = performance.now();
-  const dur = Math.max(16, tTo.current - tFrom.current);
-  const t = Math.min(1, (now - tTo.current) / dur);
-
-  return Object.values(state.cars).map((c) => {
-    const a = from.current[c.driverNum] ?? c.p;
-    const b = to.current[c.driverNum] ?? c.p;
-    return { ...c, p: { x: a.x + (b.x - a.x) * t, y: a.y + (b.y - a.y) * t } };
-  });
+  return smoothed;
 }

--- a/web/src/state/race.test.ts
+++ b/web/src/state/race.test.ts
@@ -16,9 +16,9 @@ describe('applyMessage', () => {
 
   it('applies a newer frame and ignores a stale one', () => {
     let s: RaceState = applyMessage(emptyState(), snapMsg);
-    s = applyMessage(s, { type: 'frame' as const, data: { rev: 4, timeMs: 100, cars: [{ driverNum: 1, code: 'VER', pos: 1, p: { x: 0.6, y: 0.5 }, status: 'OnTrack' }] } });
+    s = applyMessage(s, { type: 'frame' as const, data: { rev: 4, timeMs: 100, cars: [{ driverNum: 1, code: 'VER', team: 'Red Bull', pos: 1, p: { x: 0.6, y: 0.5 }, status: 'OnTrack' }] } });
     expect(s.cars[1].p.x).toBe(0.6);
-    const stale = applyMessage(s, { type: 'frame' as const, data: { rev: 4, timeMs: 100, cars: [{ driverNum: 1, code: 'XXX', pos: 1, p: { x: 0, y: 0 }, status: 'OnTrack' }] } });
+    const stale = applyMessage(s, { type: 'frame' as const, data: { rev: 4, timeMs: 100, cars: [{ driverNum: 1, code: 'XXX', team: 'Red Bull', pos: 1, p: { x: 0, y: 0 }, status: 'OnTrack' }] } });
     expect(stale.cars[1].code).toBe('VER'); // unchanged
   });
 });

--- a/web/src/state/race.ts
+++ b/web/src/state/race.ts
@@ -12,7 +12,15 @@ export function emptyState(): RaceState {
   return { session: '', mode: '', label: '', track: [], cars: {}, timeMs: 0, rev: 0 };
 }
 
-type Msg = { type: 'snapshot' | 'frame'; data: any };
+// Wire payloads from the gateway, mirroring internal/model (Snapshot, Frame).
+interface SnapshotData {
+  session: string; mode: string; label: string;
+  track?: Point[]; cars: Record<number, Car>; timeMs: number; rev: number;
+}
+interface FrameData { rev: number; timeMs: number; cars?: Car[] }
+type Msg =
+  | { type: 'snapshot'; data: SnapshotData }
+  | { type: 'frame'; data: FrameData };
 
 // applyMessage folds a snapshot or frame into state. Frames with rev <= current
 // are ignored (idempotent — mirrors the Go Apply, Tech §2.6).


### PR DESCRIPTION
## Why

Follow-up to #5, which added CI but left `npm run lint` ungated because of 6 pre-existing ESLint errors. This clears them and gates lint so the debt can't grow back.

## Changes

- **`useSmoothedCars.ts`** — the `react-hooks/refs` errors came from reading refs (`from/to/tFrom/tTo`) during render to interpolate car positions. Moved that math into the rAF callback (where the rule permits ref access) and publish the interpolated cars via `useState`. Same 60fps cadence and same interpolation math — behaviour-equivalent, just no longer an anti-pattern.
- **`race.ts`** — replaced `data: any` with a `SnapshotData | FrameData` discriminated union mirroring the Go `internal/model` types (`no-explicit-any`). `socket.ts` passes `JSON.parse(...)` so it's unaffected.
- **`race.test.ts`** — added the now-required `team` field to the two frame fixtures.
- **`ci.yml`** — added `npm run lint -- --max-warnings 0` to the web job.
- **Tech scope addendum** — updated the CI description (lint now gated; only `go test -race` remains ungated).

## Verified locally

`npm run lint` (with `--max-warnings 0`), `npm run build`, and `npm test` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)