### PR TITLE
chore: add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,50 @@
+version: 2
+updates:
+  # Go modules (root)
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      go-minor-patch:
+        update-types: ["minor", "patch"]
+
+  # Web app (Vite / TypeScript)
+  - package-ecosystem: npm
+    directory: "/web"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(dev-deps)"
+    groups:
+      npm-minor-patch:
+        update-types: ["minor", "patch"]
+
+  # Python ingest
+  - package-ecosystem: pip
+    directory: "/ingest"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      pip-minor-patch:
+        update-types: ["minor", "patch"]
+
+  # GitHub Actions workflow pins
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci(deps)"
+    groups:
+      actions-minor-patch:
+        update-types: ["minor", "patch"]


### PR DESCRIPTION
Adds `.github/dependabot.yml` to automate dependency updates across the repo's four package ecosystems.

| Ecosystem | Watches | PR prefix |
|---|---|---|
| `gomod` | root `go.mod` | `chore(deps)` |
| `npm` | `web/` | `chore(deps)` / `chore(dev-deps)` |
| `pip` | `ingest/requirements*.txt` | `chore(deps)` |
| `github-actions` | `.github/workflows/` pins | `ci(deps)` |

Each block runs **weekly** and **groups** minor + patch bumps into one PR per ecosystem to keep noise low. Major bumps and security fixes still land as separate PRs. Open-PR limit is 5 per ecosystem.

Docker (root `Dockerfile`, `ingest/Dockerfile.live`, `docker-compose.yml`) was intentionally left out and can be added as a fifth block later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)