### PR TITLE
Phase 3: Team-Radio Comms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,9 @@ jobs:
       - name: live.py <-> Go contract self-check
         run: python check_live_contract.py
         working-directory: ingest
+      - name: radio extraction self-check
+        run: python test_radio.py
+        working-directory: ingest
 
   docs-links:
     name: Docs link check

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -122,3 +122,23 @@ The per-car live readout — speed, gear, throttle, brake, DRS — shown for the
 selected in the **timing tower**. Per-tick data; updates every frame.
 
 - _Use_ "telemetry" for this readout.
+
+## Team radio
+
+A driver↔race-engineer audio clip tied to a moment in the race (a session-time).
+Best-effort, like **gap** — placed by mapping the clip's wall-clock to session time
+when a clip is recorded. The audio is streamed from a public URL at play time, never
+stored; only the reference (driver, session-time, clip URL) rides the **snapshot**.
+
+- _Use_ "team radio" (or just "radio" as the short form for the clip/data); not
+  "audio" or bare "message". A team-radio reference is a sparse, fixed timeline — it
+  rides the **snapshot**, not every **frame**.
+
+## Comms
+
+The toggleable **layer** that surfaces **team radio** during replay: a now-playing
+banner (driver attribution) and a short replayable history, switched by the comms
+toggle. It auto-plays each clip as the replay clock reaches its moment.
+
+- _Use_ "comms" / "comms layer"; never "overlay" (reserved for the Phase-4 ghost
+  delta) and not "lane" (a lane is a whole stream of state, not a UI toggle).

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A real-time F1 race tracker built as a polyglot stack — Python ingests positio
 - **Live WebSocket fan-out at scale** — one in-memory hub pushes 10 Hz frames to a thousand viewers, with backpressure that sheds milliseconds rather than dropping clients.
 - **Track-map-first design** — positions on circuit are the primary view, not an afterthought table.
 - **Pit-wall timing tower** — beside the map the board shows a live timing tower with gaps/intervals, last lap, tyres, and sector times for every car; click any driver to open a per-car telemetry panel (speed, gear, throttle, brake, DRS) sourced from the same 10 Hz frame.
+- **Team-radio comms layer** — a toggleable layer that auto-plays driver↔engineer radio in sync with the replay clock, with a now-playing banner and a short replayable history. The audio streams straight from F1's public URLs at play time — nothing is committed or downloaded — so the comms audio (only) needs network access; positions and timing stay fully offline from the committed clips. See [docs/adr/0003-team-radio-streamed-not-committed.md](docs/adr/0003-team-radio-streamed-not-committed.md).
 
 ## Run it
 

--- a/docs/adr/0003-team-radio-streamed-not-committed.md
+++ b/docs/adr/0003-team-radio-streamed-not-committed.md
@@ -1,0 +1,41 @@
+# 0003 — Team-radio audio streamed from F1's public URL, not committed
+
+Phase 3 adds **team radio** (driver↔engineer audio) as a toggleable **comms
+layer**. The audio bytes are **streamed from F1's public URL at play time** — a
+plain `<audio src="https://livetiming.formula1.com/.../TeamRadio/<clip>.mp3">`.
+Nothing is downloaded to disk and nothing is committed to the repo. The clip
+header (and so the **snapshot**) carries only a reference per message:
+`{timeMs, driverNum, clip}`, where `clip` is the full https URL.
+
+## Why
+
+Three genuine options:
+
+1. **Commit the audio** (a sidecar dir, referenced by filename). Consistent with
+   how the JSONL clips are committed, fully offline-reproducible — but adds binary
+   weight to a repo already holding ~20 MB of clips, and the no-hosting ethos is
+   about hosting nothing, not about hoarding bytes.
+2. **Gateway proxy** — a Go passthrough route fetches and re-serves the bytes.
+   Sidesteps any CORS/referer concern, still commits nothing — but it's a new
+   route, a cache dir, and code to maintain for a demo.
+3. **Stream direct from F1's URL** *(chosen)*. Verified: those URLs serve
+   `audio/mpeg`, 200, `accept-ranges: bytes`, and **play cross-origin in an
+   `<audio>` element without CORS** (no `Access-Control-Allow-Origin` header is
+   present, but plain media playback doesn't need one — only `fetch()` / Web-Audio
+   sample-reading would be blocked, and we do neither). Zero weight, zero new code,
+   and most in the spirit of "host nothing, store nothing".
+
+This is **surprising without context** — a future reader will reasonably ask why
+the audio isn't committed like the JSONL clips — and **hard-ish to reverse**: the
+external dependency is baked into the contract as `clip` = a live F1 URL.
+
+## Consequences
+
+- The comms layer depends on F1 keeping those public URLs live (they are 2024
+  assets, still served in 2026). If they ever expire or add CORS/referer locks,
+  the **upgrade path is Option 2** (gateway proxy): the only change is what `clip`
+  points at — the contract shape (`{timeMs, driverNum, clip}`) is unaffected.
+- The demo needs network access for audio (positions/timing remain fully offline
+  from the committed clips). Acceptable for a portfolio demo.
+- We did not build the proxy up front: a working stream with a named fallback
+  beats speculative infrastructure.

--- a/docs/superpowers/plans/2026-06-26-phase3-team-radio.md
+++ b/docs/superpowers/plans/2026-06-26-phase3-team-radio.md
@@ -1,0 +1,1047 @@
+# Phase 3 — Team-Radio Comms Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a toggleable **comms layer** that auto-plays driver↔engineer **team radio** as the replay clock reaches each clip's moment, with audio streamed straight from F1's public URL (nothing committed or downloaded).
+
+**Architecture:** Team radio is a sparse, fixed timeline, so it rides the **snapshot** only (like `Track`), not every frame. The recorder bakes `[{timeMs, driverNum, clip}]` into the clip header; the Go replay writer and the Python live publisher each thread it header→snapshot; the React app reads `snapshot.radio`, schedules auto-play against the frame clock with a guarded FIFO queue, and plays each clip via a native `<audio>` element. No new gateway routes, no proxy, no audio library.
+
+**Tech Stack:** Go (contract + replay writer), Python (FastF1 recorder + live publisher), React/TypeScript + Vite/Vitest (frontend).
+
+**Spec:** `docs/superpowers/specs/2026-06-26-phase3-team-radio-design.md`. **Glossary:** `CONTEXT.md` (Team radio, Comms). **Decision:** `docs/adr/0003-team-radio-streamed-not-committed.md`.
+
+**Conventions in this repo (read before starting):**
+- Go tests: `go test ./...`. Web tests: `cd web && npm test` (Vitest). Python self-checks are plain assert scripts run with `python <file>.py` (no pytest) — mirroring `ingest/check_live_contract.py`.
+- The contract is defined three times and must stay in lockstep: `internal/model/model.go` (canonical), `ingest/` (Python), `web/src/state/race.ts` (TS).
+- `npm run build` (vite) deletes the tracked `web/dist/.gitkeep`; if it vanishes, `git restore web/dist/.gitkeep` — never commit its deletion.
+- Commit after every green task.
+
+---
+
+### Task 1: Contract — `RadioMessage` type + `Snapshot.Radio` (Go)
+
+**Files:**
+- Modify: `internal/model/model.go` (add type after `RaceControlMessage` ~line 39; add field to `Snapshot` ~line 47)
+- Test: `internal/model/model_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/model/model_test.go`:
+
+```go
+func TestSnapshotRoundTripWithRadio(t *testing.T) {
+	in := NewSnapshot("replay", "replay", "Monza 2024 · Race")
+	in.Radio = []RadioMessage{
+		{TimeMs: 3300500, DriverNum: 1, Clip: "https://livetiming.formula1.com/x/VER_1.mp3"},
+		{TimeMs: 3301000, DriverNum: 16, Clip: "https://livetiming.formula1.com/x/LEC_16.mp3"},
+	}
+	b, err := json.Marshal(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out Snapshot
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatal(err)
+	}
+	if len(out.Radio) != 2 || out.Radio[1].DriverNum != 16 || out.Radio[0].Clip == "" {
+		t.Fatalf("radio round-trip wrong: %+v", out.Radio)
+	}
+}
+
+func TestSnapshotOmitsEmptyRadio(t *testing.T) {
+	b, err := json.Marshal(NewSnapshot("replay", "replay", "x"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(b), "radio") {
+		t.Fatalf("empty radio should be omitted, got %s", b)
+	}
+}
+```
+
+If `strings` is not already imported in the test file, add it to the import block.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/model/ -run TestSnapshot -v`
+Expected: FAIL — `Radio` undefined on `Snapshot`.
+
+- [ ] **Step 3: Add the type and field**
+
+In `internal/model/model.go`, after the `RaceControlMessage` struct (line 39), add:
+
+```go
+type RadioMessage struct {
+	TimeMs    int64  `json:"timeMs"`    // session clock at which the team radio occurred
+	DriverNum int    `json:"driverNum"` // FE derives code/team/colour from the cars map
+	Clip      string `json:"clip"`      // full https URL to the .mp3 on livetiming.formula1.com
+}
+```
+
+In the `Snapshot` struct, add this field after `Messages` (line 47):
+
+```go
+	Radio      []RadioMessage       `json:"radio,omitempty"`
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/model/ -run TestSnapshot -v`
+Expected: PASS (both).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/model/model.go internal/model/model_test.go
+git commit -m "feat(contract): add RadioMessage + Snapshot.Radio"
+```
+
+---
+
+### Task 2: Replay path — thread radio header→snapshot (Go)
+
+**Files:**
+- Modify: `internal/feed/replay/play.go` (`clipHeader` line 16; `Source` struct line 27; `Load` return line 81; add accessor near line 84)
+- Modify: `internal/app/writer.go` (`Source` interface line 13; set `snap.Radio` near line 44)
+- Test: `internal/feed/replay/play_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/feed/replay/play_test.go` (write a tiny clip to a temp file and load it):
+
+```go
+func TestLoadParsesRadioFromHeader(t *testing.T) {
+	clip := `{"track":[{"x":0.1,"y":0.2}],"label":"T","maxRev":1,"radio":[{"timeMs":3300500,"driverNum":1,"clip":"https://x/VER.mp3"}]}
+{"timeMs":3300000,"frame":{"rev":1,"timeMs":3300000,"cars":[{"driverNum":1,"code":"VER","team":"Red Bull","pos":1,"p":{"x":0.1,"y":0.2},"status":"OnTrack"}]}}
+`
+	path := filepath.Join(t.TempDir(), "clip.jsonl")
+	if err := os.WriteFile(path, []byte(clip), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	src, err := Load(path, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	radio := src.Radio()
+	if len(radio) != 1 || radio[0].DriverNum != 1 || radio[0].TimeMs != 3300500 {
+		t.Fatalf("radio not parsed: %+v", radio)
+	}
+}
+```
+
+Ensure `path/filepath`, `os` are imported in the test file (add any missing).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/feed/replay/ -run TestLoadParsesRadio -v`
+Expected: FAIL — `src.Radio` undefined.
+
+- [ ] **Step 3: Implement parsing + accessor**
+
+In `internal/feed/replay/play.go`:
+
+Add `Radio` to `clipHeader` (line 16 struct):
+
+```go
+type clipHeader struct {
+	Track  []model.Point        `json:"track"`
+	Label  string               `json:"label"`
+	MaxRev int64                `json:"maxRev"`
+	Radio  []model.RadioMessage `json:"radio"`
+}
+```
+
+Add a field to `Source` (line 27 struct), after `track`:
+
+```go
+	radio []model.RadioMessage
+```
+
+In `Load`, set it on the returned `Source` (line 81) — change the return to include `radio: hdr.Radio`:
+
+```go
+	return &Source{track: hdr.Track, radio: hdr.Radio, label: hdr.Label, lines: lines, max: hdr.MaxRev, speed: speed}, nil
+```
+
+Add the accessor next to `Track()` (line 84):
+
+```go
+func (s *Source) Radio() []model.RadioMessage { return s.radio }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/feed/replay/ -run TestLoadParsesRadio -v`
+Expected: PASS.
+
+- [ ] **Step 5: Wire it into the writer**
+
+In `internal/app/writer.go`, add `Radio()` to the `Source` interface (line 13):
+
+```go
+type Source interface {
+	Events(ctx context.Context) (<-chan model.Frame, error)
+	Track() []model.Point
+	Radio() []model.RadioMessage
+	Label() string
+	Mode() string
+}
+```
+
+And set it on the snapshot right after `snap.Track` (line 44):
+
+```go
+	snap.Track = wr.src.Track()
+	snap.Radio = wr.src.Radio()
+```
+
+- [ ] **Step 6: Run the whole Go suite**
+
+Run: `go test ./...`
+Expected: PASS. (If `internal/app` has a mock/fake `Source` in a `_test.go` file, add a `Radio() []model.RadioMessage { return nil }` method to it so it still satisfies the interface. Search: `grep -rn "func.*Track() \[\]model.Point" internal/app`.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/feed/replay/play.go internal/feed/replay/play_test.go internal/app/writer.go
+git commit -m "feat(replay): thread team radio from clip header into snapshot"
+```
+
+---
+
+### Task 3: Live path — thread radio in `live.py` + parity check (Python)
+
+**Files:**
+- Modify: `ingest/live.py` (`build_snapshot` line 47; `publish_clip` line 69-71)
+- Modify: `ingest/check_live_contract.py` (SNAP_KEYS line 5; call line 8)
+
+- [ ] **Step 1: Update the parity check first (this is the failing test)**
+
+In `ingest/check_live_contract.py`, add `"radio"` to `SNAP_KEYS` and pass it to the call:
+
+```python
+SNAP_KEYS = {"session", "mode", "label", "track", "radio", "cars", "timeMs", "rev"}
+```
+
+```python
+snap = build_snapshot("live", "Test", [{"x": 0.1, "y": 0.2}],
+                      [{"timeMs": 1000, "driverNum": 1, "clip": "https://x/a.mp3"}], 5)
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cd ingest && python check_live_contract.py`
+Expected: FAIL — `build_snapshot()` takes 4 positional args but 5 given (signature mismatch).
+
+- [ ] **Step 3: Add radio to `build_snapshot` and pass it through**
+
+In `ingest/live.py`, change `build_snapshot` (line 47):
+
+```python
+def build_snapshot(session, label, track, radio, rev):
+    return {
+        "session": session, "mode": "live", "label": label,
+        "track": track, "radio": radio, "cars": {}, "timeMs": 0, "rev": rev,
+    }
+```
+
+In `publish_clip` (lines 69-71), read radio from the header and pass it in:
+
+```python
+    track = header.get("track", [])
+    radio = header.get("radio", [])
+    label = label_override or header.get("label", "Live")
+    snapshot = build_snapshot(session, label, track, radio, starting_rev(r, session))
+```
+
+- [ ] **Step 4: Run the parity check to verify it passes**
+
+Run: `cd ingest && python check_live_contract.py`
+Expected: `live.py contract self-check PASSED`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ingest/live.py ingest/check_live_contract.py
+git commit -m "feat(live): pass team radio from clip header into the live snapshot"
+```
+
+---
+
+### Task 4: Recorder — radio extraction module (Python, pure + TDD)
+
+A pure, dependency-free module so the `Utc`→session-ms mapping and window filter are unit-testable without FastF1 or the network.
+
+**Files:**
+- Create: `ingest/radio.py`
+- Create: `ingest/test_radio.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `ingest/test_radio.py`:
+
+```python
+"""Self-check for ingest/radio.extract_radio (no fastf1/network needed)."""
+import sys
+from datetime import datetime, timezone
+from radio import extract_radio
+
+# t0 = session-time zero at 2024-09-01T12:00:00Z
+t0 = datetime(2024, 9, 1, 12, 0, 0, tzinfo=timezone.utc).timestamp()
+caps = [
+    {"Utc": "2024-09-01T12:55:10.000Z", "RacingNumber": "16", "Path": "TeamRadio/LEC.mp3"},  # 3310s -> in window
+    {"Utc": "2024-09-01T12:00:30.000Z", "RacingNumber": "1", "Path": "TeamRadio/VER.mp3"},   # 30s -> before window
+    {"Utc": "2024-09-01T12:54:00.000Z", "RacingNumber": "4", "Path": "TeamRadio/NOR.mp3"},   # 3240s -> before 3300
+]
+out = extract_radio(caps, t0, 3300, 3750, "https://livetiming.formula1.com", "/static/x/")
+
+assert len(out) == 1, f"expected 1 in-window clip, got {len(out)}: {out}"
+m = out[0]
+assert m["timeMs"] == 3310000, m
+assert m["driverNum"] == 16 and isinstance(m["driverNum"], int), m
+assert m["clip"] == "https://livetiming.formula1.com/static/x/TeamRadio/LEC.mp3", m
+
+# sorted ascending when multiple in-window
+caps2 = [
+    {"Utc": "2024-09-01T12:56:00.000Z", "RacingNumber": "1", "Path": "b.mp3"},   # 3360s
+    {"Utc": "2024-09-01T12:55:00.000Z", "RacingNumber": "16", "Path": "a.mp3"},  # 3300s
+]
+out2 = extract_radio(caps2, t0, 3300, 3750, "https://x", "/p/")
+assert [m["timeMs"] for m in out2] == [3300000, 3360000], out2
+
+print("radio.extract_radio self-check PASSED")
+sys.exit(0)
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cd ingest && python test_radio.py`
+Expected: FAIL — `ModuleNotFoundError: No module named 'radio'`.
+
+- [ ] **Step 3: Implement `ingest/radio.py`**
+
+```python
+"""Pure helpers for baking team radio into a clip header.
+
+Kept free of fastf1/pandas so it is unit-testable and importable in the CI
+contract job (which installs only `redis`). The recorder does the FastF1 fetch
+and tz handling, then hands plain dicts here.
+"""
+from datetime import datetime, timezone
+
+
+def _utc_to_session_ms(utc_str, t0_epoch_s):
+    """Map an ISO-8601 UTC instant (e.g. '2024-09-01T12:24:46.541Z') to session
+    milliseconds, where t0_epoch_s is session-time zero as a UTC epoch second."""
+    dt = datetime.fromisoformat(utc_str.replace("Z", "+00:00")).astimezone(timezone.utc)
+    return round((dt.timestamp() - t0_epoch_s) * 1000)
+
+
+def extract_radio(captures, t0_epoch_s, window_start_s, window_end_s, base_url, api_path):
+    """captures: list of {'Utc','RacingNumber','Path'} from FastF1's team_radio feed.
+    Returns [{timeMs, driverNum, clip}] for captures inside the window, sorted by time."""
+    out = []
+    for cap in captures:
+        time_ms = _utc_to_session_ms(cap["Utc"], t0_epoch_s)
+        if window_start_s * 1000 <= time_ms < window_end_s * 1000:
+            out.append({
+                "timeMs": time_ms,
+                "driverNum": int(cap["RacingNumber"]),
+                "clip": base_url + api_path + cap["Path"],
+            })
+    out.sort(key=lambda m: m["timeMs"])
+    return out
+```
+
+- [ ] **Step 4: Run it to verify it passes**
+
+Run: `cd ingest && python test_radio.py`
+Expected: `radio.extract_radio self-check PASSED`.
+
+- [ ] **Step 5: Wire the self-check into CI**
+
+In `.github/workflows/ci.yml`, in the `contract` job after the existing `check_live_contract.py` step (line 57-59), add:
+
+```yaml
+      - name: radio extraction self-check
+        run: python test_radio.py
+        working-directory: ingest
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ingest/radio.py ingest/test_radio.py .github/workflows/ci.yml
+git commit -m "feat(ingest): pure team-radio extraction helper + self-check in CI"
+```
+
+---
+
+### Task 5: Recorder — fetch radio, widen window, emit + validate (Python)
+
+**Files:**
+- Modify: `ingest/record.py` (imports ~line 22; window constant line 56; header build line 432; size warning line 543; header validation line 560)
+
+- [ ] **Step 1: Widen the window**
+
+Change `ingest/record.py` line 56-57:
+
+```python
+# Window: 7.5-min green-flag mid-race window (widened from 2.5 min in Phase 3 so the
+# comms layer has enough team radio to feel alive — see ADR-0003 / Phase 3 spec).
+WINDOW_START_S = 3300   # 55 min into session
+WINDOW_END_S   = 3750   # 62.5 min  (7.5-min window)
+```
+
+- [ ] **Step 2: Fetch + extract radio after the session loads**
+
+In `ingest/record.py`, add the import near the top (after line 29, `from pathlib import Path`):
+
+```python
+from fastf1 import _api
+from radio import extract_radio
+```
+
+After the driver-info block (after line 106, the `for num, info in sorted(driver_info...)` print loop), add:
+
+```python
+# ---------------------------------------------------------------------------
+# Team radio (Phase 3): baked into the header as [{timeMs, driverNum, clip}].
+# Streamed from F1's public URL at play time, never stored (ADR-0003).
+# ---------------------------------------------------------------------------
+print("\nFetching team radio...")
+radio_clips = []
+try:
+    raw = _api.fetch_page(session.api_path, "team_radio")  # list of [ts, content]
+    captures = []
+    for _ts, content in raw:
+        caps = content.get("Captures") if isinstance(content, dict) else None
+        if caps:
+            captures.extend(caps.values() if isinstance(caps, dict) else caps)
+    t0_epoch_s = pd.Timestamp(session.t0_date).tz_localize("UTC").timestamp()
+    radio_clips = extract_radio(
+        captures, t0_epoch_s, WINDOW_START_S, WINDOW_END_S,
+        _api.base_url, session.api_path,
+    )
+    print(f"Team radio: {len(captures)} captures in session, {len(radio_clips)} in window")
+except Exception as e:
+    print(f"  Warning: team radio fetch failed ({e}); clip will have no radio")
+```
+
+- [ ] **Step 3: Emit radio in the header**
+
+Change the header dict in `ingest/record.py` (lines 432-436):
+
+```python
+    header = {
+        "track": track_points,
+        "label": GP_LABEL,
+        "maxRev": max_rev,
+        "radio": radio_clips,
+    }
+```
+
+- [ ] **Step 4: Raise the file-size warning ceiling**
+
+The 7.5-min Monza clip is ~23 MB by design. Change `ingest/record.py` line 543-544:
+
+```python
+if size_mb > 25.0:
+    print(f"WARNING: File exceeds 25 MB! Consider trimming the window or reducing Hz.")
+```
+
+- [ ] **Step 5: Validate the radio header field**
+
+In the header-validation block of `ingest/record.py`, after the `maxRev` assertion (line 570), add:
+
+```python
+    assert 'radio' in hdr, "header missing 'radio'"
+    assert isinstance(hdr['radio'], list), "radio must be a list"
+    for rm in hdr['radio']:
+        assert {'timeMs', 'driverNum', 'clip'} <= set(rm.keys()), f"radio item missing fields: {rm}"
+        assert WINDOW_START_S * 1000 <= rm['timeMs'] < WINDOW_END_S * 1000, f"radio timeMs out of window: {rm}"
+        assert rm['clip'].startswith('http'), f"radio clip not a URL: {rm}"
+```
+
+And extend the success print (line 571):
+
+```python
+    print(f"  Header OK: {len(hdr['track'])} track points, maxRev={hdr['maxRev']}, {len(hdr['radio'])} radio clips")
+```
+
+- [ ] **Step 6: Update the contract docstring**
+
+In the module docstring of `ingest/record.py` (line 7), update the header-line description:
+
+```
+  Header line: {"track":[{"x":float,"y":float},...], "label":"...", "maxRev":int,
+                "radio":[{"timeMs":int,"driverNum":int,"clip":"https://..."}]}
+```
+
+- [ ] **Step 7: Commit (recorder logic only — clips re-baked in Task 6)**
+
+```bash
+git add ingest/record.py
+git commit -m "feat(record): bake team radio into clip header; widen window to 7.5 min"
+```
+
+---
+
+### Task 6: Re-bake the committed clips
+
+Network + FastF1 cache required. This regenerates the binary clips; expect Monza 2024 to grow ~7.8 MB → ~23 MB. Monza 2023 must be re-baked too so the compare lanes stay phase-aligned (identical window length).
+
+- [ ] **Step 1: Re-bake Monza 2024 (default replay)**
+
+Run:
+```bash
+.venv/Scripts/python.exe ingest/record.py data/replays/monza-2024-race.jsonl --year 2024 --gp Monza --session R --label "Monza 2024 · Race"
+```
+Expected: ends with `Contract validation PASSED` and `Header OK: ... ~5 radio clips`. If the radio count is 0, stop and investigate (the window or fetch failed) — do not commit an empty layer.
+
+- [ ] **Step 2: Re-bake Monza 2023 (compare phase parity)**
+
+Run:
+```bash
+.venv/Scripts/python.exe ingest/record.py data/replays/monza-2023-race.jsonl --year 2023 --gp Monza --session R --label "Monza 2023 · Race"
+```
+Expected: `Contract validation PASSED`.
+
+- [ ] **Step 3: Re-bake Silverstone 2024 (live lane)**
+
+Run:
+```bash
+.venv/Scripts/python.exe ingest/record.py data/replays/silverstone-2024-race.jsonl --year 2024 --gp Silverstone --session R --label "Silverstone 2024 · Race"
+```
+Expected: `Contract validation PASSED`. Note the radio count — if Silverstone's widened window is sparse, that's acceptable (live-lane radio is a bonus, not a goal).
+
+- [ ] **Step 4: Verify radio is present in a baked clip**
+
+Run:
+```bash
+head -c 400 data/replays/monza-2024-race.jsonl
+```
+Expected: the header line contains a non-empty `"radio":[{"timeMs":...,"driverNum":...,"clip":"https://livetiming.formula1.com/..."}]`.
+
+- [ ] **Step 5: Commit the re-baked clips**
+
+```bash
+git add data/replays/monza-2024-race.jsonl data/replays/monza-2023-race.jsonl data/replays/silverstone-2024-race.jsonl
+git commit -m "data: re-bake clips with team radio (7.5-min window)"
+```
+
+---
+
+### Task 7: Frontend state — parse `radio` into `RaceState` (TS)
+
+**Files:**
+- Modify: `web/src/state/race.ts`
+- Test: `web/src/state/race.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `web/src/state/race.test.ts`:
+
+```ts
+import { applyMessage, emptyState } from './race';
+
+test('snapshot carries the radio timeline', () => {
+  const s = applyMessage(emptyState(), {
+    type: 'snapshot',
+    data: {
+      session: 'replay', mode: 'replay', label: 'M', cars: {}, timeMs: 3300000, rev: 1,
+      radio: [{ timeMs: 3300500, driverNum: 1, clip: 'https://x/VER.mp3' }],
+    },
+  });
+  expect(s.radio).toHaveLength(1);
+  expect(s.radio[0].driverNum).toBe(1);
+});
+
+test('a frame does not clobber the radio timeline', () => {
+  const s0 = applyMessage(emptyState(), {
+    type: 'snapshot',
+    data: {
+      session: 'replay', mode: 'replay', label: 'M', cars: {}, timeMs: 3300000, rev: 1,
+      radio: [{ timeMs: 3300500, driverNum: 1, clip: 'https://x/VER.mp3' }],
+    },
+  });
+  const s1 = applyMessage(s0, { type: 'frame', data: { rev: 2, timeMs: 3300100, cars: [] } });
+  expect(s1.radio).toHaveLength(1);
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cd web && npm test -- race.test`
+Expected: FAIL — `radio` missing on the state type / undefined.
+
+- [ ] **Step 3: Add radio to the types and `applyMessage`**
+
+In `web/src/state/race.ts`:
+
+Add an interface above `RaceState` (after `Car`, ~line 11):
+
+```ts
+export interface RadioMessage { timeMs: number; driverNum: number; clip: string }
+```
+
+Add `radio` to `RaceState` (line 12-15):
+
+```ts
+export interface RaceState {
+  session: string; mode: string; label: string;
+  track: Point[]; cars: Record<number, Car>; timeMs: number; rev: number;
+  radio: RadioMessage[];
+}
+```
+
+Add it to `emptyState` (line 18):
+
+```ts
+  return { session: '', mode: '', label: '', track: [], cars: {}, timeMs: 0, rev: 0, radio: [] };
+```
+
+Add `radio` to `SnapshotData` (line 22-25):
+
+```ts
+interface SnapshotData {
+  session: string; mode: string; label: string;
+  track?: Point[]; cars: Record<number, Car>; timeMs: number; rev: number;
+  radio?: RadioMessage[];
+}
+```
+
+In `applyMessage`, set it from the snapshot (line 36-39):
+
+```ts
+    return {
+      session: d.session, mode: d.mode, label: d.label,
+      track: d.track ?? [], cars: { ...d.cars }, timeMs: d.timeMs, rev: d.rev,
+      radio: d.radio ?? [],
+    };
+```
+
+(The frame branch already spreads `...s`, so `radio` is preserved across frames with no change.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd web && npm test -- race.test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/state/race.ts web/src/state/race.test.ts
+git commit -m "feat(web): parse team radio timeline from the snapshot"
+```
+
+---
+
+### Task 8: Frontend — comms scheduling core (pure TS + TDD)
+
+The cursor/queue logic — the spec's required correctness test. Pure functions, no React, no audio.
+
+**Files:**
+- Create: `web/src/state/comms.ts`
+- Test: `web/src/state/comms.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `web/src/state/comms.test.ts`:
+
+```ts
+import { describe, test, expect } from 'vitest';
+import { stepComms, type CommsCursor } from './comms';
+import type { RadioMessage } from './race';
+
+const tl: RadioMessage[] = [
+  { timeMs: 100, driverNum: 1, clip: 'a' },
+  { timeMs: 200, driverNum: 16, clip: 'b' },
+  { timeMs: 5000, driverNum: 4, clip: 'c' },
+];
+
+describe('stepComms', () => {
+  test('init from snapshot: earlier messages are history, not fired', () => {
+    const { cursor, fired, history } = stepComms({ lastClock: -1 }, 150, tl, true);
+    expect(fired).toEqual([]);                 // nothing auto-plays on connect
+    expect(history.map((m) => m.driverNum)).toEqual([1]); // 100 <= 150 -> history
+    expect(cursor.lastClock).toBe(150);
+  });
+
+  test('steady state fires messages crossed since lastClock', () => {
+    const { cursor, fired } = stepComms({ lastClock: 150 }, 250, tl, false);
+    expect(fired.map((m) => m.driverNum)).toEqual([16]); // 150 < 200 <= 250
+    expect(cursor.lastClock).toBe(250);
+  });
+
+  test('loop (clock jumps back) resets cursor without firing', () => {
+    const { cursor, fired } = stepComms({ lastClock: 5000 }, 120, tl, false);
+    expect(fired).toEqual([]);
+    expect(cursor.lastClock).toBe(120);
+  });
+
+  test('multiple crossed in one step fire in time order', () => {
+    const { fired } = stepComms({ lastClock: 50 }, 250, tl, false);
+    expect(fired.map((m) => m.timeMs)).toEqual([100, 200]);
+  });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cd web && npm test -- comms.test`
+Expected: FAIL — cannot find `./comms`.
+
+- [ ] **Step 3: Implement `web/src/state/comms.ts`**
+
+```ts
+import type { RadioMessage } from './race';
+
+export interface CommsCursor { lastClock: number }
+
+export interface CommsStep {
+  cursor: CommsCursor;
+  fired: RadioMessage[];   // messages to enqueue for auto-play this step
+  history: RadioMessage[]; // messages to add to history (silent) — only on snapshot init
+}
+
+// stepComms advances the cursor by one frame/snapshot and decides what to play.
+// One rule drives steady-state, connect, and loop:
+//   - isSnapshot: init lastClock = clock; messages at/before clock go to history, none fire.
+//   - clock < lastClock (loop): reset lastClock = clock, fire nothing.
+//   - otherwise (steady): fire messages with lastClock < timeMs <= clock, in time order.
+export function stepComms(
+  cursor: CommsCursor,
+  clock: number,
+  timeline: RadioMessage[],
+  isSnapshot: boolean,
+): CommsStep {
+  if (isSnapshot) {
+    const history = timeline.filter((m) => m.timeMs <= clock).sort((a, b) => a.timeMs - b.timeMs);
+    return { cursor: { lastClock: clock }, fired: [], history };
+  }
+  if (clock < cursor.lastClock) {
+    return { cursor: { lastClock: clock }, fired: [], history: [] };
+  }
+  const fired = timeline
+    .filter((m) => m.timeMs > cursor.lastClock && m.timeMs <= clock)
+    .sort((a, b) => a.timeMs - b.timeMs);
+  return { cursor: { lastClock: clock }, fired, history: [] };
+}
+
+// isStale reports whether a queued clip has fallen too far behind the race clock to
+// auto-play (it is still shown in history). Best-effort sync, ~3s tolerance.
+export function isStale(msg: RadioMessage, currentClock: number, toleranceMs = 3000): boolean {
+  return currentClock - msg.timeMs > toleranceMs;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd web && npm test -- comms.test`
+Expected: PASS (all four).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/state/comms.ts web/src/state/comms.test.ts
+git commit -m "feat(web): pure comms scheduling core (cursor + loop + staleness)"
+```
+
+---
+
+### Task 9: Frontend — comms hook with audio playback (React/TS)
+
+Wires the pure core to a single `<audio>` element with a FIFO queue. The toggle is the user gesture that unlocks autoplay.
+
+**Files:**
+- Create: `web/src/hooks/useComms.ts`
+
+- [ ] **Step 1: Implement the hook**
+
+Create `web/src/hooks/useComms.ts`:
+
+```ts
+import { useEffect, useRef, useState } from 'react';
+import type { RaceState, RadioMessage } from '../state/race';
+import { stepComms, isStale, type CommsCursor } from '../state/comms';
+
+const HISTORY_MAX = 6;
+
+// useComms drives the comms layer from the race state. It tracks the play cursor,
+// queues fired clips into one <audio> element (FIFO), skips clips that have gone
+// stale vs the race clock, and keeps a short newest-first history. `enabled` gates
+// auto-play; the toggle click is the user gesture that satisfies autoplay policy.
+export function useComms(state: RaceState, enabled: boolean) {
+  const [nowPlaying, setNowPlaying] = useState<RadioMessage | null>(null);
+  const [history, setHistory] = useState<RadioMessage[]>([]);
+  // All refs declared before pump() so nothing is used-before-defined (lint gate).
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const cursorRef = useRef<CommsCursor>({ lastClock: -1 });
+  const queueRef = useRef<RadioMessage[]>([]);
+  const lastRevRef = useRef<number>(-1);
+  const nowPlayingRef = useRef<RadioMessage | null>(null);
+  const clockRef = useRef<number>(0); // latest race clock, read by pump's staleness check
+
+  if (!audioRef.current && typeof Audio !== 'undefined') {
+    audioRef.current = new Audio();
+  }
+
+  function pump() {
+    const audio = audioRef.current;
+    if (!audio || nowPlayingRef.current) return;
+    let next = queueRef.current.shift();
+    // Drop clips that have fallen too far behind the race clock (kept in history).
+    while (next && isStale(next, clockRef.current)) next = queueRef.current.shift();
+    if (!next) return;
+    nowPlayingRef.current = next;
+    setNowPlaying(next);
+    audio.src = next.clip; // ponytail: no crossOrigin attr -> plays cross-origin without CORS
+    audio.play().catch(() => { nowPlayingRef.current = null; setNowPlaying(null); });
+  }
+
+  useEffect(() => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    const onEnded = () => { nowPlayingRef.current = null; setNowPlaying(null); pump(); };
+    audio.addEventListener('ended', onEnded);
+    return () => audio.removeEventListener('ended', onEnded);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // On each state change, advance the cursor and enqueue fired clips.
+  useEffect(() => {
+    if (state.rev === 0) return;
+    clockRef.current = state.timeMs;
+    const justConnected = lastRevRef.current === -1; // seed history once on first snapshot
+    lastRevRef.current = state.rev;
+
+    const { cursor, fired, history: hist } = stepComms(
+      cursorRef.current, state.timeMs, state.radio, justConnected,
+    );
+    cursorRef.current = cursor;
+
+    if (justConnected && hist.length) {
+      setHistory(hist.slice(-HISTORY_MAX).reverse()); // newest first
+    }
+    if (fired.length) {
+      // history tracks regardless of enabled; only enabled enqueues audio.
+      setHistory((h) => [...[...fired].reverse(), ...h].slice(0, HISTORY_MAX));
+      if (enabled) {
+        queueRef.current.push(...fired);
+        pump();
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state.rev]);
+
+  // Stop audio + clear the queue when the layer is switched off.
+  useEffect(() => {
+    if (enabled) return;
+    queueRef.current = [];
+    audioRef.current?.pause();
+    nowPlayingRef.current = null;
+    setNowPlaying(null);
+  }, [enabled]);
+
+  function replay(msg: RadioMessage) {
+    const audio = audioRef.current;
+    if (!audio) return;
+    queueRef.current = []; // manual replay jumps the queue
+    nowPlayingRef.current = msg;
+    setNowPlaying(msg);
+    audio.src = msg.clip;
+    audio.play().catch(() => { nowPlayingRef.current = null; setNowPlaying(null); });
+  }
+
+  return { nowPlaying, history, replay };
+}
+```
+
+**Known limitation (ponytail):** Rev is monotonic and never resets (CONTEXT.md), so a *reconnect* snapshot mid-replay can't be told apart from a frame by rev — `justConnected` only seeds history on the very first snapshot. A reconnect could therefore enqueue a small batch, but the staleness skip drops anything >3 s behind the clock, so at most one near-current clip plays. Acceptable for a best-effort demo layer.
+
+- [ ] **Step 2: Type-check**
+
+Run: `cd web && npm run build`
+Expected: builds clean (tsc passes). If `web/dist/.gitkeep` disappears, run `git restore web/dist/.gitkeep`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add web/src/hooks/useComms.ts web/dist/.gitkeep
+git commit -m "feat(web): useComms hook — FIFO audio queue with staleness skip"
+```
+
+---
+
+### Task 10: Frontend — Comms UI component + wire into App
+
+**Files:**
+- Create: `web/src/components/teamColours.ts`
+- Create: `web/src/components/Comms.tsx`
+- Modify: `web/src/components/Map.tsx` (use the shared colours)
+- Modify: `web/src/App.tsx`
+
+- [ ] **Step 1: Extract the shared team-colour lookup**
+
+Create `web/src/components/teamColours.ts` (move the map out of `Map.tsx`):
+
+```ts
+export const teamColour: Record<string, string> = {
+  'Red Bull': '#3671C6', Ferrari: '#E8002D', Mercedes: '#27F4D2', McLaren: '#FF8000',
+  'Aston Martin': '#229971', Alpine: '#0093CC', Williams: '#64C4FF',
+  RB: '#6692FF', 'Kick Sauber': '#52E252', Haas: '#B6BABD',
+  AlphaTauri: '#2B4562', 'Alfa Romeo': '#C92D4B',
+};
+```
+
+In `web/src/components/Map.tsx`, delete the local `teamColour` const (lines 5-10) and import it instead:
+
+```ts
+import { teamColour } from './teamColours';
+```
+
+- [ ] **Step 2: Build the Comms component**
+
+Create `web/src/components/Comms.tsx`:
+
+```tsx
+import { useState } from 'react';
+import type { RaceState } from '../state/race';
+import { useComms } from '../hooks/useComms';
+import { teamColour } from './teamColours';
+
+// Comms is the toggleable team-radio layer: a now-playing banner + a short
+// replayable history. Audio streams from F1's public URL (ADR-0003).
+export function Comms({ state }: { state: RaceState }) {
+  const [enabled, setEnabled] = useState(false);
+  const { nowPlaying, history, replay } = useComms(state, enabled);
+
+  function codeFor(driverNum: number) {
+    return state.cars[driverNum]?.code ?? String(driverNum);
+  }
+  function colourFor(driverNum: number) {
+    return teamColour[state.cars[driverNum]?.team ?? ''] ?? '#bbb';
+  }
+
+  return (
+    <div style={{ display: 'grid', gap: 8 }}>
+      <button
+        onClick={() => setEnabled((v) => !v)}
+        style={{
+          border: 'none', cursor: 'pointer', padding: '6px 14px', borderRadius: 8,
+          fontFamily: 'monospace', fontSize: 13, justifySelf: 'start',
+          background: enabled ? '#3671C6' : '#1a1a1a', color: enabled ? '#fff' : '#888',
+        }}
+      >
+        {enabled ? '📻 Comms ON' : '📻 Comms OFF'}
+      </button>
+
+      {enabled && nowPlaying && (
+        <div style={{
+          display: 'flex', alignItems: 'center', gap: 8, padding: '8px 12px',
+          background: '#1a1a1a', borderRadius: 8, fontFamily: 'monospace', fontSize: 13,
+        }}>
+          <span style={{ color: colourFor(nowPlaying.driverNum), fontWeight: 700 }}>
+            {codeFor(nowPlaying.driverNum)}
+          </span>
+          <span style={{ color: '#888' }}>radio</span>
+          <button onClick={() => replay(nowPlaying)} style={replayBtn}>↻</button>
+        </div>
+      )}
+
+      {enabled && history.length > 0 && (
+        <div style={{ display: 'grid', gap: 4 }}>
+          {history.map((m, i) => (
+            <div key={`${m.timeMs}-${i}`} style={{
+              display: 'flex', alignItems: 'center', gap: 8,
+              fontFamily: 'monospace', fontSize: 12, color: '#aaa',
+            }}>
+              <span style={{ color: colourFor(m.driverNum), fontWeight: 700 }}>{codeFor(m.driverNum)}</span>
+              <button onClick={() => replay(m)} style={replayBtn}>▶</button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+const replayBtn: React.CSSProperties = {
+  border: 'none', cursor: 'pointer', background: 'transparent', color: '#3671C6',
+  fontSize: 13, padding: '0 4px',
+};
+```
+
+- [ ] **Step 3: Wire into App**
+
+In `web/src/App.tsx`, import it (after the `SourceToggle` import, line 8):
+
+```tsx
+import { Comms } from './components/Comms';
+```
+
+Add it to the right-hand column, after the Telemetry block (after line 78, the closing `</div>` of the Telemetry section, before line 79's `</div>`):
+
+```tsx
+        <div>
+          <h3 style={{ margin: '0 0 8px' }}>Comms</h3>
+          <Comms state={state} />
+        </div>
+```
+
+- [ ] **Step 4: Build + test**
+
+Run: `cd web && npm run build && npm test`
+Expected: builds clean, all tests pass. Restore `web/dist/.gitkeep` if vite removed it.
+
+- [ ] **Step 5: Lint (CI gate is `--max-warnings 0`)**
+
+Run: `cd web && npm run lint -- --max-warnings 0`
+Expected: no errors/warnings. Fix any (e.g. unused imports) before committing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/src/components/teamColours.ts web/src/components/Comms.tsx web/src/components/Map.tsx web/src/App.tsx web/dist/.gitkeep
+git commit -m "feat(web): comms layer UI (banner + history) wired into the board"
+```
+
+---
+
+### Task 11: Docs — README feature note
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Add the comms layer to the feature list and note the audio dependency**
+
+Find the feature/phase list in `README.md` (search for "Timing" or "Phase 2") and add a bullet describing the **comms layer** (toggleable team-radio audio synced to the replay clock). Add a one-line note that audio streams from F1's public URLs at play time — so the audio (only) needs network access — linking `docs/adr/0003-team-radio-streamed-not-committed.md`. Match the surrounding wording/format exactly; do not restructure the README.
+
+- [ ] **Step 2: Verify links resolve (mirrors the CI docs-link job)**
+
+Run: `npx --yes lychee --no-progress --exclude-loopback README.md CONTEXT.md docs/*.md docs/adr/**/*.md` (or just re-read the edited section to confirm the ADR path is correct).
+Expected: no broken links.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: note the Phase 3 comms layer in the README"
+```
+
+---
+
+## Final verification (before opening the PR)
+
+- [ ] `go test ./...` — all Go packages pass.
+- [ ] `cd web && npm run build && npm test && npm run lint -- --max-warnings 0` — web builds, tests, lints clean.
+- [ ] `cd ingest && python check_live_contract.py && python test_radio.py` — both self-checks pass.
+- [ ] `git status` clean and `web/dist/.gitkeep` still tracked (not deleted).
+- [ ] `docker compose up --build -d`, open http://localhost:8080: toggle **Comms ON**, let the replay run; a radio clip should auto-play with the driver's code in the banner and appear in history. Toggle to the **Live** lane and confirm the same. (Manual — the user drives the browser check.)
+
+## Notes / out of scope (carried from the spec)
+
+- Compare lanes (`#compare`) will carry `radio` in their snapshots (same replay source path) but the `Compare` view does not mount the comms layer — no task needed, by design.
+- No committed audio, no gateway proxy, no audio library, no transcripts, no `Frame.Radio`. The proxy is the named fallback in ADR-0003 if F1's URLs ever expire.
+- Autoplay note: the toggle click satisfies Chrome's autoplay policy (the demo target). Safari can be stricter about programmatic `.play()`; acceptable for the demo.

--- a/docs/superpowers/specs/2026-06-26-phase3-team-radio-design.md
+++ b/docs/superpowers/specs/2026-06-26-phase3-team-radio-design.md
@@ -19,9 +19,11 @@ A **toggleable radio layer** over the existing board: when on, it **auto-plays**
 **In scope**
 - New `RadioMessage` type + `Radio []RadioMessage` on **`Snapshot` only** (`internal/model/model.go`); Python↔Go contract parity updated.
 - Recorder (`ingest/record.py`): fetch `team_radio`, map `Utc`→session-time via `t0_date`, keep in-window captures, bake a radio timeline into the **clip header** (`[{timeMs, driverNum, clip}]`, `clip` = full https URL).
-- **Widen the recorder window** 3600→3300s (2.5→7.5 min) for radio density; re-bake `monza-2024-race.jsonl` (default replay) and `monza-2023-race.jsonl` (compare phase). Bake radio into `silverstone-2024-race.jsonl` (live lane) too — free from the same recorder change.
-- Gateway: thread the `Radio` field header→snapshot. No new routes, no proxy.
-- Frontend: a radio hook that schedules auto-play against the frame clock (FIFO queue + staleness skip + loop reset), an `<audio>` element, a toggleable now-playing banner + small history, and a layer toggle alongside the existing toggles.
+- **Widen the recorder window** 3600→3300s (2.5→7.5 min) for radio density; re-bake `monza-2024-race.jsonl` (default replay) and `monza-2023-race.jsonl` (compare phase). Bake radio into `silverstone-2024-race.jsonl` (live lane) too.
+- Thread `Radio` header→snapshot on **both** lane paths: the Go replay path (`clipHeader` in `internal/feed/replay/play.go` → `Source.Radio()` → `snap.Radio` in `internal/app/writer.go`, next to the existing `snap.Track`) **and** the Python live path (`ingest/live.py` `build_snapshot`, mirroring its `header.get("track")` with `header.get("radio")` — one line, not free). No new routes, no proxy.
+- Frontend (the **comms layer**): a comms hook that schedules auto-play against the frame clock (FIFO queue + staleness skip + loop reset), an `<audio>` element, a toggleable now-playing banner + small history, and a comms toggle alongside the existing toggles.
+
+**Terminology** (CONTEXT.md): the data is **team radio** (short form "radio", as in the `radio` snapshot field / `RadioMessage` type); the on-screen feature is the **comms layer**, switched by the **comms toggle**. Never "overlay" (reserved, Phase 4).
 
 **Out of scope (explicitly deferred / not built — ponytail)**
 - **Committing audio, any download/cache dir, Git LFS.** Streamed from F1's URL; nothing on disk.
@@ -35,7 +37,7 @@ A **toggleable radio layer** over the existing board: when on, it **auto-plays**
 ## Design decisions (from brainstorming)
 
 1. **Stream from F1's URL; metadata-only in the clip.** The clip header carries `{timeMs, driverNum, clip-URL}` (tiny text). At play time the browser streams the bytes from CloudFront via a plain `<audio src>`. Verified: cross-origin playback works without CORS. This resolves both the "audio source" and "binary asset" questions at once and is fully in the spirit of the no-hosting rule — we host nothing and commit nothing.
-   - **Known ceiling (ponytail):** depends on F1 keeping those public URLs live (they're 2024 assets, still served in 2026). If they ever expire or add CORS/referer locks, the upgrade path is a small Go gateway passthrough route serving the bytes (sidesteps CORS, still nothing committed). Named, not built.
+   - **Known ceiling (ponytail):** depends on F1 keeping those public URLs live (they're 2024 assets, still served in 2026). If they ever expire or add CORS/referer locks, the upgrade path is a small Go gateway passthrough route serving the bytes (sidesteps CORS, still nothing committed). Named, not built. Recorded as **ADR-0003** (`docs/adr/0003-team-radio-streamed-not-committed.md`).
 2. **`Radio` on `Snapshot` only — not rebroadcast per-frame.** Radio is a finite, sparse timeline for a replay clip; it belongs in the snapshot (the source of truth, healed on reconnect) exactly like `Track []Point` is sent once. No `Frame.Radio`, no ADR-0002 frame-size pressure, no benchmark impact. The FE already tracks the frame clock and schedules playback locally.
    - Contrast with `RaceControlMessage` (which sits on both Snapshot and Frame): that shape anticipated live text flags; radio's fixed-timeline nature makes snapshot-only both correct and lazier. If a true-live radio source is ever added, add `Frame.Radio` then.
 3. **Auto-play at each message's moment, with a guarded queue.** One `<audio>` element, FIFO. As the frame `timeMs` passes an unplayed message, enqueue it. Any message more than **~3 s stale** vs the current race clock when it reaches the queue front is **skipped for audio but still added to history** (so a busy spell, or toggling the layer on mid-replay, never lags the audio behind the race). On replay **loop** (clock jumps backward), reset the played-cursor so the timeline replays.
@@ -69,9 +71,13 @@ Radio []RadioMessage `json:"radio,omitempty"`
 
 ## Frontend (`web/src`)
 
-- **Radio hook** (new, in `state/` or `hooks/`): holds `snapshot.radio`; on each frame, fires any message with `timeMs <= currentClock` not yet played; manages the FIFO queue + ~3 s staleness skip + loop-reset (cursor resets when the clock jumps backward).
+- **Radio hook** (new, in `state/` or `hooks/`): holds `snapshot.radio` and a `lastClock` cursor. One rule drives steady-state, loop, and connect:
+  - **Steady state:** each frame, enqueue every message with `lastClock < timeMs <= frame.timeMs`, then `lastClock = frame.timeMs` (~100 ms window at 10 Hz → normally 0–1 messages).
+  - **Connect mid-replay:** on the snapshot, init `lastClock = snapshot.timeMs`; all earlier messages go straight to **history** (clickable), not the play queue — a late joiner is never blasted with backlog audio.
+  - **Loop:** detect `frame.timeMs < lastClock` (Rev still climbs, `timeMs` resets), set `lastClock = frame.timeMs` and enqueue nothing; the timeline re-fires on the new lap.
+  - **Staleness:** at the queue front, if `currentClock - msg.timeMs > 3000`, skip its audio but still show it in banner/history (keeps a busy spell — clips longer than the gaps between them — from lagging the race).
 - **Audio:** a single `<audio>` element; `src` set to the firing message's `clip`; no `crossOrigin` attribute (keep it CORS-free).
-- **UI (banner + small history):** a transient **now-playing banner** — driver code in team colour + a replay button, auto-fades — plus a short **collapsible history** of recent clips (click to replay). Driver code/team/colour from the existing `cars` map. A **radio layer toggle** sits with the existing source/seconds toggles; OFF disables auto-play and hides the banner/history.
+- **UI (the comms layer — banner + small history):** a transient **now-playing banner** — driver code in team colour + a replay button, auto-fades — plus a short **collapsible history** of recent clips (click to replay). Driver code/team/colour from the existing `cars` map. A **comms toggle** sits with the existing source/seconds toggles; OFF disables auto-play and hides the banner/history.
 
 ## Testing
 
@@ -88,4 +94,4 @@ Radio []RadioMessage `json:"radio,omitempty"`
 - **Loop/seek edge cases** in the FE cursor reset — covered by the queue logic test.
 
 ---
-*Next: `grill-with-docs` pass to pressure-test against CONTEXT.md + ADRs and update domain docs inline (CONTEXT.md gains "radio layer"; no ADR expected unless the contract decision warrants one).*
+*Updated by `grill-with-docs` (2026-06-26): live-lane plumbing sharpened (one-line `live.py` change, not "free"); FE cursor rule made precise (steady/connect/loop/staleness from one comparison); CONTEXT.md gained **Team radio** + **Comms** entries; canonical terms locked (data = "team radio"/`radio`; UI = "comms layer"/"comms toggle"; "overlay" stays reserved for Phase 4).*

--- a/docs/superpowers/specs/2026-06-26-phase3-team-radio-design.md
+++ b/docs/superpowers/specs/2026-06-26-phase3-team-radio-design.md
@@ -1,0 +1,91 @@
+# F1 Race Tracker — Phase 3: Team-Radio Comms — Design
+
+**Status:** Approved (brainstorming) · **Date:** 2026-06-26 · **Milestone:** Phase 3 (second of two remaining phases; Phase 4 = ghost overlay)
+
+## Context
+
+Phases 1–2 shipped the full pipeline (Python FastF1 ingest → Redis seam → Go gateway WS fan-out → React track map) plus the pit-wall timing tower and telemetry. Phase 3 adds a **team-radio layer**: the driver↔engineer audio, played alongside the race as a toggleable layer on the **same pipeline**. No new architecture; ADR-0001 (single gateway) and ADR-0002 (timing fields rebroadcast) are both unaffected.
+
+This is the **second change to the event model / contract**. Phase 3 introduces two things earlier phases never had: **audio**, and **events tied to a moment in the race**. The contract already has `RaceControlMessage` + `Messages []…` on `Snapshot`/`Frame`, but the recorder never populates them — so radio is the first event-timeline to actually ride a clip.
+
+**Data source is verified real.** `fastf1._api.fetch_page(api_path, 'team_radio')` returns a `jsonStream` of captures: `{Utc, RacingNumber, Path}` where `Path` is `TeamRadio/<file>.mp3` under the session's `api_path`. Monza 2024 race has **65 captures**. The full URL `https://livetiming.formula1.com/static/.../TeamRadio/<file>.mp3` serves `audio/mpeg`, 200 OK, `accept-ranges: bytes` — and **plays cross-origin in an `<audio>` element without CORS** (no `Access-Control-Allow-Origin` header is present, but plain media playback doesn't need one; only `fetch()`/Web-Audio sample-reading would be blocked, and we do neither).
+
+## Goal
+
+A **toggleable radio layer** over the existing board: when on, it **auto-plays** each radio message as the replay clock reaches its moment, with a now-playing banner (driver attribution) and a short replayable history. Audio is **streamed straight from F1's public URL at play time** — nothing committed to the repo, nothing downloaded to disk. The committed **replay** clips are the demo target; the layer keeps the track map + timing tower primary.
+
+## Scope
+
+**In scope**
+- New `RadioMessage` type + `Radio []RadioMessage` on **`Snapshot` only** (`internal/model/model.go`); Python↔Go contract parity updated.
+- Recorder (`ingest/record.py`): fetch `team_radio`, map `Utc`→session-time via `t0_date`, keep in-window captures, bake a radio timeline into the **clip header** (`[{timeMs, driverNum, clip}]`, `clip` = full https URL).
+- **Widen the recorder window** 3600→3300s (2.5→7.5 min) for radio density; re-bake `monza-2024-race.jsonl` (default replay) and `monza-2023-race.jsonl` (compare phase). Bake radio into `silverstone-2024-race.jsonl` (live lane) too — free from the same recorder change.
+- Gateway: thread the `Radio` field header→snapshot. No new routes, no proxy.
+- Frontend: a radio hook that schedules auto-play against the frame clock (FIFO queue + staleness skip + loop reset), an `<audio>` element, a toggleable now-playing banner + small history, and a layer toggle alongside the existing toggles.
+
+**Out of scope (explicitly deferred / not built — ponytail)**
+- **Committing audio, any download/cache dir, Git LFS.** Streamed from F1's URL; nothing on disk.
+- **A gateway proxy for the audio.** Back-pocket fallback only if F1 ever expires/locks the URLs (would be a tiny passthrough route + the proxy URL in `clip`). Not built now.
+- **Audio library, Web-Audio visualiser, waveform.** Native `<audio>` only.
+- **Transcripts.** The feed has none; not synthesised.
+- **Per-frame radio plumbing.** Radio is a fixed sparse timeline → snapshot-only, like `Track`. No `Frame.Radio`.
+- **Radio in the compare view.** 2023 is re-baked only to keep window phase with 2024; the compare view does not render the layer.
+- **The genuine SignalR `--live` path.** Unchanged and out of scope, as in Phase 2.
+
+## Design decisions (from brainstorming)
+
+1. **Stream from F1's URL; metadata-only in the clip.** The clip header carries `{timeMs, driverNum, clip-URL}` (tiny text). At play time the browser streams the bytes from CloudFront via a plain `<audio src>`. Verified: cross-origin playback works without CORS. This resolves both the "audio source" and "binary asset" questions at once and is fully in the spirit of the no-hosting rule — we host nothing and commit nothing.
+   - **Known ceiling (ponytail):** depends on F1 keeping those public URLs live (they're 2024 assets, still served in 2026). If they ever expire or add CORS/referer locks, the upgrade path is a small Go gateway passthrough route serving the bytes (sidesteps CORS, still nothing committed). Named, not built.
+2. **`Radio` on `Snapshot` only — not rebroadcast per-frame.** Radio is a finite, sparse timeline for a replay clip; it belongs in the snapshot (the source of truth, healed on reconnect) exactly like `Track []Point` is sent once. No `Frame.Radio`, no ADR-0002 frame-size pressure, no benchmark impact. The FE already tracks the frame clock and schedules playback locally.
+   - Contrast with `RaceControlMessage` (which sits on both Snapshot and Frame): that shape anticipated live text flags; radio's fixed-timeline nature makes snapshot-only both correct and lazier. If a true-live radio source is ever added, add `Frame.Radio` then.
+3. **Auto-play at each message's moment, with a guarded queue.** One `<audio>` element, FIFO. As the frame `timeMs` passes an unplayed message, enqueue it. Any message more than **~3 s stale** vs the current race clock when it reaches the queue front is **skipped for audio but still added to history** (so a busy spell, or toggling the layer on mid-replay, never lags the audio behind the race). On replay **loop** (clock jumps backward), reset the played-cursor so the timeline replays.
+   - **Autoplay policy:** browsers block audio until a user gesture. The **layer toggle is that gesture** (and the user's opt-in). Layer OFF → no auto-play. Toggling ON mid-replay fires only messages from *now* forward; earlier ones appear in history as clickable.
+4. **Widen the window to 7.5 min for radio density.** The current 2.5-min mid-race window (3600–3750s) contains **only 1 capture**. Measured alternatives: widen to 7.5 min (3300–3750s) → **~5 captures** during real racing; or move to the closing-laps cluster (~78.7 min) → 4 captures same size; or the post-race burst (132.8 min) → 22 but cars aren't racing (rejected — kills the track-map demo). **Chosen: widen to 7.5 min**, keeping the mid-race action. Cost: `monza-2024-race.jsonl` grows ~7.8 MB → ~23 MB, the loop is 3× longer, and `monza-2023-race.jsonl` must be re-baked to the same window so the compare lanes stay in phase.
+5. **Driver attribution derived in the FE.** `RadioMessage` carries only `driverNum`; the FE maps it to code/team/colour via the existing `cars` map it already holds. No redundant `code`/`team` in the contract.
+
+## The contract extension
+
+New type and one `Snapshot` field (`internal/model/model.go`):
+
+```go
+type RadioMessage struct {
+    TimeMs    int64  `json:"timeMs"`    // session clock at which the radio occurred (within the window)
+    DriverNum int    `json:"driverNum"` // FE derives code/team/colour from the cars map
+    Clip      string `json:"clip"`      // full https URL to the .mp3 on livetiming.formula1.com
+}
+
+// on Snapshot (not Frame):
+Radio []RadioMessage `json:"radio,omitempty"`
+```
+
+`omitempty`: a clip with no in-window radio simply omits the field; the FE treats absence as an empty timeline (layer toggle shows nothing to play), not an error.
+
+## Recorder (`ingest/record.py`)
+
+- After loading the session (telemetry already loaded for `t0_date`), call `fastf1._api.fetch_page(session.api_path, 'team_radio')`, flatten the `Captures`, and for each: `timeMs = round((Timestamp(Utc, UTC→naive) - t0_date).total_seconds() * 1000)`, keep those with `WINDOW_START_S*1000 <= timeMs < WINDOW_END_S*1000`, build `clip = base_url + api_path + Path`.
+- Emit `radio: [{timeMs, driverNum, clip}]` sorted by `timeMs` in the **clip header line** (alongside the existing track/header data).
+- Change `WINDOW_START_S` 3600 → 3300 (window now 7.5 min). Re-bake monza-2024, monza-2023 (compare phase), silverstone-2024 (radio comes free).
+- The Go replay player reads the header and copies `header.radio` → `Snapshot.Radio`.
+
+## Frontend (`web/src`)
+
+- **Radio hook** (new, in `state/` or `hooks/`): holds `snapshot.radio`; on each frame, fires any message with `timeMs <= currentClock` not yet played; manages the FIFO queue + ~3 s staleness skip + loop-reset (cursor resets when the clock jumps backward).
+- **Audio:** a single `<audio>` element; `src` set to the firing message's `clip`; no `crossOrigin` attribute (keep it CORS-free).
+- **UI (banner + small history):** a transient **now-playing banner** — driver code in team colour + a replay button, auto-fades — plus a short **collapsible history** of recent clips (click to replay). Driver code/team/colour from the existing `cars` map. A **radio layer toggle** sits with the existing source/seconds toggles; OFF disables auto-play and hides the banner/history.
+
+## Testing
+
+- **Recorder:** unit check on `Utc`→`timeMs` window mapping and that the in-window count is sane (>0 for the widened Monza window); clip header validation extended to accept `radio`.
+- **Frontend:** queue logic test — fires in order, skips stale (>3 s), resets cursor on loop, no auto-play when layer off.
+- **Contract parity:** Python↔Go `radio`/`RadioMessage` shape stays green in the existing CI parity check.
+- **CI** unchanged otherwise (Go fmt+vet+test, Web build+test, Docker build, docs link check, validate).
+
+## Risks / open items
+
+- **F1 URL longevity** (decision 1 ceiling) — accepted; proxy is the named fallback.
+- **Window widening weight** — accepted (+~15 MB); compare phase preserved by re-baking 2023.
+- **Silverstone radio density** — verify its widened window has enough captures during the plan; if sparse, live-lane radio is a thin bonus, not a goal.
+- **Loop/seek edge cases** in the FE cursor reset — covered by the queue logic test.
+
+---
+*Next: `grill-with-docs` pass to pressure-test against CONTEXT.md + ADRs and update domain docs inline (CONTEXT.md gains "radio layer"; no ADR expected unless the contract decision warrants one).*

--- a/ingest/check_live_contract.py
+++ b/ingest/check_live_contract.py
@@ -2,10 +2,11 @@
 import sys
 from live import build_snapshot, build_frame
 
-SNAP_KEYS = {"session", "mode", "label", "track", "cars", "timeMs", "rev"}
+SNAP_KEYS = {"session", "mode", "label", "track", "radio", "cars", "timeMs", "rev"}
 FRAME_KEYS = {"session", "rev", "t", "timeMs", "cars"}
 
-snap = build_snapshot("live", "Test", [{"x": 0.1, "y": 0.2}], 5)
+snap = build_snapshot("live", "Test", [{"x": 0.1, "y": 0.2}],
+                      [{"timeMs": 1000, "driverNum": 1, "clip": "https://x/a.mp3"}], 5)
 frame = build_frame("live", 6, 1234, [{"driverNum": 1, "code": "VER", "team": "Red Bull",
                                        "pos": 1, "p": {"x": 0.1, "y": 0.2}, "status": "OnTrack"}])
 

--- a/ingest/live.py
+++ b/ingest/live.py
@@ -9,7 +9,7 @@ Modes:
 
 Redis contract:
   SET     snapshot:<session> = {"session","mode","label","track":[{x,y}],
-                                "cars":{"1":{...}},"timeMs","rev"}
+                                "radio":[{timeMs,driverNum,clip}],"cars":{"1":{...}},"timeMs","rev"}
   PUBLISH frames:<session>   = {"session","rev","t","timeMs","cars":[{...}]}
   Car = {"driverNum":int,"code":str,"team":str,"pos":int,"p":{"x":float,"y":float},"status":str}
   Go marshals map[int]CarState with STRING keys, so snapshot.cars is keyed by str(driverNum).

--- a/ingest/live.py
+++ b/ingest/live.py
@@ -44,10 +44,10 @@ def starting_rev(r, session):
         return 0
 
 
-def build_snapshot(session, label, track, rev):
+def build_snapshot(session, label, track, radio, rev):
     return {
         "session": session, "mode": "live", "label": label,
-        "track": track, "cars": {}, "timeMs": 0, "rev": rev,
+        "track": track, "radio": radio, "cars": {}, "timeMs": 0, "rev": rev,
     }
 
 
@@ -67,8 +67,9 @@ def publish_clip(r, session, clip_path, label_override):
         sys.exit(1)
 
     track = header.get("track", [])
+    radio = header.get("radio", [])
     label = label_override or header.get("label", "Live")
-    snapshot = build_snapshot(session, label, track, starting_rev(r, session))
+    snapshot = build_snapshot(session, label, track, radio, starting_rev(r, session))
     rev = snapshot["rev"]
     base_ms = lines[0]["timeMs"]
     print(f"live: streaming {len(lines)} frames of '{label}' to session '{session}' (start rev {rev})")

--- a/ingest/live_signalr.py
+++ b/ingest/live_signalr.py
@@ -279,7 +279,7 @@ def _replay_capture(r, session: str, label: str, capture_path: str) -> None:
 
     bounds = BoundBox()
     rev = starting_rev(r, session)
-    snapshot = build_snapshot(session, label or "Live F1", [], rev)
+    snapshot = build_snapshot(session, label or "Live F1", [], [], rev)
     r.set(snap_key(session), json.dumps(snapshot, separators=(",", ":")))
 
     # Interleave events by timedelta
@@ -423,7 +423,7 @@ def _run_live_signalr(r, session: str, label: str) -> None:
     driver_info: dict[str, dict] = {}
     running_positions: dict[str, int] = {}
     latest_cars: dict[str, dict] = {}
-    snapshot_holder = [build_snapshot(session, label or "Live F1", [], rev_holder[0])]
+    snapshot_holder = [build_snapshot(session, label or "Live F1", [], [], rev_holder[0])]
     last_publish = [time.monotonic() - FRAME_INTERVAL_S]
 
     r.set(snap_key(session), json.dumps(snapshot_holder[0], separators=(",", ":")))

--- a/ingest/radio.py
+++ b/ingest/radio.py
@@ -20,15 +20,24 @@ def extract_radio(captures, t0_epoch_s, window_start_s, window_end_s, base_url, 
 
     The clip URL join is slash-normalised: it works whether or not api_path has a
     trailing slash (or Path a leading one), so a missing separator can't silently
-    produce a broken URL."""
+    produce a broken URL. A capture with a missing/non-numeric RacingNumber (or a
+    missing Utc/Path) is skipped rather than crashing the whole extraction — the
+    feed is external, so one malformed entry must not drop the entire timeline."""
     out = []
     for cap in captures:
-        time_ms = _utc_to_session_ms(cap["Utc"], t0_epoch_s)
+        utc, num, path = cap.get("Utc"), cap.get("RacingNumber"), cap.get("Path")
+        if utc is None or num is None or path is None:
+            continue
+        try:
+            driver_num = int(num)
+        except (TypeError, ValueError):
+            continue
+        time_ms = _utc_to_session_ms(utc, t0_epoch_s)
         if window_start_s * 1000 <= time_ms < window_end_s * 1000:
             out.append({
                 "timeMs": time_ms,
-                "driverNum": int(cap["RacingNumber"]),
-                "clip": base_url + api_path.rstrip("/") + "/" + cap["Path"].lstrip("/"),
+                "driverNum": driver_num,
+                "clip": base_url + api_path.rstrip("/") + "/" + path.lstrip("/"),
             })
     out.sort(key=lambda m: m["timeMs"])
     return out

--- a/ingest/radio.py
+++ b/ingest/radio.py
@@ -1,0 +1,30 @@
+"""Pure helpers for baking team radio into a clip header.
+
+Kept free of fastf1/pandas so it is unit-testable and importable in the CI
+contract job (which installs only `redis`). The recorder does the FastF1 fetch
+and tz handling, then hands plain dicts here.
+"""
+from datetime import datetime, timezone
+
+
+def _utc_to_session_ms(utc_str, t0_epoch_s):
+    """Map an ISO-8601 UTC instant (e.g. '2024-09-01T12:24:46.541Z') to session
+    milliseconds, where t0_epoch_s is session-time zero as a UTC epoch second."""
+    dt = datetime.fromisoformat(utc_str.replace("Z", "+00:00")).astimezone(timezone.utc)
+    return round((dt.timestamp() - t0_epoch_s) * 1000)
+
+
+def extract_radio(captures, t0_epoch_s, window_start_s, window_end_s, base_url, api_path):
+    """captures: list of {'Utc','RacingNumber','Path'} from FastF1's team_radio feed.
+    Returns [{timeMs, driverNum, clip}] for captures inside the window, sorted by time."""
+    out = []
+    for cap in captures:
+        time_ms = _utc_to_session_ms(cap["Utc"], t0_epoch_s)
+        if window_start_s * 1000 <= time_ms < window_end_s * 1000:
+            out.append({
+                "timeMs": time_ms,
+                "driverNum": int(cap["RacingNumber"]),
+                "clip": base_url + api_path + cap["Path"],
+            })
+    out.sort(key=lambda m: m["timeMs"])
+    return out

--- a/ingest/radio.py
+++ b/ingest/radio.py
@@ -16,7 +16,11 @@ def _utc_to_session_ms(utc_str, t0_epoch_s):
 
 def extract_radio(captures, t0_epoch_s, window_start_s, window_end_s, base_url, api_path):
     """captures: list of {'Utc','RacingNumber','Path'} from FastF1's team_radio feed.
-    Returns [{timeMs, driverNum, clip}] for captures inside the window, sorted by time."""
+    Returns [{timeMs, driverNum, clip}] for captures inside the window, sorted by time.
+
+    The clip URL join is slash-normalised: it works whether or not api_path has a
+    trailing slash (or Path a leading one), so a missing separator can't silently
+    produce a broken URL."""
     out = []
     for cap in captures:
         time_ms = _utc_to_session_ms(cap["Utc"], t0_epoch_s)
@@ -24,7 +28,7 @@ def extract_radio(captures, t0_epoch_s, window_start_s, window_end_s, base_url, 
             out.append({
                 "timeMs": time_ms,
                 "driverNum": int(cap["RacingNumber"]),
-                "clip": base_url + api_path + cap["Path"],
+                "clip": base_url + api_path.rstrip("/") + "/" + cap["Path"].lstrip("/"),
             })
     out.sort(key=lambda m: m["timeMs"])
     return out

--- a/ingest/record.py
+++ b/ingest/record.py
@@ -120,7 +120,9 @@ try:
         caps = content.get("Captures") if isinstance(content, dict) else None
         if caps:
             captures.extend(caps.values() if isinstance(caps, dict) else caps)
-    t0_epoch_s = pd.Timestamp(session.t0_date).tz_localize("UTC").timestamp()
+    # t0_date is tz-naive-UTC today; tz_convert if FastF1 ever returns it tz-aware.
+    _t0 = pd.Timestamp(session.t0_date)
+    t0_epoch_s = (_t0.tz_convert("UTC") if _t0.tzinfo else _t0.tz_localize("UTC")).timestamp()
     radio_clips = extract_radio(
         captures, t0_epoch_s, WINDOW_START_S, WINDOW_END_S,
         _api.base_url, session.api_path,

--- a/ingest/record.py
+++ b/ingest/record.py
@@ -4,7 +4,8 @@ FastF1 → JSONL clip recorder.
 Bakes a real F1 session into the contract read by the Go replay player.
 
 CONTRACT (must match internal/model/model.go + web/src/state/race.ts):
-  Header line: {"track":[{"x":float,"y":float},...], "label":"...", "maxRev":int}
+  Header line: {"track":[{"x":float,"y":float},...], "label":"...", "maxRev":int,
+                "radio":[{"timeMs":int,"driverNum":int,"clip":"https://..."}]}
   Frame lines: {"timeMs":int, "frame":{"rev":int,"timeMs":int,"cars":[
                  {"driverNum":int,"code":"VER","team":"Red Bull","pos":int,
                   "p":{"x":float,"y":float},"status":"OnTrack"}]}}
@@ -27,6 +28,8 @@ import sys
 import os
 import argparse
 from pathlib import Path
+from fastf1 import _api
+from radio import extract_radio
 
 # ---------------------------------------------------------------------------
 # Args
@@ -50,11 +53,10 @@ GP_LABEL = _args.label or f"{_args.gp} {_args.year} · Race"
 HZ = 10          # target sample rate (frames per second)
 TRACK_POINTS = 150  # number of track outline points
 
-# Window: 15:00 - 17:30 into session (green-flag mid-race racing at Monza).
-# Monza race is ~1:20:00 total. We pick a ~2.5-min window in the middle of lap ~30-35.
-# Note: this window is generic enough for a full race; may need tuning per circuit.
-WINDOW_START_S = 3600   # 60 min into session
-WINDOW_END_S   = 3750   # 60 + 2.5 min = 62.5 min
+# Window: 7.5-min green-flag mid-race window (widened from 2.5 min in Phase 3 so the
+# comms layer has enough team radio to feel alive — see ADR-0003 / Phase 3 spec).
+WINDOW_START_S = 3300   # 55 min into session
+WINDOW_END_S   = 3750   # 62.5 min  (7.5-min window)
 
 # FastF1 team name → frontend colour map key (from web/src/components/Map.tsx teamColour)
 TEAM_MAP = {
@@ -104,6 +106,28 @@ for num in session.drivers:
 print(f"Driver info ({len(driver_info)} drivers):")
 for num, info in sorted(driver_info.items()):
     print(f"  {num:>3} | {info['code']} | {info['team']}")
+
+# ---------------------------------------------------------------------------
+# Team radio (Phase 3): baked into the header as [{timeMs, driverNum, clip}].
+# Streamed from F1's public URL at play time, never stored (ADR-0003).
+# ---------------------------------------------------------------------------
+print("\nFetching team radio...")
+radio_clips = []
+try:
+    raw = _api.fetch_page(session.api_path, "team_radio")  # list of [ts, content]
+    captures = []
+    for _ts, content in raw:
+        caps = content.get("Captures") if isinstance(content, dict) else None
+        if caps:
+            captures.extend(caps.values() if isinstance(caps, dict) else caps)
+    t0_epoch_s = pd.Timestamp(session.t0_date).tz_localize("UTC").timestamp()
+    radio_clips = extract_radio(
+        captures, t0_epoch_s, WINDOW_START_S, WINDOW_END_S,
+        _api.base_url, session.api_path,
+    )
+    print(f"Team radio: {len(captures)} captures in session, {len(radio_clips)} in window")
+except Exception as e:
+    print(f"  Warning: team radio fetch failed ({e}); clip will have no radio")
 
 # ---------------------------------------------------------------------------
 # Collect all position data and determine coordinate bounds
@@ -433,6 +457,7 @@ with open(OUTPUT_PATH, 'w', encoding='utf-8') as f:
         "track": track_points,
         "label": GP_LABEL,
         "maxRev": max_rev,
+        "radio": radio_clips,
     }
     f.write(json.dumps(header, separators=(',', ':')) + '\n')
 
@@ -540,8 +565,8 @@ size_bytes = os.path.getsize(OUTPUT_PATH)
 size_mb = size_bytes / (1024 * 1024)
 print(f"File size: {size_mb:.2f} MB ({size_bytes:,} bytes)")
 
-if size_mb > 5.0:
-    print(f"WARNING: File exceeds 5 MB! Consider trimming the window or reducing Hz.")
+if size_mb > 25.0:
+    print(f"WARNING: File exceeds 25 MB! Consider trimming the window or reducing Hz.")
 
 # ---------------------------------------------------------------------------
 # Contract validation
@@ -568,7 +593,13 @@ try:
         assert 'x' in tp and 'y' in tp, f"track point missing x/y: {tp}"
         assert 0 <= tp['x'] <= 1 and 0 <= tp['y'] <= 1, f"track point out of [0,1]: {tp}"
     assert hdr['maxRev'] == n_frames, f"maxRev mismatch: {hdr['maxRev']} vs {n_frames}"
-    print(f"  Header OK: {len(hdr['track'])} track points, maxRev={hdr['maxRev']}")
+    assert 'radio' in hdr, "header missing 'radio'"
+    assert isinstance(hdr['radio'], list), "radio must be a list"
+    for rm in hdr['radio']:
+        assert {'timeMs', 'driverNum', 'clip'} <= set(rm.keys()), f"radio item missing fields: {rm}"
+        assert WINDOW_START_S * 1000 <= rm['timeMs'] < WINDOW_END_S * 1000, f"radio timeMs out of window: {rm}"
+        assert rm['clip'].startswith('http'), f"radio clip not a URL: {rm}"
+    print(f"  Header OK: {len(hdr['track'])} track points, maxRev={hdr['maxRev']}, {len(hdr['radio'])} radio clips")
 except AssertionError as e:
     print(f"  HEADER ERROR: {e}")
     errors += 1

--- a/ingest/test_radio.py
+++ b/ingest/test_radio.py
@@ -9,6 +9,7 @@ caps = [
     {"Utc": "2024-09-01T12:55:10.000Z", "RacingNumber": "16", "Path": "TeamRadio/LEC.mp3"},  # 3310s -> in window
     {"Utc": "2024-09-01T12:00:30.000Z", "RacingNumber": "1", "Path": "TeamRadio/VER.mp3"},   # 30s -> before window
     {"Utc": "2024-09-01T12:54:00.000Z", "RacingNumber": "4", "Path": "TeamRadio/NOR.mp3"},   # 3240s -> before 3300
+    {"Utc": "2024-09-01T13:02:30.000Z", "RacingNumber": "55", "Path": "TeamRadio/SAI.mp3"},  # 3750s -> EXACTLY at upper bound; half-open window excludes it
 ]
 out = extract_radio(caps, t0, 3300, 3750, "https://livetiming.formula1.com", "/static/x/")
 
@@ -17,6 +18,8 @@ m = out[0]
 assert m["timeMs"] == 3310000, m
 assert m["driverNum"] == 16 and isinstance(m["driverNum"], int), m
 assert m["clip"] == "https://livetiming.formula1.com/static/x/TeamRadio/LEC.mp3", m
+# half-open window: a capture exactly at window_end_s (3750s) is EXCLUDED
+assert 55 not in [c["driverNum"] for c in out], f"upper-bound capture leaked in: {out}"
 
 # sorted ascending when multiple in-window
 caps2 = [

--- a/ingest/test_radio.py
+++ b/ingest/test_radio.py
@@ -1,0 +1,30 @@
+"""Self-check for ingest/radio.extract_radio (no fastf1/network needed)."""
+import sys
+from datetime import datetime, timezone
+from radio import extract_radio
+
+# t0 = session-time zero at 2024-09-01T12:00:00Z
+t0 = datetime(2024, 9, 1, 12, 0, 0, tzinfo=timezone.utc).timestamp()
+caps = [
+    {"Utc": "2024-09-01T12:55:10.000Z", "RacingNumber": "16", "Path": "TeamRadio/LEC.mp3"},  # 3310s -> in window
+    {"Utc": "2024-09-01T12:00:30.000Z", "RacingNumber": "1", "Path": "TeamRadio/VER.mp3"},   # 30s -> before window
+    {"Utc": "2024-09-01T12:54:00.000Z", "RacingNumber": "4", "Path": "TeamRadio/NOR.mp3"},   # 3240s -> before 3300
+]
+out = extract_radio(caps, t0, 3300, 3750, "https://livetiming.formula1.com", "/static/x/")
+
+assert len(out) == 1, f"expected 1 in-window clip, got {len(out)}: {out}"
+m = out[0]
+assert m["timeMs"] == 3310000, m
+assert m["driverNum"] == 16 and isinstance(m["driverNum"], int), m
+assert m["clip"] == "https://livetiming.formula1.com/static/x/TeamRadio/LEC.mp3", m
+
+# sorted ascending when multiple in-window
+caps2 = [
+    {"Utc": "2024-09-01T12:56:00.000Z", "RacingNumber": "1", "Path": "b.mp3"},   # 3360s
+    {"Utc": "2024-09-01T12:55:00.000Z", "RacingNumber": "16", "Path": "a.mp3"},  # 3300s
+]
+out2 = extract_radio(caps2, t0, 3300, 3750, "https://x", "/p/")
+assert [m["timeMs"] for m in out2] == [3300000, 3360000], out2
+
+print("radio.extract_radio self-check PASSED")
+sys.exit(0)

--- a/ingest/test_radio.py
+++ b/ingest/test_radio.py
@@ -10,9 +10,11 @@ caps = [
     {"Utc": "2024-09-01T12:00:30.000Z", "RacingNumber": "1", "Path": "TeamRadio/VER.mp3"},   # 30s -> before window
     {"Utc": "2024-09-01T12:54:00.000Z", "RacingNumber": "4", "Path": "TeamRadio/NOR.mp3"},   # 3240s -> before 3300
     {"Utc": "2024-09-01T13:02:30.000Z", "RacingNumber": "55", "Path": "TeamRadio/SAI.mp3"},  # 3750s -> EXACTLY at upper bound; half-open window excludes it
+    {"Utc": "2024-09-01T12:55:20.000Z", "RacingNumber": "TBD", "Path": "TeamRadio/BAD.mp3"}, # in window but non-numeric number -> skipped, not a crash
 ]
 out = extract_radio(caps, t0, 3300, 3750, "https://livetiming.formula1.com", "/static/x/")
 
+# A malformed in-window capture is skipped, not fatal: still exactly 1 valid clip.
 assert len(out) == 1, f"expected 1 in-window clip, got {len(out)}: {out}"
 m = out[0]
 assert m["timeMs"] == 3310000, m

--- a/internal/app/writer.go
+++ b/internal/app/writer.go
@@ -13,6 +13,7 @@ import (
 type Source interface {
 	Events(ctx context.Context) (<-chan model.Frame, error)
 	Track() []model.Point
+	Radio() []model.RadioMessage
 	Label() string
 	Mode() string
 }
@@ -42,6 +43,7 @@ func (wr *Writer) Run(ctx context.Context, session string) error {
 	}
 	snap := model.NewSnapshot(session, wr.src.Mode(), wr.src.Label())
 	snap.Track = wr.src.Track()
+	snap.Radio = wr.src.Radio()
 	snap.Rev = base
 	rev := base
 	for {

--- a/internal/app/writer_test.go
+++ b/internal/app/writer_test.go
@@ -16,9 +16,10 @@ import (
 
 type fakeSource struct{ frames []model.Frame }
 
-func (f *fakeSource) Track() []model.Point { return []model.Point{{X: 0, Y: 0}} }
-func (f *fakeSource) Label() string        { return "Fake" }
-func (f *fakeSource) Mode() string         { return "replay" }
+func (f *fakeSource) Track() []model.Point          { return []model.Point{{X: 0, Y: 0}} }
+func (f *fakeSource) Radio() []model.RadioMessage   { return nil }
+func (f *fakeSource) Label() string                 { return "Fake" }
+func (f *fakeSource) Mode() string                  { return "replay" }
 func (f *fakeSource) Events(ctx context.Context) (<-chan model.Frame, error) {
 	ch := make(chan model.Frame)
 	go func() {

--- a/internal/app/writer_test.go
+++ b/internal/app/writer_test.go
@@ -16,10 +16,10 @@ import (
 
 type fakeSource struct{ frames []model.Frame }
 
-func (f *fakeSource) Track() []model.Point          { return []model.Point{{X: 0, Y: 0}} }
-func (f *fakeSource) Radio() []model.RadioMessage   { return nil }
-func (f *fakeSource) Label() string                 { return "Fake" }
-func (f *fakeSource) Mode() string                  { return "replay" }
+func (f *fakeSource) Track() []model.Point        { return []model.Point{{X: 0, Y: 0}} }
+func (f *fakeSource) Radio() []model.RadioMessage { return nil }
+func (f *fakeSource) Label() string               { return "Fake" }
+func (f *fakeSource) Mode() string                { return "replay" }
 func (f *fakeSource) Events(ctx context.Context) (<-chan model.Frame, error) {
 	ch := make(chan model.Frame)
 	go func() {

--- a/internal/feed/replay/play.go
+++ b/internal/feed/replay/play.go
@@ -83,10 +83,10 @@ func Load(path string, speed float64) (*Source, error) {
 	return &Source{track: hdr.Track, radio: hdr.Radio, label: hdr.Label, lines: lines, max: hdr.MaxRev, speed: speed}, nil
 }
 
-func (s *Source) Track() []model.Point          { return s.track }
-func (s *Source) Radio() []model.RadioMessage   { return s.radio }
-func (s *Source) Label() string                 { return s.label }
-func (s *Source) Mode() string                  { return "replay" }
+func (s *Source) Track() []model.Point        { return s.track }
+func (s *Source) Radio() []model.RadioMessage { return s.radio }
+func (s *Source) Label() string               { return s.label }
+func (s *Source) Mode() string                { return "replay" }
 
 // Events streams frames forever, looping. T is stamped to emit-time (Tech §2.9).
 // Rev on the emitted frame is advisory — the writer reassigns a monotonic Rev.

--- a/internal/feed/replay/play.go
+++ b/internal/feed/replay/play.go
@@ -14,9 +14,10 @@ import (
 )
 
 type clipHeader struct {
-	Track  []model.Point `json:"track"`
-	Label  string        `json:"label"`
-	MaxRev int64         `json:"maxRev"`
+	Track  []model.Point        `json:"track"`
+	Label  string               `json:"label"`
+	MaxRev int64                `json:"maxRev"`
+	Radio  []model.RadioMessage `json:"radio"`
 }
 
 type clipLine struct {
@@ -26,6 +27,7 @@ type clipLine struct {
 
 type Source struct {
 	track []model.Point
+	radio []model.RadioMessage
 	label string
 	lines []clipLine
 	max   int64
@@ -78,12 +80,13 @@ func Load(path string, speed float64) (*Source, error) {
 	if hdr.MaxRev == 0 {
 		hdr.MaxRev = lines[len(lines)-1].Frame.Rev
 	}
-	return &Source{track: hdr.Track, label: hdr.Label, lines: lines, max: hdr.MaxRev, speed: speed}, nil
+	return &Source{track: hdr.Track, radio: hdr.Radio, label: hdr.Label, lines: lines, max: hdr.MaxRev, speed: speed}, nil
 }
 
-func (s *Source) Track() []model.Point { return s.track }
-func (s *Source) Label() string        { return s.label }
-func (s *Source) Mode() string         { return "replay" }
+func (s *Source) Track() []model.Point          { return s.track }
+func (s *Source) Radio() []model.RadioMessage   { return s.radio }
+func (s *Source) Label() string                 { return s.label }
+func (s *Source) Mode() string                  { return "replay" }
 
 // Events streams frames forever, looping. T is stamped to emit-time (Tech §2.9).
 // Rev on the emitted frame is advisory — the writer reassigns a monotonic Rev.

--- a/internal/feed/replay/play_test.go
+++ b/internal/feed/replay/play_test.go
@@ -98,7 +98,7 @@ func TestLoadParsesRadioFromHeader(t *testing.T) {
 		t.Fatal(err)
 	}
 	radio := src.Radio()
-	if len(radio) != 1 || radio[0].DriverNum != 1 || radio[0].TimeMs != 3300500 {
+	if len(radio) != 1 || radio[0].DriverNum != 1 || radio[0].TimeMs != 3300500 || radio[0].Clip == "" {
 		t.Fatalf("radio not parsed: %+v", radio)
 	}
 }

--- a/internal/feed/replay/play_test.go
+++ b/internal/feed/replay/play_test.go
@@ -84,3 +84,21 @@ func TestReplay_HeaderAndMonotonicRevAcrossLoop(t *testing.T) {
 		}
 	}
 }
+
+func TestLoadParsesRadioFromHeader(t *testing.T) {
+	clip := `{"track":[{"x":0.1,"y":0.2}],"label":"T","maxRev":1,"radio":[{"timeMs":3300500,"driverNum":1,"clip":"https://x/VER.mp3"}]}
+{"timeMs":3300000,"frame":{"rev":1,"timeMs":3300000,"cars":[{"driverNum":1,"code":"VER","team":"Red Bull","pos":1,"p":{"x":0.1,"y":0.2},"status":"OnTrack"}]}}
+`
+	path := filepath.Join(t.TempDir(), "clip.jsonl")
+	if err := os.WriteFile(path, []byte(clip), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	src, err := Load(path, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	radio := src.Radio()
+	if len(radio) != 1 || radio[0].DriverNum != 1 || radio[0].TimeMs != 3300500 {
+		t.Fatalf("radio not parsed: %+v", radio)
+	}
+}

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -38,6 +38,12 @@ type RaceControlMessage struct {
 	Driver   *int   `json:"driver,omitempty"`
 }
 
+type RadioMessage struct {
+	TimeMs    int64  `json:"timeMs"`    // session clock at which the team radio occurred
+	DriverNum int    `json:"driverNum"` // FE derives code/team/colour from the cars map
+	Clip      string `json:"clip"`      // full https URL to the .mp3 on livetiming.formula1.com
+}
+
 type Snapshot struct {
 	SessionKey string               `json:"session"`
 	Mode       string               `json:"mode"`  // "live" | "replay"
@@ -45,6 +51,7 @@ type Snapshot struct {
 	Track      []Point              `json:"track,omitempty"`
 	Cars       map[int]CarState     `json:"cars"`
 	Messages   []RaceControlMessage `json:"messages,omitempty"`
+	Radio      []RadioMessage       `json:"radio,omitempty"`
 	TimeMs     int64                `json:"timeMs"`
 	Rev        int64                `json:"rev"`
 }

--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -41,3 +41,32 @@ func TestCarStateOmitsZeroTimingFields(t *testing.T) {
 		}
 	}
 }
+
+func TestSnapshotRoundTripWithRadio(t *testing.T) {
+	in := NewSnapshot("replay", "replay", "Monza 2024 · Race")
+	in.Radio = []RadioMessage{
+		{TimeMs: 3300500, DriverNum: 1, Clip: "https://livetiming.formula1.com/x/VER_1.mp3"},
+		{TimeMs: 3301000, DriverNum: 16, Clip: "https://livetiming.formula1.com/x/LEC_16.mp3"},
+	}
+	b, err := json.Marshal(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out Snapshot
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatal(err)
+	}
+	if len(out.Radio) != 2 || out.Radio[1].DriverNum != 16 || out.Radio[0].Clip == "" {
+		t.Fatalf("radio round-trip wrong: %+v", out.Radio)
+	}
+}
+
+func TestSnapshotOmitsEmptyRadio(t *testing.T) {
+	b, err := json.Marshal(NewSnapshot("replay", "replay", "x"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(b), "radio") {
+		t.Fatalf("empty radio should be omitted, got %s", b)
+	}
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -6,6 +6,7 @@ import { TimingTower } from './components/TimingTower';
 import { TelemetryPanel } from './components/TelemetryPanel';
 import { StatusBadge } from './components/StatusBadge';
 import { SourceToggle } from './components/SourceToggle';
+import { Comms } from './components/Comms';
 import { Compare } from './components/Compare';
 
 const SIZE = 600;
@@ -75,6 +76,10 @@ export default function App() {
         <div>
           <h3 style={{ margin: '0 0 8px' }}>Telemetry</h3>
           <TelemetryPanel car={selected != null ? state.cars[selected] : undefined} />
+        </div>
+        <div>
+          <h3 style={{ margin: '0 0 8px' }}>Comms</h3>
+          <Comms state={state} />
         </div>
       </div>
     </div>

--- a/web/src/components/Comms.tsx
+++ b/web/src/components/Comms.tsx
@@ -1,0 +1,64 @@
+import type { CSSProperties } from 'react';
+import type { RaceState } from '../state/race';
+import { useComms } from '../hooks/useComms';
+import { teamColour } from './teamColours';
+
+// Comms is the toggleable team-radio layer: a now-playing banner + a short
+// replayable history. Audio streams from F1's public URL (ADR-0003).
+export function Comms({ state }: { state: RaceState }) {
+  const { enabled, toggle, nowPlaying, history, replay } = useComms(state);
+
+  function codeFor(driverNum: number) {
+    return state.cars[driverNum]?.code ?? String(driverNum);
+  }
+  function colourFor(driverNum: number) {
+    return teamColour[state.cars[driverNum]?.team ?? ''] ?? '#bbb';
+  }
+
+  return (
+    <div style={{ display: 'grid', gap: 8 }}>
+      <button
+        onClick={toggle}
+        style={{
+          border: 'none', cursor: 'pointer', padding: '6px 14px', borderRadius: 8,
+          fontFamily: 'monospace', fontSize: 13, justifySelf: 'start',
+          background: enabled ? '#3671C6' : '#1a1a1a', color: enabled ? '#fff' : '#888',
+        }}
+      >
+        {enabled ? '📻 Comms ON' : '📻 Comms OFF'}
+      </button>
+
+      {enabled && nowPlaying && (
+        <div style={{
+          display: 'flex', alignItems: 'center', gap: 8, padding: '8px 12px',
+          background: '#1a1a1a', borderRadius: 8, fontFamily: 'monospace', fontSize: 13,
+        }}>
+          <span style={{ color: colourFor(nowPlaying.driverNum), fontWeight: 700 }}>
+            {codeFor(nowPlaying.driverNum)}
+          </span>
+          <span style={{ color: '#888' }}>radio</span>
+          <button onClick={() => replay(nowPlaying)} style={replayBtn}>↻</button>
+        </div>
+      )}
+
+      {enabled && history.length > 0 && (
+        <div style={{ display: 'grid', gap: 4 }}>
+          {history.map((m, i) => (
+            <div key={`${m.timeMs}-${i}`} style={{
+              display: 'flex', alignItems: 'center', gap: 8,
+              fontFamily: 'monospace', fontSize: 12, color: '#aaa',
+            }}>
+              <span style={{ color: colourFor(m.driverNum), fontWeight: 700 }}>{codeFor(m.driverNum)}</span>
+              <button onClick={() => replay(m)} style={replayBtn}>▶</button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+const replayBtn: CSSProperties = {
+  border: 'none', cursor: 'pointer', background: 'transparent', color: '#3671C6',
+  fontSize: 13, padding: '0 4px',
+};

--- a/web/src/components/Map.tsx
+++ b/web/src/components/Map.tsx
@@ -1,13 +1,8 @@
 import type { RaceState } from '../state/race';
 import { useSmoothedCars } from '../hooks/useSmoothedCars';
+import { teamColour } from './teamColours';
 
 const SIZE = 600;
-const teamColour: Record<string, string> = {
-  'Red Bull': '#3671C6', Ferrari: '#E8002D', Mercedes: '#27F4D2', McLaren: '#FF8000',
-  'Aston Martin': '#229971', Alpine: '#0093CC', Williams: '#64C4FF',
-  RB: '#6692FF', 'Kick Sauber': '#52E252', Haas: '#B6BABD',
-  AlphaTauri: '#2B4562', 'Alfa Romeo': '#C92D4B',
-};
 
 export function Map({ state }: { state: RaceState }) {
   const cars = useSmoothedCars(state);

--- a/web/src/components/teamColours.ts
+++ b/web/src/components/teamColours.ts
@@ -1,0 +1,6 @@
+export const teamColour: Record<string, string> = {
+  'Red Bull': '#3671C6', Ferrari: '#E8002D', Mercedes: '#27F4D2', McLaren: '#FF8000',
+  'Aston Martin': '#229971', Alpine: '#0093CC', Williams: '#64C4FF',
+  RB: '#6692FF', 'Kick Sauber': '#52E252', Haas: '#B6BABD',
+  AlphaTauri: '#2B4562', 'Alfa Romeo': '#C92D4B',
+};

--- a/web/src/hooks/useComms.ts
+++ b/web/src/hooks/useComms.ts
@@ -1,0 +1,101 @@
+import { useEffect, useRef, useState } from 'react';
+import type { RaceState, RadioMessage } from '../state/race';
+import { stepComms, isStale, type CommsCursor } from '../state/comms';
+
+const HISTORY_MAX = 6;
+
+// useComms drives the comms layer from the race state. It owns the on/off `enabled`
+// flag, tracks the play cursor, queues fired clips into one <audio> element (FIFO),
+// skips clips that have gone stale vs the race clock, and keeps a short newest-first
+// history. `toggle()` is a click handler — the user gesture that unlocks autoplay.
+export function useComms(state: RaceState) {
+  const [enabled, setEnabled] = useState(false);
+  const [nowPlaying, setNowPlaying] = useState<RadioMessage | null>(null);
+  const [history, setHistory] = useState<RadioMessage[]>([]);
+  // All refs declared before the helpers so nothing is used-before-defined (lint gate).
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const cursorRef = useRef<CommsCursor>({ lastClock: -1 });
+  const queueRef = useRef<RadioMessage[]>([]);
+  const lastRevRef = useRef<number>(-1);
+  const nowPlayingRef = useRef<RadioMessage | null>(null);
+  const enabledRef = useRef<boolean>(false); // read by the rev-effect without re-subscribing
+  const clockRef = useRef<number>(0);        // latest race clock, read by pump's staleness check
+
+  function pump() {
+    const audio = audioRef.current;
+    if (!audio || nowPlayingRef.current) return;
+    let next = queueRef.current.shift();
+    // Drop clips that have fallen too far behind the race clock (kept in history).
+    while (next && isStale(next, clockRef.current)) next = queueRef.current.shift();
+    if (!next) return;
+    nowPlayingRef.current = next;
+    setNowPlaying(next);
+    audio.src = next.clip; // ponytail: no crossOrigin attr -> plays cross-origin without CORS
+    audio.play().catch(() => { nowPlayingRef.current = null; setNowPlaying(null); });
+  }
+
+  // Create the single audio element on mount and wire 'ended' to drain the queue.
+  // Declared before the rev-effect so the element exists when pump() first runs.
+  useEffect(() => {
+    if (typeof Audio === 'undefined') return;
+    const audio = new Audio();
+    audioRef.current = audio;
+    const onEnded = () => { nowPlayingRef.current = null; setNowPlaying(null); pump(); };
+    audio.addEventListener('ended', onEnded);
+    return () => { audio.removeEventListener('ended', onEnded); audio.pause(); };
+  }, []);
+
+  // On each state change, advance the cursor and enqueue fired clips.
+  useEffect(() => {
+    if (state.rev === 0) return;
+    clockRef.current = state.timeMs;
+    const justConnected = lastRevRef.current === -1; // seed history once on first snapshot
+    lastRevRef.current = state.rev;
+
+    const { cursor, fired, history: hist } = stepComms(
+      cursorRef.current, state.timeMs, state.radio, justConnected,
+    );
+    cursorRef.current = cursor;
+
+    if (justConnected && hist.length) {
+      setHistory(hist.slice(-HISTORY_MAX).reverse()); // newest first
+    }
+    if (fired.length) {
+      // history tracks regardless of enabled; only enabled enqueues audio.
+      setHistory((h) => [...[...fired].reverse(), ...h].slice(0, HISTORY_MAX));
+      if (enabledRef.current) {
+        queueRef.current.push(...fired);
+        pump();
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state.rev]);
+
+  // toggle() runs from an onClick, so its setState calls are not cascading-render
+  // hazards. Turning off stops audio and clears the queue + banner.
+  function toggle() {
+    if (enabled) {
+      queueRef.current = [];
+      audioRef.current?.pause();
+      nowPlayingRef.current = null;
+      setNowPlaying(null);
+      enabledRef.current = false;
+      setEnabled(false);
+    } else {
+      enabledRef.current = true;
+      setEnabled(true);
+    }
+  }
+
+  function replay(msg: RadioMessage) {
+    const audio = audioRef.current;
+    if (!audio) return;
+    queueRef.current = []; // manual replay jumps the queue
+    nowPlayingRef.current = msg;
+    setNowPlaying(msg);
+    audio.src = msg.clip;
+    audio.play().catch(() => { nowPlayingRef.current = null; setNowPlaying(null); });
+  }
+
+  return { enabled, toggle, nowPlaying, history, replay };
+}

--- a/web/src/hooks/useComms.ts
+++ b/web/src/hooks/useComms.ts
@@ -31,7 +31,14 @@ export function useComms(state: RaceState) {
     nowPlayingRef.current = next;
     setNowPlaying(next);
     audio.src = next.clip; // ponytail: no crossOrigin attr -> plays cross-origin without CORS
-    audio.play().catch(() => { nowPlayingRef.current = null; setNowPlaying(null); });
+    // A late play() rejection (transient error, or an interrupting src change/AbortError)
+    // must only clear the banner if this clip is still the current one — otherwise it
+    // would blank the clip that has since replaced it.
+    audio.play().catch(() => {
+      if (nowPlayingRef.current !== next) return;
+      nowPlayingRef.current = null;
+      setNowPlaying(null);
+    });
   }
 
   // Create the single audio element on mount and wire 'ended' to drain the queue.
@@ -74,7 +81,7 @@ export function useComms(state: RaceState) {
   // toggle() runs from an onClick, so its setState calls are not cascading-render
   // hazards. Turning off stops audio and clears the queue + banner.
   function toggle() {
-    if (enabled) {
+    if (enabledRef.current) {
       queueRef.current = [];
       audioRef.current?.pause();
       nowPlayingRef.current = null;
@@ -94,7 +101,11 @@ export function useComms(state: RaceState) {
     nowPlayingRef.current = msg;
     setNowPlaying(msg);
     audio.src = msg.clip;
-    audio.play().catch(() => { nowPlayingRef.current = null; setNowPlaying(null); });
+    audio.play().catch(() => {
+      if (nowPlayingRef.current !== msg) return; // a newer replay/clip already took over
+      nowPlayingRef.current = null;
+      setNowPlaying(null);
+    });
   }
 
   return { enabled, toggle, nowPlaying, history, replay };

--- a/web/src/state/comms.test.ts
+++ b/web/src/state/comms.test.ts
@@ -1,0 +1,35 @@
+import { describe, test, expect } from 'vitest';
+import { stepComms } from './comms';
+import type { RadioMessage } from './race';
+
+const tl: RadioMessage[] = [
+  { timeMs: 100, driverNum: 1, clip: 'a' },
+  { timeMs: 200, driverNum: 16, clip: 'b' },
+  { timeMs: 5000, driverNum: 4, clip: 'c' },
+];
+
+describe('stepComms', () => {
+  test('init from snapshot: earlier messages are history, not fired', () => {
+    const { cursor, fired, history } = stepComms({ lastClock: -1 }, 150, tl, true);
+    expect(fired).toEqual([]);                 // nothing auto-plays on connect
+    expect(history.map((m) => m.driverNum)).toEqual([1]); // 100 <= 150 -> history
+    expect(cursor.lastClock).toBe(150);
+  });
+
+  test('steady state fires messages crossed since lastClock', () => {
+    const { cursor, fired } = stepComms({ lastClock: 150 }, 250, tl, false);
+    expect(fired.map((m) => m.driverNum)).toEqual([16]); // 150 < 200 <= 250
+    expect(cursor.lastClock).toBe(250);
+  });
+
+  test('loop (clock jumps back) resets cursor without firing', () => {
+    const { cursor, fired } = stepComms({ lastClock: 5000 }, 120, tl, false);
+    expect(fired).toEqual([]);
+    expect(cursor.lastClock).toBe(120);
+  });
+
+  test('multiple crossed in one step fire in time order', () => {
+    const { fired } = stepComms({ lastClock: 50 }, 250, tl, false);
+    expect(fired.map((m) => m.timeMs)).toEqual([100, 200]);
+  });
+});

--- a/web/src/state/comms.ts
+++ b/web/src/state/comms.ts
@@ -1,0 +1,39 @@
+import type { RadioMessage } from './race';
+
+export interface CommsCursor { lastClock: number }
+
+export interface CommsStep {
+  cursor: CommsCursor;
+  fired: RadioMessage[];   // messages to enqueue for auto-play this step
+  history: RadioMessage[]; // messages to add to history (silent) — only on snapshot init
+}
+
+// stepComms advances the cursor by one frame/snapshot and decides what to play.
+// One rule drives steady-state, connect, and loop:
+//   - isSnapshot: init lastClock = clock; messages at/before clock go to history, none fire.
+//   - clock < lastClock (loop): reset lastClock = clock, fire nothing.
+//   - otherwise (steady): fire messages with lastClock < timeMs <= clock, in time order.
+export function stepComms(
+  cursor: CommsCursor,
+  clock: number,
+  timeline: RadioMessage[],
+  isSnapshot: boolean,
+): CommsStep {
+  if (isSnapshot) {
+    const history = timeline.filter((m) => m.timeMs <= clock).sort((a, b) => a.timeMs - b.timeMs);
+    return { cursor: { lastClock: clock }, fired: [], history };
+  }
+  if (clock < cursor.lastClock) {
+    return { cursor: { lastClock: clock }, fired: [], history: [] };
+  }
+  const fired = timeline
+    .filter((m) => m.timeMs > cursor.lastClock && m.timeMs <= clock)
+    .sort((a, b) => a.timeMs - b.timeMs);
+  return { cursor: { lastClock: clock }, fired, history: [] };
+}
+
+// isStale reports whether a queued clip has fallen too far behind the race clock to
+// auto-play (it is still shown in history). Best-effort sync, ~3s tolerance.
+export function isStale(msg: RadioMessage, currentClock: number, toleranceMs = 3000): boolean {
+  return currentClock - msg.timeMs > toleranceMs;
+}

--- a/web/src/state/race.test.ts
+++ b/web/src/state/race.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, test } from 'vitest';
 import { emptyState, applyMessage, type RaceState } from './race';
 
 const snapMsg = {
@@ -46,4 +46,28 @@ describe('timing fields', () => {
     expect(s1.cars[1].tyre).toBe('SOFT');
     expect(s1.cars[1].drs).toBe(true);
   });
+});
+
+test('snapshot carries the radio timeline', () => {
+  const s = applyMessage(emptyState(), {
+    type: 'snapshot',
+    data: {
+      session: 'replay', mode: 'replay', label: 'M', cars: {}, timeMs: 3300000, rev: 1,
+      radio: [{ timeMs: 3300500, driverNum: 1, clip: 'https://x/VER.mp3' }],
+    },
+  });
+  expect(s.radio).toHaveLength(1);
+  expect(s.radio[0].driverNum).toBe(1);
+});
+
+test('a frame does not clobber the radio timeline', () => {
+  const s0 = applyMessage(emptyState(), {
+    type: 'snapshot',
+    data: {
+      session: 'replay', mode: 'replay', label: 'M', cars: {}, timeMs: 3300000, rev: 1,
+      radio: [{ timeMs: 3300500, driverNum: 1, clip: 'https://x/VER.mp3' }],
+    },
+  });
+  const s1 = applyMessage(s0, { type: 'frame', data: { rev: 2, timeMs: 3300100, cars: [] } });
+  expect(s1.radio).toHaveLength(1);
 });

--- a/web/src/state/race.ts
+++ b/web/src/state/race.ts
@@ -9,19 +9,22 @@ export interface Car {
   gapMs?: number; gapLaps?: number; intMs?: number;
   speed?: number; gear?: number; throttle?: number; brake?: number; drs?: boolean;
 }
+export interface RadioMessage { timeMs: number; driverNum: number; clip: string }
 export interface RaceState {
   session: string; mode: string; label: string;
   track: Point[]; cars: Record<number, Car>; timeMs: number; rev: number;
+  radio: RadioMessage[];
 }
 
 export function emptyState(): RaceState {
-  return { session: '', mode: '', label: '', track: [], cars: {}, timeMs: 0, rev: 0 };
+  return { session: '', mode: '', label: '', track: [], cars: {}, timeMs: 0, rev: 0, radio: [] };
 }
 
 // Wire payloads from the gateway, mirroring internal/model (Snapshot, Frame).
 interface SnapshotData {
   session: string; mode: string; label: string;
   track?: Point[]; cars: Record<number, Car>; timeMs: number; rev: number;
+  radio?: RadioMessage[];
 }
 interface FrameData { rev: number; timeMs: number; cars?: Car[] }
 type Msg =
@@ -36,6 +39,7 @@ export function applyMessage(s: RaceState, msg: Msg): RaceState {
     return {
       session: d.session, mode: d.mode, label: d.label,
       track: d.track ?? [], cars: { ...d.cars }, timeMs: d.timeMs, rev: d.rev,
+      radio: d.radio ?? [],
     };
   }
   const d = msg.data;


### PR DESCRIPTION
## What this adds

A toggleable **comms layer** that auto-plays driver↔engineer **team radio** in sync with the replay clock — a now-playing banner (driver attribution in team colour) plus a short replayable history. Audio **streams straight from F1's public URLs at play time**; nothing is committed or downloaded.

Same pipeline as before (Python ingest → Redis seam → Go gateway → React), no new architecture. ADR-0001 and ADR-0002 unaffected.

## Design trail
- Spec: `docs/superpowers/specs/2026-06-26-phase3-team-radio-design.md`
- Plan: `docs/superpowers/plans/2026-06-26-phase3-team-radio.md`
- Decision: **ADR-0003** — team-radio audio streamed from F1's URL, not committed (3-way trade-off vs. commit-binaries / gateway-proxy; proxy is the named fallback if URLs ever expire)
- Glossary: CONTEXT.md gains **Team radio** + **Comms** ("overlay" stays reserved for Phase 4)

## Contract change (snapshot-only)
`RadioMessage{TimeMs, DriverNum, Clip}` + `Radio []RadioMessage` on **`Snapshot`** (not `Frame`) — a sparse fixed timeline, like `Track`. Threaded through both lane writers (Go replay `play.go`/`writer.go` and Python live `live.py`). Python↔Go parity self-check updated.

## Recorder
Fetches FastF1 `team_radio`, maps each clip's `Utc` → session-ms via `t0_date`, bakes `[{timeMs, driverNum, clip}]` into the clip header. Window widened 2.5→7.5 min (3300–3750s) for radio density. Pure extraction helper (`ingest/radio.py`) is stdlib-only and runs in CI.

Re-baked clips: **Monza 2024 (5 radio clips, default replay) · Monza 2023 (7, re-baked to keep compare phase) · Silverstone 2024 (1, live lane)** — all 4500 frames, compare lanes stay in phase. This adds ~weight to the committed clips (Monza-2024 ~20 MB) — the deliberate cost of the 7.5-min window.

## Frontend
- `comms.ts` — pure cursor/queue logic (steady-state / mid-replay connect / loop-reset / staleness), unit-tested
- `useComms.ts` — owns the on/off toggle, drains a FIFO queue into one `<audio>` element, skips clips >3 s stale
- `Comms.tsx` — banner + history, wired beside the timing tower

## Verification
**Automated (all green):**
- `go test ./...` — 6/6 packages
- web `npm run build` / `npm test` (23) / `npm run lint --max-warnings 0` — all clean
- `ingest/check_live_contract.py` + `ingest/test_radio.py` — both pass (radio self-check newly wired into CI)
- End-to-end: a freshly-baked clip URL returns `200 audio/mpeg` (257 KB)

**NOT yet verified — needs a human at a browser with sound:** in-browser playback (toggle Comms ON, confirm a clip auto-plays and the banner shows the driver). Everything up to the `<audio>` element is verified; actual audible playback is pending manual check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)