### PR TITLE
ci: fix govulncheck build failure under Go 1.26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,10 @@ jobs:
         with:
           go-version-file: go.mod
       - name: govulncheck (Go)
-        run: go run golang.org/x/vuln/cmd/govulncheck@v1.1.3 ./...
+        # Intentionally @latest, not pinned: `go run` compiles govulncheck with the repo's Go
+        # toolchain (go.mod = 1.26), and older pinned releases fail to build under it
+        # ("invalid array length ..."). Tracking latest keeps it toolchain-compatible.
+        run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...
       - uses: actions/setup-node@v4
         with:
           node-version: '20'


### PR DESCRIPTION
Follow-up to #20. The `security` CI job failed because `govulncheck@v1.1.3` is
compiled by `go run` against the repo's Go toolchain (go.mod = 1.26.4) and its
older dependencies don't build there (`invalid array length -delta * delta`).

Reverts govulncheck to `@latest` (documented usage — it must track the toolchain),
with a comment explaining why it can't be pinned like `pip-audit`. Verified locally:
`go run golang.org/x/vuln/cmd/govulncheck@latest ./...` → "No vulnerabilities found".

`pip-audit==2.7.3` stays pinned (pip-installed, no toolchain coupling; verified it resolves).

🤖 Generated with [Claude Code](https://claude.com/claude-code)