### PR TITLE
fix: bump Go toolchain to 1.26.5 to resolve GO-2026-5856

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/natcat38/f1-race-tracker
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/alicebob/miniredis/v2 v2.38.0


### PR DESCRIPTION
## Summary
- CI's `Dependency vulnerability scan` job was failing: `govulncheck` flagged GO-2026-5856, an Encrypted Client Hello privacy leak in `crypto/tls`, present in Go 1.26.4 and fixed in 1.26.5.
- CI reads its toolchain version from `go.mod`'s `go` directive, so bumping `1.26.4` → `1.26.5` is sufficient for `setup-go` to pull the patched release.

## Test plan
- [x] `go run golang.org/x/vuln/cmd/govulncheck@latest ./...` locally → "No vulnerabilities found"
- [x] `go build ./...` and `go vet ./...` pass
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)