### PR TITLE
fix(ingest): pin numpy back to 2.4.6, the last version supporting Python 3.11

### DIFF
--- a/ingest/requirements.txt
+++ b/ingest/requirements.txt
@@ -1,5 +1,7 @@
 fastf1==3.8.3
-numpy==2.5.1
+# numpy>=2.5.0 requires Python>=3.12; CI pins 3.11 (see ci.yml), so 2.4.6 is the
+# newest resolvable version. Bumping past this needs a CI python-version bump too.
+numpy==2.4.6
 # Transitive via fastf1's CacheControl / signalrcore — pinned up from the resolved
 # 1.1.2 to fix GHSA-6v7p-g79w-8964.
 msgpack>=1.2.1


### PR DESCRIPTION
## Summary
- #23 bumped numpy to 2.5.1, but that release requires Python>=3.12 while CI pins 3.11 (see `ci.yml`)
- `pip-audit` can't resolve the install, so the required "Dependency vulnerability scan" check has been failing on `main` and every subsequent PR since
- Reverts to 2.4.6, the newest numpy release that still supports 3.11

## Test plan
- [ ] CI green, including the Dependency vulnerability scan