### PR TITLE
Static GH Pages demo, live-capture handoff, and doc/issue sweep

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,8 @@ jobs:
           # (.github/workflows/pages.yml) has deployed at least once post-merge
           # and Settings > Pages > Source is set to "GitHub Actions" — both
           # happen after this PR merges, not before. Remove this --exclude once
-          # https://natcat38.github.io/f1-race-tracker/ is confirmed live.
+          # https://natcat38.github.io/f1-race-tracker/ is confirmed live —
+          # tracked in issue #41.
           args: "--no-progress --exclude-loopback --exclude 'https://natcat38\\.github\\.io/f1-race-tracker/?$' README.md CONTEXT.md docs/*.md docs/adr/**/*.md"
           fail: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,12 @@ jobs:
       - uses: actions/checkout@v7
       - uses: lycheeverse/lychee-action@v2
         with:
-          args: "--no-progress --exclude-loopback README.md CONTEXT.md docs/*.md docs/adr/**/*.md"
+          # The static-demo link in README.md 404s until the Pages workflow
+          # (.github/workflows/pages.yml) has deployed at least once post-merge
+          # and Settings > Pages > Source is set to "GitHub Actions" — both
+          # happen after this PR merges, not before. Remove this --exclude once
+          # https://natcat38.github.io/f1-race-tracker/ is confirmed live.
+          args: "--no-progress --exclude-loopback --exclude 'https://natcat38\\.github\\.io/f1-race-tracker/?$' README.md CONTEXT.md docs/*.md docs/adr/**/*.md"
           fail: true
 
   docker:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,62 @@
+name: Deploy static demo
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'web/**'
+      - 'cmd/bake-static/**'
+      - 'internal/**'
+      - 'data/replays/monza-2024-race.jsonl'
+      - '.github/workflows/pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
+
+      - name: Bake the static-demo clip
+        run: go run ./cmd/bake-static --clip data/replays/monza-2024-race.jsonl --out web/public/static-demo/monza-2024-race.ndjson --session static-demo
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      - run: npm ci
+        working-directory: web
+
+      - name: Build (static-demo base path + player)
+        run: npm run build
+        working-directory: web
+        env:
+          VITE_STATIC_DEMO: 'true'
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/upload-pages-artifact@v4
+        with:
+          path: web/dist
+
+      - uses: actions/deploy-pages@v4
+        id: deployment

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,10 @@ node_modules/
 web/dist/
 !web/dist/.gitkeep
 web/.vite/
+# Baked by `go run ./cmd/bake-static` for the GitHub Pages static demo — CI
+# generates this fresh on every deploy (.github/workflows/pages.yml), it's
+# never committed.
+web/public/static-demo/
 
 # --- OS / IDE ---
 .DS_Store

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -78,6 +78,19 @@ rather than connecting to a real session. The UI labels this state honestly
 (`Live (demo)`, with a tooltip) rather than leaving the caveat only in the docs.
 
 - _Use_ "source" for the live-vs-replay choice; the operator switches it via a toggle.
+- Neither term describes the **static demo** (below) — that has no pipeline at all.
+
+## Static demo
+
+The frontend-only build hosted on GitHub Pages: a baked snapshot+frames JSON per
+clip, played back by the frontend alone on a client-side clock, with no **writer**,
+no **seam**, and no **gateway** behind it. It visually resembles the **replay**
+source (same clip content) but shares none of its machinery — nothing here proves
+anything about the real pipeline. A third front door alongside the README/video and
+`docker-compose`, not a replacement for either.
+
+- _Use_ "static demo" (or "the Pages demo"); never call it "replay" — that term is
+  reserved for the pipeline-backed source above.
 
 ## Compare
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ The product is judged first by whether it helps you understand how the car is pe
 - **A polyglot seam done right** — Python and Go publish byte-identical JSON to the same Redis keys; the gateway consumes either with zero code changes.
 - **Live WebSocket fan-out at scale** — one in-memory hub pushes 10 Hz frames to a thousand viewers, with backpressure that sheds milliseconds rather than dropping clients.
 
+## Quick look (no clone required)
+
+**[Live static demo →](https://natcat38.github.io/f1-race-tracker/)** — a frontend-only build that plays back one recorded clip, client-side, with no backend running. This is the fastest way to see what the project does, but it's a simplified artifact, not the real system: no live source, no cross-year comparison, and nothing here proves the polyglot pipeline actually works.
+
+For that, run it for real:
+
 ## Run it
 
 ```bash

--- a/cmd/bake-static/main.go
+++ b/cmd/bake-static/main.go
@@ -1,0 +1,87 @@
+// Command bake-static reads a replay clip and writes it as a sequence of
+// WebSocket wire envelopes — the same {type,data} shape internal/ws/frame.go
+// encodes for real clients — to a newline-delimited JSON file. The GitHub
+// Pages static demo fetches this file and feeds the frontend's existing
+// applyMessage reducer directly, with no Go/Python/Redis behind it.
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/natcat38/f1-race-tracker/internal/feed/replay"
+	"github.com/natcat38/f1-race-tracker/internal/model"
+	"github.com/natcat38/f1-race-tracker/internal/ws"
+)
+
+func main() {
+	clip := flag.String("clip", "data/replays/monza-2024-race.jsonl", "source replay clip (.jsonl)")
+	out := flag.String("out", "web/public/static-demo/monza-2024-race.ndjson", "output path (.ndjson)")
+	session := flag.String("session", "static-demo", "session key baked into the snapshot")
+	flag.Parse()
+
+	if err := run(*clip, *out, *session); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func run(clipPath, outPath, session string) error {
+	src, err := replay.Load(clipPath, 1)
+	if err != nil {
+		return fmt.Errorf("bake-static: load clip: %w", err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
+		return fmt.Errorf("bake-static: mkdir: %w", err)
+	}
+	f, err := os.Create(outPath)
+	if err != nil {
+		return fmt.Errorf("bake-static: create %s: %w", outPath, err)
+	}
+	defer f.Close()
+
+	w := bufio.NewWriter(f)
+	if err := bake(src, session, w); err != nil {
+		return err
+	}
+	return w.Flush()
+}
+
+// bake writes one snapshot envelope (the clip's header fields, no cars yet)
+// followed by one frame envelope per clip line, in order. Each frame's Rev is
+// reassigned 1..N — mirroring what Writer.Run does when publishing this same
+// clip to a fresh Redis session — rather than trusting the file's own
+// (advisory, possibly-repeating) Rev values.
+func bake(src *replay.Source, session string, w *bufio.Writer) error {
+	snap := model.NewSnapshot(session, src.Mode(), src.Label())
+	snap.Track = src.Track()
+	snap.Radio = src.Radio()
+	snap.LapTrace = src.LapTrace()
+	snap.TotalLaps = src.TotalLaps()
+	snap.Stints = src.Stints()
+
+	sb, err := ws.EncodeSnapshot(snap)
+	if err != nil {
+		return fmt.Errorf("bake-static: encode snapshot: %w", err)
+	}
+	if _, err := w.Write(append(sb, '\n')); err != nil {
+		return fmt.Errorf("bake-static: write snapshot: %w", err)
+	}
+
+	for i, fr := range src.Frames() {
+		fr.Rev = int64(i + 1)
+		fr.SessionKey = session
+		fb, err := ws.EncodeFrame(fr)
+		if err != nil {
+			return fmt.Errorf("bake-static: encode frame %d: %w", i, err)
+		}
+		if _, err := w.Write(append(fb, '\n')); err != nil {
+			return fmt.Errorf("bake-static: write frame %d: %w", i, err)
+		}
+	}
+	return nil
+}

--- a/cmd/bake-static/main_test.go
+++ b/cmd/bake-static/main_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeTempClip(t *testing.T, body string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "clip.jsonl")
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func TestRun_BakesSnapshotThenFramesWithMonotonicRev(t *testing.T) {
+	body := `{"track":[{"x":0,"y":0}],"label":"Test Clip"}
+{"timeMs":100,"frame":{"rev":9,"timeMs":100,"cars":[{"driverNum":1,"code":"VER","team":"Red Bull","pos":1,"p":{"x":0.1,"y":0.1},"status":"OnTrack"}]}}
+{"timeMs":200,"frame":{"rev":9,"timeMs":200,"cars":[{"driverNum":1,"code":"VER","team":"Red Bull","pos":1,"p":{"x":0.2,"y":0.2},"status":"OnTrack"}]}}
+`
+	clipPath := writeTempClip(t, body)
+	outPath := filepath.Join(t.TempDir(), "out.ndjson")
+
+	if err := run(clipPath, outPath, "static-demo"); err != nil {
+		t.Fatal(err)
+	}
+
+	f, err := os.Open(outPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	var lines []string
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		if sc.Text() != "" {
+			lines = append(lines, sc.Text())
+		}
+	}
+	if len(lines) != 3 {
+		t.Fatalf("got %d lines, want 3 (1 snapshot + 2 frames)", len(lines))
+	}
+
+	var env struct {
+		Type string          `json:"type"`
+		Data json.RawMessage `json:"data"`
+	}
+
+	if err := json.Unmarshal([]byte(lines[0]), &env); err != nil {
+		t.Fatal(err)
+	}
+	if env.Type != "snapshot" {
+		t.Errorf("line 0 type = %q, want snapshot", env.Type)
+	}
+	if !strings.Contains(string(env.Data), `"session":"static-demo"`) {
+		t.Errorf("snapshot data missing session key: %s", env.Data)
+	}
+
+	wantRevs := []int64{1, 2}
+	for i, wantRev := range wantRevs {
+		if err := json.Unmarshal([]byte(lines[i+1]), &env); err != nil {
+			t.Fatal(err)
+		}
+		if env.Type != "frame" {
+			t.Errorf("line %d type = %q, want frame", i+1, env.Type)
+		}
+		var fd struct {
+			Rev int64 `json:"rev"`
+		}
+		if err := json.Unmarshal(env.Data, &fd); err != nil {
+			t.Fatal(err)
+		}
+		if fd.Rev != wantRev {
+			// The source file's own rev (9, 9) must be reassigned monotonically —
+			// matching what Writer.Run does against a fresh Redis session.
+			t.Errorf("frame %d rev = %d, want %d (reassigned, not the file's own rev)", i, fd.Rev, wantRev)
+		}
+	}
+}

--- a/docs/F1_Race_Tracker_Product_Scope.md
+++ b/docs/F1_Race_Tracker_Product_Scope.md
@@ -140,20 +140,21 @@ A visitor who connects after playback started **immediately sees the current car
 
 ## 6. How It's Run & Demoed
 
-> This replaces the original "always-on hosted site." There is **no required hosting** and **no cost**.
+> This replaces the original "always-on hosted site." There is **no required hosting of the real system, and no cost** — see ADR-0006 for why a static, backend-free demo doesn't count as a reversal of that.
 
-The primary experience is the running app itself — a race engineer opens the board and reads it. The rest of this section is about how someone gets there:
+The primary experience is the running app itself — a race engineer opens the board and reads it. The rest of this section is about how someone gets there, via **three front doors**:
 
 - **Primary artifact (what most people see):** a polished **README** with the architecture diagram, a recorded **GIF/video** of the map animating and the two-year comparison, and the **benchmark numbers**.
-- **Hands-on reviewer:** **`docker-compose up`** runs the *full real system* locally — Python ingestion + Redis + the Go gateway — so a serious reviewer sees the actual polyglot architecture, not a simplified version. The gateway is stateless by design (so it *could* run as multiple replicas), but the system currently runs and is benchmarked as a single gateway — see `docs/adr/0001-single-gateway-deferred-multigateway.md`.
-- **Hosted live link:** *optional and deferred.* Running it 24/7 is never a requirement or a maintenance burden.
+- **Quick look, no clone required:** a **static demo** on GitHub Pages — a frontend-only build that plays back one pre-baked clip client-side, with no Python, Redis, or Go behind it (see `CONTEXT.md`'s **Static demo** entry and `docs/adr/0006-static-gh-pages-demo-as-third-front-door.md`). Free and zero-maintenance, so it doesn't reopen the cost/ops concern §7 retires — but it is explicitly a lesser artifact, framed honestly as a quick look, never as "the system." It has no live source and (for now) no cross-year comparison.
+- **Hands-on reviewer:** **`docker-compose up`** runs the *full real system* locally — Python ingestion + Redis + the Go gateway — so a serious reviewer sees the actual polyglot architecture, not a simplified version. This remains the **only** way to see the real system run; the static demo does not substitute for it. The gateway is stateless by design (so it *could* run as multiple replicas), but the system currently runs and is benchmarked as a single gateway — see `docs/adr/0001-single-gateway-deferred-multigateway.md`.
+- **Hosted live link (of the real system):** *optional and deferred.* Running the full stack 24/7 is never a requirement or a maintenance burden — this is distinct from the static demo above, which has no stack to run.
 - **The benchmark** (concurrent WebSocket connections, p50/p99 fan-out latency) is run on demand and published in `BENCHMARKS.md` — it measures how a **single gateway** holds up as concurrent viewers climb (a lower bound, since the load generator shares the host). The stateless-gateway + Redis seam is what *would* make a multi-gateway tier a config change; building and benchmarking that tier is future work (see ADR-0001).
 
 ---
 
 ## 7. Out of Scope
 
-- **Always-on public hosting** — deliberately retired; demo is README + video + local `docker-compose`.
+- **Always-on hosting of the real system** — deliberately retired; the hands-on experience stays local `docker-compose`. (A free, zero-maintenance **static demo** of the frontend alone is not this — see ADR-0006.)
 - **Paid data tiers** — uses **free** F1 data only (FastF1; OpenF1 historical). Live uses FastF1's free client, best-effort.
 - **Full-race data files in the repo** — only short, curated, downsampled clips are committed; the recorder bakes more on demand.
 - **User accounts / auth** — none; runs locally, single-operator.

--- a/docs/adr/0002-timing-fields-rebroadcast-flat.md
+++ b/docs/adr/0002-timing-fields-rebroadcast-flat.md
@@ -11,9 +11,15 @@ fields on the existing struct), needs zero gateway changes, and heals via the
 snapshot for free: `model.Apply` already does a wholesale per-car replace, so a
 reconnecting client's snapshot carries the latest timing with no extra code.
 
-The cost is frame size — roughly doubled (~2 KB → ~4 KB for 20 cars). This is
-gated by the existing load-test benchmark (`BENCHMARKS.md`, 1000 viewers @ 10 Hz).
-If p99 frame latency regresses or drops appear, the upgrade path is to split the
-slow fields into a separate lower-cadence message ("Option B") — telemetry stays
-per-frame, lap/tyre/sector/gap publish only on change. We did not build that up
-front because the benchmark, not a guess, should justify the added complexity.
+The cost is frame size — roughly doubled (~2 KB → ~4 KB for 20 cars, at Phase 2).
+This is gated by the existing load-test benchmark (`BENCHMARKS.md`, 1000 viewers
+@ 10 Hz). If p99 frame latency regresses or drops appear, the upgrade path is to
+split the slow fields into a separate lower-cadence message ("Option B") —
+telemetry stays per-frame, lap/tyre/sector/gap publish only on change. We did not
+build that up front because the benchmark, not a guess, should justify the added
+complexity.
+
+> **Update (Phase 5, ADR-0005):** the ~4 KB figure is now mildly understated —
+> Phase 5 added per-car `lap` and occasional per-frame `weather`, measuring
+> closer to ~5.7 KB for 20 cars on the current default clip. No benchmark
+> regression observed; "Option B" remains unbuilt for the same reason as above.

--- a/docs/adr/0005-phase5-stints-and-weather-extend-existing-patterns.md
+++ b/docs/adr/0005-phase5-stints-and-weather-extend-existing-patterns.md
@@ -1,0 +1,55 @@
+# 0005 — Phase 5's `stints` and `weather` extend existing contract patterns, not new ones
+
+**Status:** accepted
+
+## Context
+
+Phase 5 (pit-wall completion, `32957a1` / PR #39) added `stints` and `weather` to
+the event model (`internal/model/model.go`), but neither shipped with its own
+ADR, unlike every prior contract change (ADR-0002 timing/telemetry, ADR-0003
+team radio, ADR-0004 ghost-overlay lap traces). Recorded here for the same
+reason those exist: so a future reader doesn't wonder whether a new
+data-placement pattern was introduced.
+
+## Decision
+
+Neither field introduces anything new — each is a straightforward instance of
+an already-decided pattern:
+
+- **`Stints map[int][]Stint`** rides the **snapshot** only, `omitempty`,
+  session-constant (baked once at record time, not windowed to the replay
+  clip — a driver's full-race stint plan even though the clip only plays part
+  of the race). This is the exact same shape as `LapTrace` (ADR-0004): an
+  additive snapshot field, populated once by the recorder, carried forward
+  automatically because `Apply`'s snapshot branch is a wholesale replace.
+- **`Weather *Weather`** rides **both** the snapshot and `Frame`, following
+  ADR-0002's flat-rebroadcast pattern: attached to a frame only when the
+  sample changes from the last one emitted (rare — session weather is
+  ~1-minute cadence at bake time), then folded into the snapshot by `Apply`
+  (`internal/model/apply.go`) so a reconnecting client always has the current
+  reading without waiting for the next change.
+
+## Consequences
+
+- No gateway change, no new message type, no new accumulation logic — both
+  fields fit the two data-placement patterns the contract already had
+  (session-constant-on-snapshot per ADR-0004; flat-field-on-frame-when-changed
+  per ADR-0002's spirit, though weather only rebroadcasts on actual change
+  rather than every tick).
+- **ADR-0002's frame-size estimate is now mildly understated.** It cited
+  "~2 KB → ~4 KB for 20 cars" for the Phase 2 fields. Measuring a real frame
+  from the current default clip (`data/replays/monza-2024-race.jsonl`, ~20
+  cars, Phase 5's `lap` and telemetry fields included) gives ~5.7 KB — larger
+  again once Phase 5's fields are counted, though `weather` itself only adds
+  ~60 bytes on the rare frame it rides. Still gated by the same load-test
+  benchmark (`BENCHMARKS.md`); no regression has been observed, so the
+  "Option B" split ADR-0002 describes remains unbuilt.
+
+## Considered and rejected
+
+- **A new lower-cadence message type for `weather`.** Rejected for the same
+  reason ADR-0002 rejected it for timing fields: the benchmark hasn't shown a
+  problem, and `weather` is far rarer than the timing fields already flowing
+  on the flat contract — building a second message type for an even smaller
+  cost than the one already accepted would be solving a problem that doesn't
+  exist yet.

--- a/docs/adr/0006-static-gh-pages-demo-as-third-front-door.md
+++ b/docs/adr/0006-static-gh-pages-demo-as-third-front-door.md
@@ -1,0 +1,80 @@
+# Static GitHub Pages demo: a third front door, not a hosting reversal
+
+**Status:** accepted
+
+## Context
+
+§6/§7 of `F1_Race_Tracker_Product_Scope.md` retire "always-on public hosting":
+the primary artifact is README + recorded video, the hands-on experience is
+`docker-compose up` running the real polyglot system, and a hosted live link is
+explicitly optional and deferred. The stated reason is cost/maintenance — no
+server to keep alive or pay for.
+
+The single biggest adoption friction is exactly that: a recruiter or portfolio
+visitor won't clone the repo and run `docker compose up`. An always-on visual
+demo converts "I'll never run this" into "oh, I see what it does" — but
+building one means hosting *something*, which reads as a direct reversal of
+§7's "always-on public hosting" bullet.
+
+Two different reasons turned out to be bundled into "no hosting":
+1. **Cost/maintenance** (the one §6 states) — a static GitHub Pages site is
+   free and zero-maintenance, so this reason doesn't block it.
+2. **The hands-on reviewer should see the real system** (implicit in §6's
+   "not a simplified version") — a static, backend-free replay is
+   structurally a simplified version. This reason isn't satisfied by GH Pages
+   and isn't overridden by it either.
+
+## Decision
+
+Add a **static demo**: a frontend-only build hosted on GitHub Pages that reads
+a pre-baked snapshot+frames JSON for one clip and plays it back client-side on
+a JS clock, with no writer, no seam, no gateway behind it (see `CONTEXT.md`'s
+**Static demo** entry). It sits **alongside** the README/video and
+`docker-compose`, not in place of either — a third front door, explicitly
+framed (in the README and in-app) as a quick look, not the real architecture.
+`docker-compose` remains the only way to see the actual polyglot system run.
+
+Key design choices, resolved during scoping:
+- **Bake, don't reimplement.** The static file is produced by reusing the
+  existing Go replay-load → hub-accumulation → `encodeSnapshot`/`encodeFrame`
+  path (`internal/ws/frame.go`), writing envelopes to a file instead of
+  broadcasting over WebSocket. No second translation of the clip format into
+  wire format gets written in TypeScript or Python.
+- **No custom decimation.** The default clip (`monza-2024-race.jsonl`, 24 MB
+  raw) gzip-compresses to ~927 KB — under the 2 MB budget with no downsampling
+  or coordinate quantization. GitHub Pages' Fastly CDN serves gzip
+  automatically. Revisit only if a future clip's baseline exceeds budget.
+- **v1 scope: one clip, full feature parity except the live source.** Track
+  map, timing tower, stints, weather, race control, team radio (streamed
+  live from F1's public URLs, same as today) all work statically. Compare and
+  ghost overlay (which need two synced clips) are deferred to a fast-follow.
+  The live/replay source toggle is hidden entirely in the static build rather
+  than shown disabled.
+- **Playback clock** ports the Go replay player's real per-frame `timeMs`
+  pacing and looping (`playFromStart`), not a flat interval.
+
+## Consequences
+
+- Two build outputs from one frontend: the docker-compose `web/dist` (base
+  `/`) and the Pages `dist` (base `/f1-race-tracker/`), selected by a Vite
+  build-time flag.
+- A new CI workflow builds and publishes the static demo on push to `main`;
+  it's additive and doesn't touch the existing CI/OKF workflows.
+- `CONTEXT.md`'s **Live/Replay** entry now cross-references **Static demo** so
+  the two are never conflated — the static build proves nothing about the
+  live pipeline.
+- `docs/F1_Race_Tracker_Product_Scope.md` §6/§7 are updated to describe three
+  front doors instead of two, and to state explicitly that "no always-on
+  hosting" meant cost/maintenance, not "no static artifact."
+
+## Considered and rejected
+
+- **Treat this as a full reversal and drop the no-hosting rule.** Rejected —
+  the "see the real system" reason behind the rule still holds for the
+  hands-on reviewer; `docker-compose` stays the only way to see it.
+- **Replace the README/video as the primary artifact with the Pages demo.**
+  Rejected — additive, not a replacement; the recorded video/GIF stays useful
+  for a visitor who won't even follow a link.
+- **Ship compare/ghost overlay in v1.** Rejected for now — they need two
+  synced baked clips (heavier payload, more bake work); prove the single-clip
+  player and size budget first.

--- a/docs/superpowers/plans/2026-07-23-phase5-pit-wall-completion.md
+++ b/docs/superpowers/plans/2026-07-23-phase5-pit-wall-completion.md
@@ -1,0 +1,257 @@
+# Phase 5 — Pit-wall completion: make the race-engineer story real
+
+> **Status: as-executed, archived retroactively.** This plan drove the work shipped in
+> commit `32957a1` / PR [#39](https://github.com/natcat38/f1-race-tracker/pull/39)
+> ("Pit-wall completion — strategy, weather, live-field coverage"). It originally lived
+> only as a local, uncommitted plan file, which meant it wasn't reviewable by anyone
+> cloning the repo — see issue [#36](https://github.com/natcat38/f1-race-tracker/issues/36).
+> Committed here unchanged in substance (light formatting only) to restore the
+> per-milestone plan pattern the earlier phases established. The described decisions
+> (contract fields, clip re-bake windows, feature scope) are recorded as landed;
+> `docs/F1_Race_Tracker_Product_Scope.md` and `CONTEXT.md` are the current source of
+> truth for the shipped product, not this plan.
+
+## Context
+
+Evaluation of branch `feat/pit-wall-race-engineer-polish` found the pipeline solid (Python bake → Redis → Go gateway → WebSocket → React; `docker compose up` just works) but the product can't deliver its "you're the race engineer" promise:
+
+- **All three replay clips are laps 1–5 slices** — hardcoded `WINDOW_START_S = 3300 / WINDOW_END_S = 3750` in [record.py:66-67](../../../ingest/record.py). Verified: 90,000/90,000 car frames are `status:"OnTrack"`, zero pit stops, no tyre-age resets. Strategy signals are structurally impossible.
+- **Two CI blockers uncommitted**: `internal/model/model.go` fails `gofmt`; new `lap`/`totalLaps` fields missing from the golden contract fixture.
+- **Missing analysis features**: stint history, weather, gap trends, rival sector deltas, two-car telemetry compare. The "LIVE" toggle silently plays a second replay clip. `live_signalr.py` is positions-only and unverified.
+
+User decisions: re-bake all three clips around a pit window; label live honestly; do all polish; build ALL formerly-deferred features. Docs may be amended freely.
+
+**Ordering rule**: Phase 1 extends the wire contract with everything later phases need, so clips are re-baked exactly once.
+
+**Contract discipline (applies to every phase)**: any field added to the Go model MUST land, in the same commit, in all of:
+1. [internal/model/model.go](../../../internal/model/model.go) (+ [apply.go](../../../internal/model/apply.go) if frame-carried)
+2. TS mirror [web/src/state/race.ts](../../../web/src/state/race.ts) (interfaces, `parseMsg` guards, `applyMessage`)
+3. Python builders `build_snapshot`/`build_frame` in [ingest/live.py:51-64](../../../ingest/live.py)
+4. [ingest/check_live_contract.py](../../../ingest/check_live_contract.py) key sets
+5. Golden fixture [testdata/contract/golden_snapshot.json](../../../testdata/contract/golden_snapshot.json) + BOTH its tests: [internal/model/contract_test.go](../../../internal/model/contract_test.go) and [web/src/state/contract.test.ts](../../../web/src/state/contract.test.ts)
+
+---
+
+## Phase 0 — CI blockers
+
+1. `gofmt -w internal/model/model.go` (the new `Lap` field broke struct-tag alignment; CI has a hard `gofmt -l` gate).
+2. Golden fixture: add `"lap": 12` to car `"1"` and top-level `"totalLaps": 53` in [golden_snapshot.json](../../../testdata/contract/golden_snapshot.json). Assert in [contract_test.go](../../../internal/model/contract_test.go) (`c1.Lap != 12`, `s.TotalLaps != 53`) and [contract.test.ts](../../../web/src/state/contract.test.ts) (`s.cars[1].lap`, `s.totalLaps`).
+
+**Gate**: `gofmt -l .` prints nothing; `go test ./internal/model/...`; `cd web && npx vitest run src/state/contract.test.ts`.
+
+---
+
+## Phase 1 — Contract extension + single re-bake
+
+### 1a. Go model
+
+[model.go](../../../internal/model/model.go) — add after `RadioMessage`:
+
+```go
+// Stint is one tyre stint from the full-race lap data (session-constant, like LapTrace).
+type Stint struct {
+	Compound string `json:"compound"` // "SOFT"|"MEDIUM"|"HARD"|"INTERMEDIATE"|"WET"
+	StartLap int    `json:"startLap"`
+	EndLap   int    `json:"endLap"`
+}
+
+// Weather is a low-rate sample (~1/min at bake). Rides on a frame when it
+// changes; folded into the snapshot by Apply.
+type Weather struct {
+	AirTempC   float64 `json:"airTempC"`
+	TrackTempC float64 `json:"trackTempC"`
+	Rainfall   bool    `json:"rainfall"`
+}
+```
+
+- `Snapshot`: `Stints map[int][]Stint \`json:"stints,omitempty"\`` and `Weather *Weather \`json:"weather,omitempty"\`` (place near `LapTrace`/`TotalLaps`).
+- `Frame`: `Weather *Weather \`json:"weather,omitempty"\``.
+- [apply.go](../../../internal/model/apply.go) inside `Apply`, before `s.TimeMs = f.TimeMs`:
+  ```go
+  if f.Weather != nil {
+  	s.Weather = f.Weather
+  }
+  ```
+- [play.go:16-23](../../../internal/feed/replay/play.go): `clipHeader` gains `Stints map[int][]model.Stint \`json:"stints"\``; `Source` gains field + accessor `func (s *Source) Stints() map[int][]model.Stint`; wire through `Load` (mirror how `totalLaps` was added in this branch's diff — see `git diff internal/feed/replay/play.go`).
+- [writer.go:14-22](../../../internal/app/writer.go): `Source` interface gains `Stints() map[int][]model.Stint`; in `Run`, `snap.Stints = wr.src.Stints()` next to `snap.TotalLaps`. **Find all `Source` implementations first** — `grep -rn "TotalLaps() int" internal cmd` — and add `Stints()` to each (there is at least the replay source and test stubs in `writer_test.go`/`play_test.go`; a synthetic source may exist too).
+- Extend `writer_test.go` to assert `snap.Stints` passes through, mirroring its existing `TotalLaps` assertion.
+
+### 1b. TS mirror
+
+[race.ts](../../../web/src/state/race.ts):
+```ts
+export interface Stint { compound: string; startLap: number; endLap: number }
+export interface Weather { airTempC: number; trackTempC: number; rainfall: boolean }
+```
+- `RaceState` + `SnapshotData`: `stints?: Record<number, Stint[]>` (RaceState non-optional, default `{}`), `weather?: Weather`. `FrameData`: `weather?: Weather`.
+- `emptyState()`: `stints: {}` (weather stays undefined).
+- `applyMessage` snapshot branch: `stints: d.stints ?? {}, weather: d.weather,`. Frame branch: `weather: d.weather ?? s.weather` in the returned object.
+- `parseMsg`: reject present-but-wrong-typed values, same style as the existing guards ([race.ts:75-77](../../../web/src/state/race.ts)): `stints` must be a non-array object when present; `weather` must be a non-array object when present (both snapshot and frame).
+
+### 1c. Python mirror
+
+- [live.py:51-64](../../../ingest/live.py): `build_snapshot(..., stints, total_laps, rev)` adds `"stints": stints` (always present, default `{}` at call sites — matches how `lapTrace` behaves). `build_frame(..., weather=None)` adds `"weather": weather` only when not None (same omission pattern as `messages`).
+- Clip-replay path ([live.py:77-88](../../../ingest/live.py)): `stints = header.get("stints", {})`, pass through; pass frame-line `weather` through if present in the clip line's frame dict.
+- Update every `build_snapshot(`/`build_frame(` call site: `grep -n "build_snapshot(\|build_frame(" ingest/*.py` — includes [live_signalr.py](../../../ingest/live_signalr.py) (pass `{}` / `None` there for now; Phase 4 improves it).
+- [check_live_contract.py](../../../ingest/check_live_contract.py): add `"stints"` to `SNAP_KEYS` ([line 9](../../../ingest/check_live_contract.py)); new test asserting `weather` is omitted from frames when None and present when passed (mirror `test_frame_messages_key_optional`).
+
+### 1d. Golden fixture + both contract tests
+
+Add to [golden_snapshot.json](../../../testdata/contract/golden_snapshot.json):
+```json
+"stints": { "1": [ {"compound": "SOFT", "startLap": 1, "endLap": 14},
+                    {"compound": "HARD", "startLap": 15, "endLap": 53} ] },
+"weather": { "airTempC": 28.5, "trackTempC": 41.2, "rainfall": false }
+```
+Assert in [contract_test.go](../../../internal/model/contract_test.go): `len(s.Stints[1]) == 2`, `s.Stints[1][1].Compound == "HARD"`, `s.Weather.TrackTempC == 41.2`, `!s.Weather.Rainfall`. Mirror in [contract.test.ts](../../../web/src/state/contract.test.ts): `s.stints[1]` length 2, compound, `s.weather?.trackTempC`.
+
+### 1e. record.py: lap-window args + stints + weather
+
+[record.py](../../../ingest/record.py):
+
+1. **Args** (near [line 47-51](../../../ingest/record.py)): `--start-lap` / `--end-lap` (int, default None). After `session.laps` is available, when both given:
+   ```python
+   lap_starts = session.laps.groupby('LapNumber')['LapStartTime'].min()
+   WINDOW_START_S = int(lap_starts.loc[args.start_lap].total_seconds())
+   nxt = args.end_lap + 1
+   WINDOW_END_S = (int(lap_starts.loc[nxt].total_seconds())
+                   if nxt in lap_starts.index else WINDOW_START_S + 450)
+   print(f"Window from laps {args.start_lap}-{args.end_lap}: {WINDOW_START_S}s -> {WINDOW_END_S}s")
+   ```
+   Keep the constants as defaults when flags absent. Warn (reuse the 25 MB warning style) if the window exceeds ~600 s.
+2. **Stints** (near the `lapnum_lookup` block, [record.py:413-429](../../../ingest/record.py)) — whole-race stints per driver:
+   ```python
+   stints = {}
+   for num in session.drivers:
+       inum = int(num)
+       if inum not in driver_info: continue
+       drv = session.laps.pick_drivers(num)
+       out = []
+       for _, grp in drv.groupby('Stint'):
+           grp = grp.dropna(subset=['LapNumber'])
+           if grp.empty or pd.isna(grp['Compound'].iloc[0]): continue
+           out.append({"compound": str(grp['Compound'].iloc[0]),
+                       "startLap": int(grp['LapNumber'].min()),
+                       "endLap": int(grp['LapNumber'].max())})
+       if out: stints[inum] = out
+   ```
+   Add `"stints": stints` to the header dict at [record.py:545-552](../../../ingest/record.py).
+3. **Weather**: `wx = session.weather_data` (columns `Time` [session Timedelta], `AirTemp`, `TrackTemp`, `Rainfall` [bool]; ~1-min cadence). Build a step-lookup; in the frame-emit loop ([record.py:556+](../../../ingest/record.py)), compute the current sample per grid tick (round temps to 0.1) and attach `"weather": {"airTempC":…, "trackTempC":…, "rainfall":…}` to the frame dict **only when it differs from the last emitted one** (always emit on frame 1 so the snapshot gets seeded).
+4. **Post-write assertions** ([record.py:675+](../../../ingest/record.py)): header `stints` non-empty for ≥ 15 drivers; ≥ 1 frame carries `weather`; and when `--start-lap` was used, assert ≥ 1 frame car has `"status": "Pit"` — the whole point of the re-bake.
+
+### 1f. Re-bake all three clips (network + FastF1 cache under `cache/`)
+
+For each session, FIRST inspect pit-stop laps before choosing the window (don't guess):
+```python
+laps = session.laps
+print(laps[~laps['PitInTime'].isna()][['Driver', 'LapNumber']].sort_values('LapNumber'))
+```
+Pick a green-flag ~7.5-min window with ≥ 3 top-10 stops (green-flag: check `session.race_control_messages` for SC/red flags in range). Expected ballparks — verify against actual data: Monza 2024 ≈ laps 13–20; Monza 2023 similar; Silverstone 2024 → the rain-stop phase ≈ laps 25–33 (inters + `rainfall:true` = best demo).
+
+```bash
+python ingest/record.py data/replays/monza-2024-race.jsonl --year 2024 --gp Monza --start-lap <N> --end-lap <M>
+python ingest/record.py data/replays/monza-2023-race.jsonl --year 2023 --gp Monza --start-lap <N> --end-lap <M>
+python ingest/record.py data/replays/silverstone-2024-race.jsonl --year 2024 --gp Silverstone --start-lap <N> --end-lap <M>
+```
+Run sequentially (FastF1 memory). First run per session is slow (downloads).
+
+**Gates**: each file < 25 MB; `grep -c '"status":"Pit"' <file>` > 0 for each; `go test ./...`; `cd web && npm test`; `python -m pytest ingest`; `docker compose up --build -d` then confirm `stints`/`weather` arrive (devtools WS message or `docker compose exec redis redis-cli GET snapshot:replay | head -c 2000`).
+
+⚠️ The compare lanes assume identical-length clips for wall-clock phasing ([play.go:144](../../../internal/feed/replay/play.go) — average-gap-derived `loopLen`). Keep the two Monza windows the same lap-count/duration.
+
+---
+
+## Phase 2 — Pit-wall UX polish
+
+1. **Map pit/out** ([Map.tsx:15-20](../../../web/src/components/Map.tsx)):
+   ```tsx
+   {cars.filter((c) => c.status !== 'Out').map((c) => (
+     <g key={c.driverNum} opacity={c.status === 'Pit' ? 0.35 : 1}>
+   ```
+2. **Tower pit/out** ([TimingTower.tsx:90-91](../../../web/src/components/TimingTower.tsx)): when `c.status === 'Pit'` render `IN PIT` in the Gap cell (colour `#e8c84a`) and `—` in Int; when `'Out'` render `OUT` (colour `var(--slate)`) and grey the row (`opacity: 0.5` on the `<tr>` style). Put the label logic in a small `statusLabel(status)` helper in [timingHelpers.ts](../../../web/src/components/timingHelpers.ts) and cover it in `TimingTower.test.ts` (existing test file, pure-helper style).
+3. **Tyre format unification**: new helper in timingHelpers —
+   ```ts
+   export function tyreLabel(tyre?: string, age?: number): string {
+     if (!tyre) return '—';
+     return `${tyre[0]}${age ? age : ''}`;
+   }
+   ```
+   Use in [TimingTower.tsx:95](../../../web/src/components/TimingTower.tsx) (currently `S 5` with a space) and [Standings.tsx:16](../../../web/src/components/Standings.tsx) (currently `S5`) — the compact `S5` form wins.
+4. **Tyre legend**: extend the footnote div ([TimingTower.tsx:116-118](../../../web/src/components/TimingTower.tsx)) with swatches built from `TYRE_COLOUR` ([timingHelpers.ts:77-80](../../../web/src/components/timingHelpers.ts)): `S Soft · M Medium · H Hard · I Inter · W Wet`, each letter in its colour.
+5. **Race-control timestamps** ([RaceControl.tsx:26-36](../../../web/src/components/RaceControl.tsx)): prepend `<span style={{ fontVariantNumeric: 'tabular-nums' }}>{fmtClock(m.t)}</span>` (import `fmtClock` from timingHelpers; `m.t` is session-relative ms per [model.go:45](../../../internal/model/model.go)).
+6. **Honest live label** ([SourceToggle.tsx:4-7](../../../web/src/components/SourceToggle.tsx)): `{ key: 'live', label: '● Live (demo)' }` + `title="Demo lane streaming a second replay clip — real live ingestion not yet verified"` on the button. Busy feedback: while `busy`, the clicked button's label gets an `…` suffix (track `pending` key in state). Also check [StatusBadge.tsx](../../../web/src/components/StatusBadge.tsx) for a `LIVE` badge string and apply the same `(demo)` suffix when `state.session === 'live'`.
+7. **Cleanups**: delete `.navlink` block ([components.css:298-306](../../../web/src/styles/components.css)); check [Comms.tsx](../../../web/src/components/Comms.tsx) has empty-state copy when the layer is on but no radio yet — add "No radio in this window yet." if missing. (RaceControl already has "No incidents." — leave it.)
+
+**Gate**: `cd web && npm run lint && npm test && npm run build`; compose up → watch a pit stop read on map + tower.
+
+---
+
+## Phase 3 — Strategy & analysis features
+
+1. **Stint timeline panel** — new `web/src/components/StintChart.tsx`:
+   - Props `{ state: RaceState }`. For each car in `orderCars(state.cars)` with `state.stints[c.driverNum]`: a row `[code | flex bar]`; the bar is a `position:relative` div; each stint a child div at `left: ${(startLap-1)/totalLaps*100}%`, `width: ${(endLap-startLap+1)/totalLaps*100}%`, background `TYRE_COLOUR[compound]`, height ~10px, 1px gap.
+   - Current-lap marker: one absolute white 1px vertical line at `leaderLap/totalLaps*100%` (derive `leaderLap` exactly as [StatusRail.tsx:31](../../../web/src/components/StatusRail.tsx) does).
+   - Footnote (`className="empty"`, matching the tower's): "Full-race stint plan baked from session data — the replay window sits inside it."
+   - Mount in [App.tsx:67-80](../../../web/src/App.tsx) as `<Panel label="Strategy">` (fourth panel in `board-bottom`); change `.board-bottom` grid ([components.css:265-269](../../../web/src/styles/components.css)) to `repeat(4, minmax(220px, 1fr))` (media query at 1100px already collapses to 1fr); add `.board-bottom .panel:nth-child(4) { animation-delay: 180ms; }` beside [components.css:322-324](../../../web/src/styles/components.css).
+2. **Gap-trend sparkline**:
+   - timingHelpers: `export type GapHistory = Record<number, { lap: number; gaps: number[] }>` and pure `updateGapHistory(prev, cars)` — when `c.lap` is set and `> prev[c.driverNum]?.lap`, append `c.gapMs ?? 0` (cap 8, mirror `updateLapHistory`'s reference-equality bail-out at [timingHelpers.ts:144-155](../../../web/src/components/timingHelpers.ts)). Unit-test beside the lap-history tests.
+   - New hook `web/src/hooks/useGapHistory.ts`: copy [useLapHistory.ts](../../../web/src/hooks/useLapHistory.ts) verbatim including the session/loop-seam reset (`state.timeMs < timeMsRef.current`), swapping the fold function.
+   - [TelemetryPanel.tsx](../../../web/src/components/TelemetryPanel.tsx): new prop `gapHistory?: number[]`; render a second sparkline row labelled "Gap" when length ≥ 2 (existing `Sparkline` red/green semantics already read as growing/shrinking); trailing value via `fmtGap`. Wire in [App.tsx:69-72](../../../web/src/App.tsx).
+3. **Per-rival sector deltas** ([TimingTower.tsx:40-41](../../../web/src/components/TimingTower.tsx) + timingHelpers):
+   - New pure helper `sectorDeltaVs(v, ref)` → signed ms (`v - ref`) when both present, else undefined; and `fmtSigned(ms)` → `+0.312` / `−0.145`.
+   - In the tower: when `selected != null && c.driverNum !== selected`, superscript shows `fmtSigned(sectorDeltaVs(v, selectedCar[sNMs]))` — green when negative (faster than the reference), slate when positive; when no selection, keep today's personal-best delta. Add cases to `TimingTower.test.ts` for both modes.
+   - Update the footnote: "Click a row to set the reference car — sector deltas compare against it."
+4. **Two-car telemetry compare**:
+   - [App.tsx](../../../web/src/App.tsx): `const [rival, setRival] = useState<number | null>(null)`; clear rival when `selected` changes to null or equals rival; pass `rivalCar={rival != null ? state.cars[rival] : undefined}`, `rivalHistory`, `cars={orderCars(state.cars)}`, `onRival={setRival}`.
+   - [TelemetryPanel.tsx](../../../web/src/components/TelemetryPanel.tsx): when a primary car is shown, render a native `<select value={rival ?? ''} onChange=…>` labelled "vs" listing other cars (`— none —` default). With a rival set: two-column grid (`grid-template-columns: 1fr 1fr`), second column repeating the code/team, speed/gear/DRS, throttle/brake bars, lap sparkline for the rival. No new dependencies.
+5. **Weather chip** ([StatusRail.tsx:40-42](../../../web/src/components/StatusRail.tsx)): after the lap counter:
+   ```tsx
+   {state.weather && (
+     <span className="rail-lap" title="Baked from session weather data">
+       TRK {state.weather.trackTempC.toFixed(0)}° · AIR {state.weather.airTempC.toFixed(0)}°
+       {state.weather.rainfall && <span style={{ color: '#3671C6' }}> · RAIN</span>}
+     </span>
+   )}
+   ```
+
+**Gate**: `npm run lint && npm test && npm run build`; compose up → Silverstone lane shows RAIN + inter stints in the chart; two-car compare renders; selecting a row flips sector-delta mode.
+
+---
+
+## Phase 4 — Live client hardening ([live_signalr.py](../../../ingest/live_signalr.py))
+
+Real-session verification is impossible offline — the deliverables are field coverage, a regression harness, and a runbook. Keep the existing `UNVERIFIED:` comment convention on every assumed message shape.
+
+1. **Field coverage**: extend the message handlers to populate per-car `lap`, `lastLapMs`, `gapMs`/`intMs` (from `TimingData` — `Lines.<num>.LastLapTime.Value`, `GapToLeader`, `IntervalToPositionAhead.Value`, `NumberOfLaps`) and `tyre`/`tyreAge` (from `TimingAppData` `Stints`). The snapshot/frame build sites ([live_signalr.py:290,432,494-501](../../../ingest/live_signalr.py)) stop hardcoding empty timing fields. Time strings like `"1:25.633"` need a parse helper → ms; gaps like `"+1.2"`/`"1L"` need tolerant parsing (laps → `gapLaps`).
+2. **Capture-replay regression test**: new `ingest/test_capture_replay.py` (pytest picks up `ingest/` already — same collection as `check_live_contract.py`) + a small synthetic fixture `ingest/tests/capture_sample.txt` in the exact format `_replay_capture` ([live_signalr.py:235-394](../../../ingest/live_signalr.py)) consumes, containing a `DriverList`, a few `Position.z` messages, and `TimingData`/`TimingAppData` samples. The test drives the capture path and asserts the built snapshot carries positions AND the new timing/tyre fields.
+3. **Runbook**: `docs/runbooks/live-verification.md` — prerequisites (`pip install -r ingest/requirements-live.txt`), the double opt-in (`--live` + `LIVE=1`, per [live.py:132](../../../ingest/live.py) and [live_signalr.py:678](../../../ingest/live_signalr.py)), what to watch during a real session, how to save a `CAPTURE_FILE` for regression, and the definition of "verified" (each `UNVERIFIED:` assumption confirmed or corrected). CI runs `lychee` — make internal links valid.
+4. Structural-check mode must still exit 0 with no network.
+
+**Gate**: `python -m pytest ingest`; `python ingest/check_live_contract.py` exits 0.
+
+---
+
+## Phase 5 — Docs reconciliation
+
+- [README.md](../../../README.md): demo description now includes the pit window (stops, stints, weather, rain on the Silverstone lane); shrink "What's not done" to what remains true (real-session live verification pending → link the runbook; gaps still position-derived estimates).
+- [docs/F1_Race_Tracker_Product_Scope.md](../../F1_Race_Tracker_Product_Scope.md) + [Tech Scope](../../F1_Race_Tracker_Tech_Scope.md): record the clip-window change, new contract fields (`stints`, `weather`, `lap`, `totalLaps`), `Live (demo)` labeling, and the new analysis features (stint chart, gap trend, rival deltas, two-car compare).
+- [docs/ux-evaluation-2026-07.md](../../ux-evaluation-2026-07.md): add a dated "Resolved" note per finding this work closes (P2 interval, P3 empty states, etc.).
+- [CONTEXT.md](../../../CONTEXT.md): glossary entries for *stint*, *weather*, *reference car / rival delta*, in the existing voice.
+
+---
+
+## Final verification
+
+1. `gofmt -l .` empty; `go vet ./...`; `go test ./...` (plain — `-race` is CI-only on this machine, no local cgo).
+2. `cd web && npm run lint && npm test && npm run build` (eslint runs `--max-warnings 0`).
+3. `python -m pytest ingest bench`; `ruff check ingest`.
+4. `docker compose up --build -d` → `http://localhost:8080`: watch a pit stop (map dim → IN PIT tag → compound change → stint bar), gap sparkline, rival sector deltas, two-car compare, weather chip + RAIN on the Silverstone lane, `Live (demo)` label, `#compare` and `#ghost` still coherent on the re-baked Monza pair.
+5. Each `.jsonl` < 25 MB; data diff dominates the branch diff — expected.
+
+## Execution notes
+
+- Commit per phase (0+1 may merge — the fixture edits overlap). Never skip hooks.
+- FastF1 bakes need network; run the three sequentially; cache under `cache/` may already be warm.
+- All new snapshot/frame fields are optional/`omitempty` so `synthetic.jsonl` and stale clips still parse.
+- When adding `Stints()` to the `Source` interface, compile errors are the to-do list — fix every implementation the compiler names (including test stubs).
+- Keep the two Monza clips the same lap-window length (wall-clock phase alignment in [play.go:144-183](../../../internal/feed/replay/play.go) assumes identical-length clips).

--- a/docs/superpowers/plans/2026-07-24-static-gh-pages-demo.md
+++ b/docs/superpowers/plans/2026-07-24-static-gh-pages-demo.md
@@ -1,0 +1,931 @@
+# Static GitHub Pages Demo Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a frontend-only replay demo on GitHub Pages that plays the committed Monza clip with no Python/Redis/Go behind it, as a third front door alongside the README/video and `docker-compose up`.
+
+**Architecture:** A new Go command (`cmd/bake-static`) reuses the existing replay-load and WebSocket-envelope-encoding code to bake the clip into the exact wire-format messages the frontend already knows how to consume. A new frontend module (`staticReplay.ts`) fetches that baked file and feeds the same `applyMessage` reducer on a client-side clock, swapping in for `socket.ts`'s `connectRace`. A new CI workflow bakes the clip, builds the frontend with a Pages-specific base path, and deploys to GitHub Pages on push to `main`.
+
+**Tech Stack:** Go 1.26 (bake command), TypeScript/Vite/React (static player), GitHub Actions (`actions/deploy-pages`).
+
+**Decisions already locked (see `docs/adr/0006-static-gh-pages-demo-as-third-front-door.md`, `CONTEXT.md`'s "Static demo" entry) — do not re-derive these:**
+- Additive third front door, not a replacement for README/video or `docker-compose`.
+- v1 ships exactly one clip (`data/replays/monza-2024-race.jsonl`, the current `CLIP_FILE` default) with full feature parity except: no live source (toggle hidden entirely, not shown disabled), no compare/ghost overlay (deferred — those need two synced clips).
+- No custom decimation/quantization. Gzip alone takes the 24 MB raw clip to ~927 KB (measured), under a 2 MB budget. GitHub Pages' Fastly CDN serves gzip automatically.
+- The bake step reuses the existing Go wire-encoding (`internal/ws/frame.go`'s `encodeSnapshot`/`encodeFrame`), not a reimplementation in TypeScript or Python.
+- The static player ports the Go replay player's real per-frame `timeMs` pacing and looping (`internal/feed/replay/play.go`'s `playFromStart`), not a flat interval.
+
+---
+
+### Task 1: `replay.Source.Frames()` — expose the clip's frames without real-time pacing
+
+**Why:** `Source.Events()` streams frames paced in real time (the current clip takes ~7 minutes to play through) — fine for the actual replay writer, useless for a one-shot bake tool that needs the whole clip immediately. This is a small, pure getter alongside the existing `Events()`.
+
+**Files:**
+- Modify: `internal/feed/replay/play.go`
+- Test: `internal/feed/replay/play_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/feed/replay/play_test.go` (same file as `TestReplay_HeaderAndMonotonicRevAcrossLoop`, which already has the `writeTemp` helper — reuse it):
+
+```go
+func TestSource_Frames_ReturnsAllInFileOrder(t *testing.T) {
+	body := `{"track":[{"x":0,"y":0}],"label":"Lbl","maxRev":3}
+{"timeMs":100,"frame":{"rev":1,"timeMs":100,"cars":[{"driverNum":1}]}}
+{"timeMs":200,"frame":{"rev":2,"timeMs":200,"cars":[{"driverNum":1}]}}
+{"timeMs":300,"frame":{"rev":3,"timeMs":300,"cars":[{"driverNum":1}]}}
+`
+	src, err := Load(writeTemp(t, body), 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	frames := src.Frames()
+	if len(frames) != 3 {
+		t.Fatalf("got %d frames, want 3", len(frames))
+	}
+	for i, want := range []int64{100, 200, 300} {
+		if frames[i].TimeMs != want {
+			t.Errorf("frames[%d].TimeMs = %d, want %d", i, frames[i].TimeMs, want)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/feed/replay/... -run TestSource_Frames_ReturnsAllInFileOrder -v`
+Expected: FAIL with `src.Frames undefined (type *Source has no field or method Frames)`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `internal/feed/replay/play.go`, near the other exported accessor methods (`Track()`, `Radio()`, etc., around line 95-100):
+
+```go
+// Frames returns every frame in the clip, in file order, with each frame's Rev
+// exactly as recorded in the file (advisory — a caller publishing to a fresh
+// session should reassign a monotonic Rev, as Writer.Run and cmd/bake-static do).
+// Unlike Events, this does not pace playback in real time: it's for tooling that
+// needs the whole clip immediately, not a live-paced stream.
+func (s *Source) Frames() []model.Frame {
+	out := make([]model.Frame, len(s.lines))
+	for i, ln := range s.lines {
+		out[i] = ln.Frame
+	}
+	return out
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/feed/replay/... -v`
+Expected: PASS (all tests in the package, including the pre-existing ones)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/feed/replay/play.go internal/feed/replay/play_test.go
+git commit -m "feat(replay): expose Source.Frames() for non-realtime tooling"
+```
+
+---
+
+### Task 2: Export the wire-envelope encoders
+
+**Why:** `internal/ws/frame.go`'s `encodeSnapshot`/`encodeFrame` are unexported — the new bake command lives in a different package and needs to call them directly (per the ADR decision: reuse this encoding, don't reimplement it, not even the small envelope-wrapping logic). This is a pure rename with no behavior change.
+
+**Files:**
+- Modify: `internal/ws/frame.go`
+- Modify: `internal/ws/hub.go` (3 call sites)
+- Modify: `internal/ws/frame_test.go` (3 call sites)
+
+- [ ] **Step 1: Rename in `internal/ws/frame.go`**
+
+```go
+func EncodeSnapshot(s *model.Snapshot) ([]byte, error) {
+	d, err := json.Marshal(s)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(envelope{Type: "snapshot", Data: d})
+}
+
+func EncodeFrame(f model.Frame) ([]byte, error) {
+	// A zero-value frame (Rev 0, no cars) is never a real broadcast — Rev 0 is the
+	// "no frame yet" sentinel the hub's stale check assumes. Refuse it rather than
+	// silently fan out an empty frame.
+	if f.Rev == 0 && len(f.Cars) == 0 {
+		return nil, fmt.Errorf("ws: refusing to encode zero-value frame")
+	}
+	d, err := json.Marshal(f)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(envelope{Type: "frame", Data: d})
+}
+```
+
+- [ ] **Step 2: Update call sites in `internal/ws/hub.go`**
+
+Three call sites (lines 31, 70, 92 as of this plan — confirm with `grep -n encodeFrame\|encodeSnapshot internal/ws/hub.go` since line numbers shift):
+- `encodeFrame(f)` → `EncodeFrame(f)`
+- `encodeSnapshot(h.snapshot)` → `EncodeSnapshot(h.snapshot)`
+- `encodeSnapshot(snap)` → `EncodeSnapshot(snap)`
+
+- [ ] **Step 3: Update call sites in `internal/ws/frame_test.go`**
+
+Three call sites (lines 13, 35, 59):
+- `encodeSnapshot(s)` → `EncodeSnapshot(s)`
+- `encodeFrame(f)` → `EncodeFrame(f)`
+- `encodeFrame(model.Frame{})` → `EncodeFrame(model.Frame{})`
+
+- [ ] **Step 4: Run the full Go test suite to verify nothing broke**
+
+Run: `gofmt -l . && go vet ./... && go test ./...`
+Expected: PASS, no gofmt diffs, no vet warnings
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/ws/frame.go internal/ws/hub.go internal/ws/frame_test.go
+git commit -m "refactor(ws): export EncodeSnapshot/EncodeFrame for reuse outside the package"
+```
+
+---
+
+### Task 3: `cmd/bake-static` — bake a clip into wire-format NDJSON
+
+**Why:** This is the crux of the whole bet — turn the internal clip format into the exact sequence of `{type,data}` envelopes the frontend's `parseMsg`/`applyMessage` already know how to consume, using only existing, already-tested encoding logic.
+
+**Files:**
+- Create: `cmd/bake-static/main.go`
+- Test: `cmd/bake-static/main_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `cmd/bake-static/main_test.go`:
+
+```go
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeTempClip(t *testing.T, body string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "clip.jsonl")
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func TestRun_BakesSnapshotThenFramesWithMonotonicRev(t *testing.T) {
+	body := `{"track":[{"x":0,"y":0}],"label":"Test Clip"}
+{"timeMs":100,"frame":{"rev":9,"timeMs":100,"cars":[{"driverNum":1,"code":"VER","team":"Red Bull","pos":1,"p":{"x":0.1,"y":0.1},"status":"OnTrack"}]}}
+{"timeMs":200,"frame":{"rev":9,"timeMs":200,"cars":[{"driverNum":1,"code":"VER","team":"Red Bull","pos":1,"p":{"x":0.2,"y":0.2},"status":"OnTrack"}]}}
+`
+	clipPath := writeTempClip(t, body)
+	outPath := filepath.Join(t.TempDir(), "out.ndjson")
+
+	if err := run(clipPath, outPath, "static-demo"); err != nil {
+		t.Fatal(err)
+	}
+
+	f, err := os.Open(outPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	var lines []string
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		if sc.Text() != "" {
+			lines = append(lines, sc.Text())
+		}
+	}
+	if len(lines) != 3 {
+		t.Fatalf("got %d lines, want 3 (1 snapshot + 2 frames)", len(lines))
+	}
+
+	var env struct {
+		Type string          `json:"type"`
+		Data json.RawMessage `json:"data"`
+	}
+
+	if err := json.Unmarshal([]byte(lines[0]), &env); err != nil {
+		t.Fatal(err)
+	}
+	if env.Type != "snapshot" {
+		t.Errorf("line 0 type = %q, want snapshot", env.Type)
+	}
+	if !strings.Contains(string(env.Data), `"session":"static-demo"`) {
+		t.Errorf("snapshot data missing session key: %s", env.Data)
+	}
+
+	wantRevs := []int64{1, 2}
+	for i, wantRev := range wantRevs {
+		if err := json.Unmarshal([]byte(lines[i+1]), &env); err != nil {
+			t.Fatal(err)
+		}
+		if env.Type != "frame" {
+			t.Errorf("line %d type = %q, want frame", i+1, env.Type)
+		}
+		var fd struct {
+			Rev int64 `json:"rev"`
+		}
+		if err := json.Unmarshal(env.Data, &fd); err != nil {
+			t.Fatal(err)
+		}
+		if fd.Rev != wantRev {
+			// The source file's own rev (9, 9) must be reassigned monotonically —
+			// matching what Writer.Run does against a fresh Redis session.
+			t.Errorf("frame %d rev = %d, want %d (reassigned, not the file's own rev)", i, fd.Rev, wantRev)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./cmd/bake-static/... -v`
+Expected: FAIL — `undefined: run` (package doesn't exist yet)
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `cmd/bake-static/main.go`:
+
+```go
+// Command bake-static reads a replay clip and writes it as a sequence of
+// WebSocket wire envelopes — the same {type,data} shape internal/ws/frame.go
+// encodes for real clients — to a newline-delimited JSON file. The GitHub
+// Pages static demo fetches this file and feeds the frontend's existing
+// applyMessage reducer directly, with no Go/Python/Redis behind it.
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/natcat38/f1-race-tracker/internal/feed/replay"
+	"github.com/natcat38/f1-race-tracker/internal/model"
+	"github.com/natcat38/f1-race-tracker/internal/ws"
+)
+
+func main() {
+	clip := flag.String("clip", "data/replays/monza-2024-race.jsonl", "source replay clip (.jsonl)")
+	out := flag.String("out", "web/public/static-demo/monza-2024-race.ndjson", "output path (.ndjson)")
+	session := flag.String("session", "static-demo", "session key baked into the snapshot")
+	flag.Parse()
+
+	if err := run(*clip, *out, *session); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func run(clipPath, outPath, session string) error {
+	src, err := replay.Load(clipPath, 1)
+	if err != nil {
+		return fmt.Errorf("bake-static: load clip: %w", err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
+		return fmt.Errorf("bake-static: mkdir: %w", err)
+	}
+	f, err := os.Create(outPath)
+	if err != nil {
+		return fmt.Errorf("bake-static: create %s: %w", outPath, err)
+	}
+	defer f.Close()
+
+	w := bufio.NewWriter(f)
+	if err := bake(src, session, w); err != nil {
+		return err
+	}
+	return w.Flush()
+}
+
+// bake writes one snapshot envelope (the clip's header fields, no cars yet)
+// followed by one frame envelope per clip line, in order. Each frame's Rev is
+// reassigned 1..N — mirroring what Writer.Run does when publishing this same
+// clip to a fresh Redis session — rather than trusting the file's own
+// (advisory, possibly-repeating) Rev values.
+func bake(src *replay.Source, session string, w *bufio.Writer) error {
+	snap := model.NewSnapshot(session, src.Mode(), src.Label())
+	snap.Track = src.Track()
+	snap.Radio = src.Radio()
+	snap.LapTrace = src.LapTrace()
+	snap.TotalLaps = src.TotalLaps()
+	snap.Stints = src.Stints()
+
+	sb, err := ws.EncodeSnapshot(snap)
+	if err != nil {
+		return fmt.Errorf("bake-static: encode snapshot: %w", err)
+	}
+	if _, err := w.Write(append(sb, '\n')); err != nil {
+		return fmt.Errorf("bake-static: write snapshot: %w", err)
+	}
+
+	for i, fr := range src.Frames() {
+		fr.Rev = int64(i + 1)
+		fr.SessionKey = session
+		fb, err := ws.EncodeFrame(fr)
+		if err != nil {
+			return fmt.Errorf("bake-static: encode frame %d: %w", i, err)
+		}
+		if _, err := w.Write(append(fb, '\n')); err != nil {
+			return fmt.Errorf("bake-static: write frame %d: %w", i, err)
+		}
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./cmd/bake-static/... -v`
+Expected: PASS
+
+- [ ] **Step 5: Manually bake the real clip and eyeball it**
+
+```bash
+go run ./cmd/bake-static --clip data/replays/monza-2024-race.jsonl --out /tmp/monza-2024-race.ndjson --session static-demo
+wc -l /tmp/monza-2024-race.ndjson    # expect 4322 (1 snapshot + 4321 frames)
+head -c 300 /tmp/monza-2024-race.ndjson
+gzip -9 -c /tmp/monza-2024-race.ndjson | wc -c    # expect roughly ~900KB-1MB, confirming the earlier gzip measurement still holds for the wire-format shape
+```
+
+- [ ] **Step 6: Run the full Go test suite**
+
+Run: `gofmt -l . && go vet ./... && go test ./...`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add cmd/bake-static/main.go cmd/bake-static/main_test.go
+git commit -m "feat(bake-static): bake a replay clip into wire-format NDJSON for the static demo"
+```
+
+---
+
+### Task 4: `staticReplay.ts` — the frontend static player
+
+**Why:** This is the `socket.ts` swap the whole bet's frontend seam is built on: same `(onState, onStatus) => closeFn` interface as `connectRace`, but reads the baked file and paces playback on the frames' own `timeMs`, looping forever — porting `play.go`'s `playFromStart` logic into TypeScript.
+
+**Files:**
+- Create: `web/src/realtime/staticReplay.ts`
+- Test: `web/src/realtime/staticReplay.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `web/src/realtime/staticReplay.test.ts` (mirrors `socket.test.ts`'s conventions — fake timers, a fake global):
+
+```typescript
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import { connectStaticReplay } from './staticReplay';
+import type { RaceState } from '../state/race';
+
+const CLIP_NDJSON = [
+  JSON.stringify({ type: 'snapshot', data: { session: 'static-demo', mode: 'replay', label: 'Test', cars: {}, timeMs: 0, rev: 0 } }),
+  JSON.stringify({ type: 'frame', data: { rev: 1, timeMs: 100, cars: [{ driverNum: 1, code: 'VER', team: 'Red Bull', pos: 1, p: { x: 0.1, y: 0.1 }, status: 'OnTrack' }] } }),
+  JSON.stringify({ type: 'frame', data: { rev: 2, timeMs: 300, cars: [{ driverNum: 1, code: 'VER', team: 'Red Bull', pos: 1, p: { x: 0.2, y: 0.2 }, status: 'OnTrack' }] } }),
+].join('\n') + '\n';
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: true, text: () => Promise.resolve(CLIP_NDJSON) })));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe('connectStaticReplay', () => {
+  test('applies the snapshot then the first frame immediately, later frames paced by their timeMs delta', async () => {
+    const states: RaceState[] = [];
+    connectStaticReplay((s) => states.push(s));
+
+    // The first frame defines its own zero-point (offset = its own timeMs minus
+    // itself = 0) — mirrors play.go's `base := lines[0].TimeMs`, where the first
+    // emitted frame always has target=0. So the snapshot AND the first frame both
+    // play at offset 0, back to back, with no artificial delay between them.
+    await vi.waitFor(() => expect(states.length).toBeGreaterThanOrEqual(2));
+    expect(states[0].rev).toBe(0); // snapshot
+    expect(states[1].rev).toBe(1); // first frame, right behind it
+
+    await vi.advanceTimersByTimeAsync(200); // second frame is 200ms after the first (300 - 100)
+    expect(states.at(-1)?.rev).toBe(2);
+  });
+
+  test('loops back to the start after the last frame', async () => {
+    const states: RaceState[] = [];
+    connectStaticReplay((s) => states.push(s));
+    await vi.waitFor(() => expect(states.length).toBeGreaterThanOrEqual(2)); // snapshot + frame 1
+
+    await vi.advanceTimersByTimeAsync(200); // frame 2 (end of clip)
+    await vi.advanceTimersByTimeAsync(50);  // past the end -> loop restarts at the snapshot
+
+    expect(states.at(-1)?.rev).toBe(0); // back to the baked snapshot's rev
+  });
+
+  test('the returned close function stops scheduling further frames', async () => {
+    const states: RaceState[] = [];
+    const close = connectStaticReplay((s) => states.push(s));
+    await vi.waitFor(() => expect(states.length).toBeGreaterThanOrEqual(2));
+
+    close();
+    const countAtClose = states.length;
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(states.length).toBe(countAtClose); // nothing scheduled after close
+  });
+
+  test('onStatus reports connecting then live', async () => {
+    const statuses: string[] = [];
+    connectStaticReplay(() => {}, (s) => statuses.push(s));
+    expect(statuses[0]).toBe('connecting');
+    await vi.waitFor(() => expect(statuses).toContain('live'));
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd web && npm test -- staticReplay`
+Expected: FAIL — cannot find module `./staticReplay`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `web/src/realtime/staticReplay.ts`:
+
+```typescript
+import { applyMessage, emptyState, parseMsg, type RaceState } from '../state/race';
+import type { ConnStatus } from './socket';
+
+// race.ts's Msg union isn't exported (it's an internal detail of parseMsg's
+// return type) — alias it here once so every use below refers to the same
+// name instead of repeating the ReturnType<typeof parseMsg> gymnastics.
+type Msg = NonNullable<ReturnType<typeof parseMsg>>;
+
+const DEFAULT_CLIP_URL = `${import.meta.env.BASE_URL}static-demo/monza-2024-race.ndjson`;
+
+// connectStaticReplay mirrors connectRace's interface (onState/onStatus/close-fn)
+// but reads a baked NDJSON file (produced by cmd/bake-static) instead of opening
+// a WebSocket, pacing playback on each frame's own relative timeMs offset and
+// looping forever — the same algorithm as the Go replay player's playFromStart
+// (internal/feed/replay/play.go), ported here since there's no Go process to
+// pace it for us in a static build.
+export function connectStaticReplay(
+  onState: (s: RaceState) => void,
+  onStatus?: (status: ConnStatus) => void,
+  clipUrl: string = DEFAULT_CLIP_URL,
+): () => void {
+  let state = emptyState();
+  let closed = false;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let live = false;
+
+  onStatus?.('connecting');
+
+  fetch(clipUrl)
+    .then((res) => {
+      if (!res.ok) throw new Error(`static demo: fetch failed (${res.status})`);
+      return res.text();
+    })
+    .then((text) => {
+      if (closed) return;
+      const messages = text
+        .split('\n')
+        .filter((line) => line.length > 0)
+        .map((line) => {
+          try {
+            return parseMsg(JSON.parse(line));
+          } catch {
+            return null;
+          }
+        })
+        .filter((m): m is Msg => m !== null);
+      if (messages.length === 0) {
+        console.error('connectStaticReplay: baked clip had no valid messages');
+        return;
+      }
+      schedulePlayback(messages);
+    })
+    .catch((err) => {
+      console.error('connectStaticReplay: failed to load clip', err);
+    });
+
+  function schedulePlayback(messages: Msg[]) {
+    // Every frame's timeMs, relative to the first frame's timeMs — mirrors
+    // play.go's `base := s.lines[0].TimeMs`. The snapshot (if any) always plays
+    // at offset 0, same as the Go player's first-message-is-current-state model.
+    const frameBase = messages.find((m) => m.type === 'frame')?.data.timeMs ?? 0;
+    const offsets = messages.map((m) => (m.type === 'frame' ? m.data.timeMs - frameBase : 0));
+
+    let loopStart = Date.now();
+
+    const playFrom = (i: number) => {
+      if (closed) return;
+      if (i >= messages.length) {
+        loopStart = Date.now();
+        timer = setTimeout(() => playFrom(0), 0);
+        return;
+      }
+      const wait = Math.max(0, offsets[i] - (Date.now() - loopStart));
+      timer = setTimeout(() => {
+        state = applyMessage(state, messages[i]);
+        if (!live) { live = true; onStatus?.('live'); }
+        onState(state);
+        playFrom(i + 1);
+      }, wait);
+    };
+
+    playFrom(0);
+  }
+
+  return () => {
+    closed = true;
+    if (timer) clearTimeout(timer);
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd web && npm test -- staticReplay`
+Expected: PASS
+
+- [ ] **Step 5: Run the full web verification gate**
+
+Run: `cd web && npm run lint -- --max-warnings 0 && npm run build && npm test`
+Expected: PASS. If `npm run build` deletes `web/dist/.gitkeep`, that's expected until Task 7 — restore it manually for now: `git checkout web/dist/.gitkeep`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/src/realtime/staticReplay.ts web/src/realtime/staticReplay.test.ts
+git checkout web/dist/.gitkeep  # restore if npm run build wiped it
+git commit -m "feat(web): add connectStaticReplay, the static-demo socket.ts swap"
+```
+
+---
+
+### Task 5: Wire the static player into `App.tsx`
+
+**Why:** Select `connectStaticReplay` vs `connectRace` at build time via a Vite env var, and hide the source toggle (per the locked design decision — a control that can't do anything shouldn't be shown, even disabled).
+
+**Files:**
+- Modify: `web/src/App.tsx`
+
+- [ ] **Step 1: Make the change**
+
+In `web/src/App.tsx`, update the imports and the two places that reference `connectRace`/`SourceToggle`:
+
+```typescript
+import { connectRace, type ConnStatus } from './realtime/socket';
+import { connectStaticReplay } from './realtime/staticReplay';
+```
+
+```typescript
+// Build-time flag: VITE_STATIC_DEMO=true selects the file-backed static player
+// instead of the real WebSocket connection. Set only by the GitHub Pages build
+// (see .github/workflows/pages.yml) — docker-compose and local dev never set it.
+const STATIC_DEMO = import.meta.env.VITE_STATIC_DEMO === 'true';
+```
+
+Replace:
+```typescript
+  useEffect(() => connectRace(setState, setStatus), []);
+```
+with:
+```typescript
+  useEffect(() => (STATIC_DEMO ? connectStaticReplay : connectRace)(setState, setStatus), []);
+```
+
+Replace:
+```typescript
+      <StatusRail active="board" state={state} status={status} staleSec={staleSec}>
+        <SourceToggle state={state} />
+      </StatusRail>
+```
+with:
+```typescript
+      <StatusRail active="board" state={state} status={status} staleSec={staleSec}>
+        {!STATIC_DEMO && <SourceToggle state={state} />}
+      </StatusRail>
+```
+
+- [ ] **Step 2: Run the web verification gate**
+
+Run: `cd web && npm run lint -- --max-warnings 0 && npm run build && npm test`
+Expected: PASS (this doesn't add new automated coverage — `App.tsx`'s existing tests, if any, should still pass; the env-flag branch itself is exercised manually in Task 8 once the Pages build exists)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add web/src/App.tsx
+git checkout web/dist/.gitkeep  # restore if npm run build wiped it
+git commit -m "feat(web): select connectStaticReplay and hide the source toggle in the static-demo build"
+```
+
+---
+
+### Task 6: Conditional Vite `base` path
+
+**Why:** GitHub Pages project sites serve under `/f1-race-tracker/`, not `/`. `docker-compose` must keep `/`. One env var (`VITE_STATIC_DEMO`, already introduced in Task 5) drives both the frontend's source-selection branch and this build-time base path — no second flag needed.
+
+**Files:**
+- Modify: `web/vite.config.ts`
+
+- [ ] **Step 1: Make the change**
+
+Replace the whole file:
+
+```typescript
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+// https://vite.dev/config/
+export default defineConfig({
+  plugins: [react()],
+  // GitHub Pages project sites serve under /<repo>/, not /. docker-compose and
+  // local dev never set VITE_STATIC_DEMO, so they keep the default '/'.
+  base: process.env.VITE_STATIC_DEMO === 'true' ? '/f1-race-tracker/' : '/',
+  server: {
+    proxy: {
+      '/ws': { target: 'ws://localhost:8080', ws: true },
+      '/control': 'http://localhost:8080',
+    },
+  },
+})
+```
+
+- [ ] **Step 2: Verify both base paths build correctly**
+
+```bash
+cd web
+npm run build && grep -o 'src="[^"]*main[^"]*"' dist/index.html   # expect /assets/... (base '/')
+VITE_STATIC_DEMO=true npm run build && grep -o 'src="[^"]*main[^"]*"' dist/index.html   # expect /f1-race-tracker/assets/...
+```
+Expected: the asset path prefix changes between the two runs, confirming `base` takes effect.
+
+- [ ] **Step 3: Run the full web verification gate**
+
+Run: `cd web && npm run lint -- --max-warnings 0 && npm run build && npm test`
+Expected: PASS (this last `npm run build` — without `VITE_STATIC_DEMO` — leaves `dist/` in the `docker-compose`-compatible state; don't leave a Pages-based `dist/` sitting in the working tree)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web/vite.config.ts
+git checkout web/dist/.gitkeep  # restore if npm run build wiped it
+git commit -m "feat(web): conditional Vite base path for the GitHub Pages build"
+```
+
+---
+
+### Task 7: Fix #38 properly — stop `vite build` from wiping `web/dist/.gitkeep`, without breaking CI
+
+**Why:** Issue #38 proposed untracking `web/dist/.gitkeep` entirely. That would break the `go` CI job: `web/embed.go` has `//go:embed all:dist`, and on a clean checkout (the `go` job never runs `npm ci`/`npm run build` — it's a separate job from `web`), an empty `dist/` directory makes `go vet ./...`/`go test ./...` fail to compile with "pattern all:dist: no matching files found". `.gitkeep` must stay tracked. The actual annoyance — manually restoring it after every local `npm run build` — is what to fix, with an npm lifecycle hook (native npm feature, no new dependency).
+
+**Files:**
+- Modify: `web/package.json`
+
+- [ ] **Step 1: Make the change**
+
+In `web/package.json`, add a `postbuild` script (npm runs this automatically after `build`, no extra wiring needed):
+
+```json
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "postbuild": "node -e \"require('fs').closeSync(require('fs').openSync('dist/.gitkeep','a'))\"",
+    "lint": "eslint .",
+    "preview": "vite preview",
+    "test": "vitest run"
+  },
+```
+
+- [ ] **Step 2: Verify it actually fixes the annoyance**
+
+```bash
+cd web
+npm run build
+git status ../web/dist/.gitkeep   # expect: no changes (not deleted)
+```
+Expected: `git status` shows no modification to `web/dist/.gitkeep` — previously this would show `D web/dist/.gitkeep`.
+
+- [ ] **Step 3: Run the full web verification gate**
+
+Run: `cd web && npm run lint -- --max-warnings 0 && npm run build && npm test`
+Expected: PASS
+
+- [ ] **Step 4: Verify the Go CI job still works from a clean checkout perspective**
+
+```bash
+gofmt -l . && go vet ./... && go test ./...
+```
+Expected: PASS — confirms `web/dist/.gitkeep` being present (never removed from git) keeps `go vet`/`go test` compiling `web/embed.go` successfully.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/package.json
+git commit -m "fix(web): restore web/dist/.gitkeep via a postbuild hook instead of untracking it
+
+Closes #38 with a different fix than originally proposed: untracking
+.gitkeep would break the 'go' CI job, which never runs npm run build
+before go vet/go test on a clean checkout, and web/embed.go's
+'//go:embed all:dist' fails to compile against a truly empty dist/."
+```
+
+---
+
+### Task 8: `.github/workflows/pages.yml` — bake, build, deploy
+
+**Why:** Automate the whole pipeline: bake the clip with the Go tool from Task 3, build the frontend with the Pages base from Task 6, deploy via GitHub's official Pages actions. Additive — doesn't touch `ci.yml` or `okf.yml`.
+
+**Files:**
+- Create: `.github/workflows/pages.yml`
+
+- [ ] **Step 1: Write the workflow**
+
+```yaml
+name: Deploy static demo
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'web/**'
+      - 'cmd/bake-static/**'
+      - 'internal/**'
+      - 'data/replays/monza-2024-race.jsonl'
+      - '.github/workflows/pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
+
+      - name: Bake the static-demo clip
+        run: go run ./cmd/bake-static --clip data/replays/monza-2024-race.jsonl --out web/public/static-demo/monza-2024-race.ndjson --session static-demo
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      - run: npm ci
+        working-directory: web
+
+      - name: Build (static-demo base path + player)
+        run: npm run build
+        working-directory: web
+        env:
+          VITE_STATIC_DEMO: 'true'
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/upload-pages-artifact@v4
+        with:
+          path: web/dist
+
+      - uses: actions/deploy-pages@v4
+        id: deployment
+```
+
+- [ ] **Step 2: One-time manual repo setting (cannot be done from a workflow file)**
+
+In the GitHub repo settings, under **Settings → Pages → Source**, select **GitHub Actions**. This is a one-time manual step outside this plan's code changes — flag it to whoever merges this, it won't deploy without it.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/pages.yml
+git commit -m "ci: add GitHub Pages deploy workflow for the static demo"
+```
+
+- [ ] **Step 4: Verify after pushing (post-merge, not local)**
+
+Once this is on `main` and the repo setting from Step 2 is done, check the Actions tab for the "Deploy static demo" run, then visit `https://natcat38.github.io/f1-race-tracker/` and confirm: the map animates, the timing tower populates, no source toggle is visible, and the browser devtools Network tab shows the `.ndjson` fetch returned `content-encoding: gzip`.
+
+---
+
+### Task 9: README — three front doors
+
+**Why:** The README currently only describes the README/video + `docker-compose` split. Add the static demo as the third, with the same "quick look, not the real system" framing locked in the ADR.
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Read the current README's relevant section**
+
+Run: `grep -n "docker-compose\|docker compose\|hosting" README.md`
+Find the section describing how to run/experience the project (likely near the top, a "Quick start" or "Demo" section).
+
+- [ ] **Step 2: Add a "quick look" callout**
+
+Add a short section (exact placement depends on the README's current structure — insert it before or alongside the `docker-compose up` instructions, whichever reads more naturally as "try this first, then this if you want the real thing"):
+
+```markdown
+## Quick look (no clone required)
+
+**[Live static demo →](https://natcat38.github.io/f1-race-tracker/)** — a frontend-only build that plays back one recorded clip, client-side, with no backend running. This is the fastest way to see what the project does, but it's a simplified artifact, not the real system: no live source, no cross-year comparison, and nothing here proves the polyglot pipeline actually works.
+
+For that, run it for real:
+```
+
+(followed by the existing `docker-compose up` instructions, unchanged)
+
+- [ ] **Step 3: Verify links resolve**
+
+The repo's `docs-links` CI job (`lycheeverse/lychee-action`) checks `README.md` — a broken link fails CI. Since the Pages URL won't exist until Task 8's workflow has run at least once, either add this README change in the same PR as Task 8 (so both merge together and the link is live by the time CI re-checks it) or verify manually after the first successful Pages deploy.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: add the static demo as a third front door in the README"
+```
+
+---
+
+### Task 10: Full verification gate and final check
+
+**Why:** Confirm the whole branch is clean and every language's checks pass together, matching what CI will run.
+
+- [ ] **Step 1: Go**
+
+```bash
+gofmt -l . && go vet ./... && go test ./...
+```
+Expected: PASS, no output from gofmt
+
+- [ ] **Step 2: Web**
+
+```bash
+cd web && npm ci && npm run lint -- --max-warnings 0 && npm run build && npm test
+git checkout web/dist/.gitkeep  # only needed if postbuild hook (Task 7) isn't yet merged when running this manually; once merged this is a no-op
+```
+Expected: PASS
+
+- [ ] **Step 3: Ingest/bench (unaffected by this bet, but part of the full gate)**
+
+```bash
+cd ingest && python -m pytest . && ruff check .
+cd ../bench && python -m pytest .
+```
+Expected: PASS
+
+- [ ] **Step 4: Confirm git status is clean**
+
+```bash
+git status
+```
+Expected: no unexpected modified/untracked files (in particular, no stray `web/dist/` contents beyond `.gitkeep`, no leftover `web/public/static-demo/` from local testing — that directory is `.gitignore`-able since it's only ever produced by CI; add `web/public/static-demo/` to `.gitignore` if a local bake run leaves it behind)
+
+- [ ] **Step 5: Final commit if `.gitignore` needed updating**
+
+```bash
+git add .gitignore
+git commit -m "chore: gitignore the locally-baked static-demo output"
+```
+
+---
+
+## After this plan
+
+Per the user's direction: once Bet 1 lands, sweep the remaining open issues on this same branch — [#34](https://github.com/natcat38/f1-race-tracker/issues/34), [#36](https://github.com/natcat38/f1-race-tracker/issues/36), [#37](https://github.com/natcat38/f1-race-tracker/issues/37) (not #38 — folded into Task 7 above). Bet 2 (verified live capture) is timing-gated to a real race weekend and is handed off separately as `f1-race-tracker-live-capture-hungaroring-2026-07-26.md`.

--- a/docs/superpowers/plans/2026-07-24-static-gh-pages-demo.md
+++ b/docs/superpowers/plans/2026-07-24-static-gh-pages-demo.md
@@ -422,7 +422,7 @@ describe('connectStaticReplay', () => {
     // itself = 0) — mirrors play.go's `base := lines[0].TimeMs`, where the first
     // emitted frame always has target=0. So the snapshot AND the first frame both
     // play at offset 0, back to back, with no artificial delay between them.
-    await vi.waitFor(() => expect(states.length).toBeGreaterThanOrEqual(2));
+    await vi.waitFor(() => expect(states.length).toBeGreaterThanOrEqual(2), { interval: 1 });
     expect(states[0].rev).toBe(0); // snapshot
     expect(states[1].rev).toBe(1); // first frame, right behind it
 
@@ -430,21 +430,26 @@ describe('connectStaticReplay', () => {
     expect(states.at(-1)?.rev).toBe(2);
   });
 
-  test('loops back to the start after the last frame', async () => {
+  test('loops back to the first frame after the last frame, without re-emitting the snapshot, and Rev keeps climbing', async () => {
     const states: RaceState[] = [];
     connectStaticReplay((s) => states.push(s));
-    await vi.waitFor(() => expect(states.length).toBeGreaterThanOrEqual(2)); // snapshot + frame 1
+    await vi.waitFor(() => expect(states.length).toBeGreaterThanOrEqual(2), { interval: 1 }); // snapshot + frame 1
 
-    await vi.advanceTimersByTimeAsync(200); // frame 2 (end of clip)
-    await vi.advanceTimersByTimeAsync(50);  // past the end -> loop restarts at the snapshot
+    await vi.advanceTimersByTimeAsync(200); // frame 2, rev 2 (end of clip)
+    await vi.advanceTimersByTimeAsync(50);  // past the end -> loop restarts at frame 1, not the snapshot
 
-    expect(states.at(-1)?.rev).toBe(0); // back to the baked snapshot's rev
+    // The restarted frame 1 is baked with rev 1, which is <= the rev 2 the state
+    // already reached — applyMessage would silently drop it as stale (CONTEXT.md's
+    // Rev invariant) unless its rev is bumped past the previous lap's max (2),
+    // landing at 1 + 1*2 = 3. This is the whole point of the test: prove Rev keeps
+    // climbing across a loop restart instead of freezing the map.
+    expect(states.at(-1)?.rev).toBe(3);
   });
 
   test('the returned close function stops scheduling further frames', async () => {
     const states: RaceState[] = [];
     const close = connectStaticReplay((s) => states.push(s));
-    await vi.waitFor(() => expect(states.length).toBeGreaterThanOrEqual(2));
+    await vi.waitFor(() => expect(states.length).toBeGreaterThanOrEqual(2), { interval: 1 });
 
     close();
     const countAtClose = states.length;
@@ -456,7 +461,7 @@ describe('connectStaticReplay', () => {
     const statuses: string[] = [];
     connectStaticReplay(() => {}, (s) => statuses.push(s));
     expect(statuses[0]).toBe('connecting');
-    await vi.waitFor(() => expect(statuses).toContain('live'));
+    await vi.waitFor(() => expect(statuses).toContain('live'), { interval: 1 });
   });
 });
 ```
@@ -531,21 +536,45 @@ export function connectStaticReplay(
     // Every frame's timeMs, relative to the first frame's timeMs — mirrors
     // play.go's `base := s.lines[0].TimeMs`. The snapshot (if any) always plays
     // at offset 0, same as the Go player's first-message-is-current-state model.
-    const frameBase = messages.find((m) => m.type === 'frame')?.data.timeMs ?? 0;
+    const frameStartIndex = messages.findIndex((m) => m.type === 'frame');
+    const frameBase = frameStartIndex >= 0 ? messages[frameStartIndex].data.timeMs : 0;
     const offsets = messages.map((m) => (m.type === 'frame' ? m.data.timeMs - frameBase : 0));
+    // Where a loop restart resumes: the first FRAME, not index 0. The synthetic
+    // baked snapshot (empty cars, the pre-playback baseline) plays exactly once,
+    // on the very first pass — re-emitting it every lap would flash the map back
+    // to empty on every loop, and production never does this either: a real
+    // replay loop restart is detected by TimeMs decreasing and only clears the
+    // rolling message buffer (internal/model/apply.go), it never re-sends a
+    // from-scratch empty snapshot.
+    const loopRestartIndex = frameStartIndex >= 0 ? frameStartIndex : 0;
+    // applyMessage drops any frame whose Rev isn't greater than the state's
+    // current Rev (CONTEXT.md: "Rev ... must never reset — not across a replay
+    // loop"). cmd/bake-static bakes Rev as 1..N for one pass, so replaying the
+    // same baked messages verbatim on lap 2 would have every frame's Rev <= the
+    // Rev the first lap already reached, silently dropped as stale — freezing
+    // the map after one lap. Mirror play.go's `fr.Rev = ln.Frame.Rev + loop*s.max`:
+    // bump every frame's Rev by (completed laps * the highest baked Rev) so Rev
+    // keeps climbing forever, exactly like the real writer does across a loop.
+    const maxRev = messages.reduce((max, m) => (m.type === 'frame' ? Math.max(max, m.data.rev) : max), 0);
+    let lapsCompleted = 0;
 
     let loopStart = Date.now();
 
     const playFrom = (i: number) => {
       if (closed) return;
       if (i >= messages.length) {
+        lapsCompleted++;
         loopStart = Date.now();
-        timer = setTimeout(() => playFrom(0), 0);
+        timer = setTimeout(() => playFrom(loopRestartIndex), 0);
         return;
       }
       const wait = Math.max(0, offsets[i] - (Date.now() - loopStart));
       timer = setTimeout(() => {
-        state = applyMessage(state, messages[i]);
+        const msg = messages[i];
+        const bumped: Msg = msg.type === 'frame' && lapsCompleted > 0
+          ? { ...msg, data: { ...msg.data, rev: msg.data.rev + lapsCompleted * maxRev } }
+          : msg;
+        state = applyMessage(state, bumped);
         if (!live) { live = true; onStatus?.('live'); }
         onState(state);
         playFrom(i + 1);

--- a/internal/feed/replay/play.go
+++ b/internal/feed/replay/play.go
@@ -100,6 +100,19 @@ func (s *Source) Stints() map[int][]model.Stint { return s.stints }
 func (s *Source) Label() string                 { return s.label }
 func (s *Source) Mode() string                  { return "replay" }
 
+// Frames returns every frame in the clip, in file order, with each frame's Rev
+// exactly as recorded in the file (advisory — a caller publishing to a fresh
+// session should reassign a monotonic Rev, as Writer.Run and cmd/bake-static do).
+// Unlike Events, this does not pace playback in real time: it's for tooling that
+// needs the whole clip immediately, not a live-paced stream.
+func (s *Source) Frames() []model.Frame {
+	out := make([]model.Frame, len(s.lines))
+	for i, ln := range s.lines {
+		out[i] = ln.Frame
+	}
+	return out
+}
+
 // Events streams frames forever, looping. T is stamped to emit-time (see
 // knowledge/components/replay-engine.md).
 // Rev on the emitted frame is advisory — the writer reassigns a monotonic Rev.

--- a/internal/feed/replay/play_test.go
+++ b/internal/feed/replay/play_test.go
@@ -158,6 +158,27 @@ func TestLoadParsesLapTraceFromHeader(t *testing.T) {
 	}
 }
 
+func TestSource_Frames_ReturnsAllInFileOrder(t *testing.T) {
+	body := `{"track":[{"x":0,"y":0}],"label":"Lbl","maxRev":3}
+{"timeMs":100,"frame":{"rev":1,"timeMs":100,"cars":[{"driverNum":1}]}}
+{"timeMs":200,"frame":{"rev":2,"timeMs":200,"cars":[{"driverNum":1}]}}
+{"timeMs":300,"frame":{"rev":3,"timeMs":300,"cars":[{"driverNum":1}]}}
+`
+	src, err := Load(writeTemp(t, body), 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	frames := src.Frames()
+	if len(frames) != 3 {
+		t.Fatalf("got %d frames, want 3", len(frames))
+	}
+	for i, want := range []int64{100, 200, 300} {
+		if frames[i].TimeMs != want {
+			t.Errorf("frames[%d].TimeMs = %d, want %d", i, frames[i].TimeMs, want)
+		}
+	}
+}
+
 func TestLoadParsesTotalLapsFromHeader(t *testing.T) {
 	clip := `{"track":[{"x":0.1,"y":0.2}],"label":"T","maxRev":1,"totalLaps":53}
 {"timeMs":3300000,"frame":{"rev":1,"timeMs":3300000,"cars":[{"driverNum":1,"code":"VER","team":"Red Bull","pos":1,"p":{"x":0.1,"y":0.2},"status":"OnTrack"}]}}

--- a/internal/ws/frame.go
+++ b/internal/ws/frame.go
@@ -13,7 +13,7 @@ type envelope struct {
 	Data json.RawMessage `json:"data"`
 }
 
-func encodeSnapshot(s *model.Snapshot) ([]byte, error) {
+func EncodeSnapshot(s *model.Snapshot) ([]byte, error) {
 	d, err := json.Marshal(s)
 	if err != nil {
 		return nil, err
@@ -21,7 +21,7 @@ func encodeSnapshot(s *model.Snapshot) ([]byte, error) {
 	return json.Marshal(envelope{Type: "snapshot", Data: d})
 }
 
-func encodeFrame(f model.Frame) ([]byte, error) {
+func EncodeFrame(f model.Frame) ([]byte, error) {
 	// A zero-value frame (Rev 0, no cars) is never a real broadcast — Rev 0 is the
 	// "no frame yet" sentinel the hub's stale check assumes. Refuse it rather than
 	// silently fan out an empty frame.

--- a/internal/ws/frame_test.go
+++ b/internal/ws/frame_test.go
@@ -10,7 +10,7 @@ import (
 func TestEncodeSnapshot_WrapsTypeAndData(t *testing.T) {
 	s := model.NewSnapshot("demo", "replay", "Synthetic")
 	s.Rev = 3
-	b, err := encodeSnapshot(s)
+	b, err := EncodeSnapshot(s)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -32,7 +32,7 @@ func TestEncodeSnapshot_WrapsTypeAndData(t *testing.T) {
 
 func TestEncodeFrame_WrapsTypeAndData(t *testing.T) {
 	f := model.Frame{Rev: 9, TimeMs: 1234, Cars: []model.CarState{{DriverNum: 44}}}
-	b, err := encodeFrame(f)
+	b, err := EncodeFrame(f)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -54,9 +54,9 @@ func TestEncodeFrame_WrapsTypeAndData(t *testing.T) {
 
 // A zero-value Frame (Rev 0, no cars) should never be silently encoded and
 // broadcast — Rev 0 collides with the "no frame yet" sentinel the hub's stale
-// check relies on. encodeFrame must reject it.
+// check relies on. EncodeFrame must reject it.
 func TestEncodeFrame_RejectsZeroValueFrame(t *testing.T) {
-	if _, err := encodeFrame(model.Frame{}); err == nil {
+	if _, err := EncodeFrame(model.Frame{}); err == nil {
 		t.Fatal("expected error encoding a zero-value Frame (Rev 0, no cars), got nil")
 	}
 }

--- a/internal/ws/hub.go
+++ b/internal/ws/hub.go
@@ -28,7 +28,7 @@ func (h *Hub) ApplyFrame(f model.Frame) bool {
 		h.mu.Unlock()
 		return false
 	}
-	b, err := encodeFrame(f)
+	b, err := EncodeFrame(f)
 	if err != nil {
 		h.logger.Error("encode frame failed", "session", f.SessionKey, "rev", f.Rev, "err", err)
 		h.mu.Unlock()
@@ -67,7 +67,7 @@ func closeAll(clients []*Client) {
 func (h *Hub) Register(c *Client) error {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	b, err := encodeSnapshot(h.snapshot)
+	b, err := EncodeSnapshot(h.snapshot)
 	if err != nil {
 		return err
 	}
@@ -89,7 +89,7 @@ func (h *Hub) Unregister(c *Client) {
 func (h *Hub) Reset(snap *model.Snapshot) {
 	h.mu.Lock()
 	h.snapshot = snap
-	b, err := encodeSnapshot(snap)
+	b, err := EncodeSnapshot(snap)
 	if err != nil {
 		h.logger.Error("encode snapshot failed", "session", snap.SessionKey, "err", err)
 		h.mu.Unlock()

--- a/knowledge/domain/event-model.md
+++ b/knowledge/domain/event-model.md
@@ -4,19 +4,32 @@ title: Event model
 description: The normalised JSON contract (CarState, Snapshot, Frame) shared identically by Python and Go.
 resource: ../../docs/F1_Race_Tracker_Tech_Scope.md
 tags: [domain, contract, seam]
-timestamp: 2026-06-15T00:00:00Z
+timestamp: 2026-07-25T00:00:00Z
 ---
 
 # Schema
 
 The contract is defined identically in Go and Python — positions first; the same data gives
-the running order for free (see [leaderboard](/domain/leaderboard.md)).
+the running order for free (see [leaderboard](/domain/leaderboard.md)). Source of truth:
+`internal/model/model.go`.
 
-- **CarState** — `driverNum`, `code` (e.g. "VER"), `team`, `pos` (running order), `p`
-  (track-space X/Y, drives the map), `status` (`OnTrack | Pit | Out`), optional `tyre`, `speed`.
-- **Snapshot** — full current state served to new/reconnecting clients: session, mode
-  (`live | replay`), label, one-time `track` outline, `cars`, messages, `timeMs`, and `rev`.
-- **Frame** — a delta published to clients each tick; in practice nearly all cars move every frame.
+- **CarState** — `driverNum`, `code` (e.g. "VER"), `team`, `pos` (running order), `lap`, `p`
+  (track-space X/Y, drives the map), `status` (`OnTrack | Pit | Out`). Phase 2+, all optional
+  (absent renders blank): tyre/stint (`tyre`, `tyreAge`), timing (`lastLapMs`, `bestLapMs`,
+  `s1Ms`/`s2Ms`/`s3Ms`, `gapMs`, `gapLaps`, `intMs` — best-effort, derived at record time), and
+  telemetry (`speed`, `gear`, `throttle`, `brake`, `drs`).
+- **Snapshot** — full current state served to new/reconnecting clients: `session`, `mode`
+  (`live | replay`), `label`, `cars`, `timeMs`, `rev`, plus these additive fields, all
+  optional and **session-constant** (baked once, not windowed to the replay clip) unless
+  noted: one-time `track` outline, `radio` (team-radio references), `lapTrace` (per-driver
+  cumulative lap-time curve, for the ghost overlay), `totalLaps`, `stints` (per-driver tyre
+  plan), `weather` (carried forward from the last frame that changed it), and `messages`
+  (the rolling race-control buffer, cap 30 — accumulates as frames play, unlike the other
+  session-constant fields).
+- **Frame** — a delta published to clients each tick; in practice nearly all cars move every
+  frame. Carries `session`, `rev`, `t` (publish wall-time), `timeMs` (session clock), `cars`,
+  and optionally `messages` (new race-control entries this tick) and `weather` (only present
+  when the sample changes from the last one emitted).
 - **Rev** — one global, monotonic revision owned by the active writer; it must **never reset**,
   not across a replay loop nor a live↔replay switch.
 

--- a/web/package.json
+++ b/web/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
+    "postbuild": "node -e \"require('fs').closeSync(require('fs').openSync('dist/.gitkeep','a'))\"",
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest run"

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { connectRace, type ConnStatus } from './realtime/socket';
+import { connectStaticReplay } from './realtime/staticReplay';
 import { emptyState, type RaceState } from './state/race';
 import { Map } from './components/Map';
 import { TimingTower } from './components/TimingTower';
@@ -20,6 +21,11 @@ function SkeletonMap() {
   return <div className="track-skeleton">Warming up the timing feed…</div>;
 }
 
+// Build-time flag: VITE_STATIC_DEMO=true selects the file-backed static player
+// instead of the real WebSocket connection. Set only by the GitHub Pages build
+// (see .github/workflows/pages.yml) — docker-compose and local dev never set it.
+const STATIC_DEMO = import.meta.env.VITE_STATIC_DEMO === 'true';
+
 export default function App() {
   const [state, setState] = useState<RaceState>(emptyState());
   const [status, setStatus] = useState<ConnStatus>('connecting');
@@ -30,7 +36,7 @@ export default function App() {
   const lapHistory = useLapHistory(state);
   const gapHistory = useGapHistory(state);
 
-  useEffect(() => connectRace(setState, setStatus), []);
+  useEffect(() => (STATIC_DEMO ? connectStaticReplay : connectRace)(setState, setStatus), []);
   useEffect(() => {
     const onHash = () => setHash(location.hash);
     window.addEventListener('hashchange', onHash);
@@ -49,7 +55,7 @@ export default function App() {
   return (
     <div className="page">
       <StatusRail active="board" state={state} status={status} staleSec={staleSec}>
-        <SourceToggle state={state} />
+        {!STATIC_DEMO && <SourceToggle state={state} />}
       </StatusRail>
 
       <div className="board-top">

--- a/web/src/realtime/staticReplay.test.ts
+++ b/web/src/realtime/staticReplay.test.ts
@@ -68,4 +68,36 @@ describe('connectStaticReplay', () => {
     expect(statuses[0]).toBe('connecting');
     await vi.waitFor(() => expect(statuses).toContain('live'), { interval: 1 });
   });
+
+  test('reports a non-hung status instead of leaving the UI on "connecting" forever when the clip fetch fails', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.reject(new Error('network down'))));
+    const statuses: string[] = [];
+    connectStaticReplay(() => {}, (s) => statuses.push(s));
+    await vi.waitFor(() => expect(statuses).toContain('reconnecting'), { interval: 1 });
+  });
+
+  test('reports a non-hung status and does not busy-loop when the clip has no valid frame messages', async () => {
+    // Snapshot-only clip: parses fine, but has zero frames. Without the
+    // frameStartIndex guard, loopRestartIndex would fall back to 0 (the
+    // snapshot itself) and playFrom would reschedule a 0ms timer against
+    // itself forever.
+    const snapshotOnly = JSON.stringify({
+      type: 'snapshot',
+      data: { session: 'x', mode: 'replay', label: 'Test', cars: {}, timeMs: 0, rev: 0 },
+    }) + '\n';
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: true, text: () => Promise.resolve(snapshotOnly) })));
+
+    const states: RaceState[] = [];
+    const statuses: string[] = [];
+    connectStaticReplay((s) => states.push(s), (s) => statuses.push(s));
+
+    await vi.waitFor(() => expect(statuses).toContain('reconnecting'), { interval: 1 });
+    expect(states).toHaveLength(0); // playback never started — the snapshot itself is never applied
+
+    // The busy-loop this guard exists to prevent would show up as a timer
+    // still ticking; confirm none is scheduled, even after time passes.
+    expect(vi.getTimerCount()).toBe(0);
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(vi.getTimerCount()).toBe(0);
+  });
 });

--- a/web/src/realtime/staticReplay.test.ts
+++ b/web/src/realtime/staticReplay.test.ts
@@ -1,0 +1,71 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import { connectStaticReplay } from './staticReplay';
+import type { RaceState } from '../state/race';
+
+const CLIP_NDJSON = [
+  JSON.stringify({ type: 'snapshot', data: { session: 'static-demo', mode: 'replay', label: 'Test', cars: {}, timeMs: 0, rev: 0 } }),
+  JSON.stringify({ type: 'frame', data: { rev: 1, timeMs: 100, cars: [{ driverNum: 1, code: 'VER', team: 'Red Bull', pos: 1, p: { x: 0.1, y: 0.1 }, status: 'OnTrack' }] } }),
+  JSON.stringify({ type: 'frame', data: { rev: 2, timeMs: 300, cars: [{ driverNum: 1, code: 'VER', team: 'Red Bull', pos: 1, p: { x: 0.2, y: 0.2 }, status: 'OnTrack' }] } }),
+].join('\n') + '\n';
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: true, text: () => Promise.resolve(CLIP_NDJSON) })));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe('connectStaticReplay', () => {
+  test('applies the snapshot then the first frame immediately, later frames paced by their timeMs delta', async () => {
+    const states: RaceState[] = [];
+    connectStaticReplay((s) => states.push(s));
+
+    // The first frame defines its own zero-point (offset = its own timeMs minus
+    // itself = 0) — mirrors play.go's `base := lines[0].TimeMs`, where the first
+    // emitted frame always has target=0. So the snapshot AND the first frame both
+    // play at offset 0, back to back, with no artificial delay between them.
+    await vi.waitFor(() => expect(states.length).toBeGreaterThanOrEqual(2), { interval: 1 });
+    expect(states[0].rev).toBe(0); // snapshot
+    expect(states[1].rev).toBe(1); // first frame, right behind it
+
+    await vi.advanceTimersByTimeAsync(200); // second frame is 200ms after the first (300 - 100)
+    expect(states.at(-1)?.rev).toBe(2);
+  });
+
+  test('loops back to the first frame after the last frame, without re-emitting the snapshot, and Rev keeps climbing', async () => {
+    const states: RaceState[] = [];
+    connectStaticReplay((s) => states.push(s));
+    await vi.waitFor(() => expect(states.length).toBeGreaterThanOrEqual(2), { interval: 1 }); // snapshot + frame 1
+
+    await vi.advanceTimersByTimeAsync(200); // frame 2, rev 2 (end of clip)
+    await vi.advanceTimersByTimeAsync(50);  // past the end -> loop restarts at frame 1, not the snapshot
+
+    // The restarted frame 1 is baked with rev 1, which is <= the rev 2 the state
+    // already reached — applyMessage would silently drop it as stale (CONTEXT.md's
+    // Rev invariant) unless its rev is bumped past the previous lap's max (2),
+    // landing at 1 + 1*2 = 3. This is the whole point of the test: prove Rev keeps
+    // climbing across a loop restart instead of freezing the map.
+    expect(states.at(-1)?.rev).toBe(3);
+  });
+
+  test('the returned close function stops scheduling further frames', async () => {
+    const states: RaceState[] = [];
+    const close = connectStaticReplay((s) => states.push(s));
+    await vi.waitFor(() => expect(states.length).toBeGreaterThanOrEqual(2), { interval: 1 });
+
+    close();
+    const countAtClose = states.length;
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(states.length).toBe(countAtClose); // nothing scheduled after close
+  });
+
+  test('onStatus reports connecting then live', async () => {
+    const statuses: string[] = [];
+    connectStaticReplay(() => {}, (s) => statuses.push(s));
+    expect(statuses[0]).toBe('connecting');
+    await vi.waitFor(() => expect(statuses).toContain('live'), { interval: 1 });
+  });
+});

--- a/web/src/realtime/staticReplay.ts
+++ b/web/src/realtime/staticReplay.ts
@@ -44,14 +44,21 @@ export function connectStaticReplay(
           }
         })
         .filter((m): m is Msg => m !== null);
-      if (messages.length === 0) {
-        console.error('connectStaticReplay: baked clip had no valid messages');
+      // Require at least one FRAME, not just any message: a clip with only a
+      // parseable snapshot and zero valid frames would otherwise pass this
+      // check, then schedulePlayback's loopRestartIndex would fall back to 0
+      // (the snapshot itself) and playFrom would reschedule a 0ms timer against
+      // itself forever — a busy-loop pegging the tab instead of a visible error.
+      if (!messages.some((m) => m.type === 'frame')) {
+        console.error('connectStaticReplay: baked clip had no valid frame messages');
+        onStatus?.('reconnecting'); // no live source to fall back to on a static page — signals "not progressing" over a silent hang
         return;
       }
       schedulePlayback(messages);
     })
     .catch((err) => {
       console.error('connectStaticReplay: failed to load clip', err);
+      onStatus?.('reconnecting'); // same: nothing to reconnect to, but better than a silent "connecting" hang
     });
 
   function schedulePlayback(messages: Msg[]) {

--- a/web/src/realtime/staticReplay.ts
+++ b/web/src/realtime/staticReplay.ts
@@ -1,0 +1,113 @@
+import { applyMessage, emptyState, parseMsg, type RaceState } from '../state/race';
+import type { ConnStatus } from './socket';
+
+// race.ts's Msg union isn't exported (it's an internal detail of parseMsg's
+// return type) — alias it here once so every use below refers to the same
+// name instead of repeating the ReturnType<typeof parseMsg> gymnastics.
+type Msg = NonNullable<ReturnType<typeof parseMsg>>;
+
+const DEFAULT_CLIP_URL = `${import.meta.env.BASE_URL}static-demo/monza-2024-race.ndjson`;
+
+// connectStaticReplay mirrors connectRace's interface (onState/onStatus/close-fn)
+// but reads a baked NDJSON file (produced by cmd/bake-static) instead of opening
+// a WebSocket, pacing playback on each frame's own relative timeMs offset and
+// looping forever — the same algorithm as the Go replay player's playFromStart
+// (internal/feed/replay/play.go), ported here since there's no Go process to
+// pace it for us in a static build.
+export function connectStaticReplay(
+  onState: (s: RaceState) => void,
+  onStatus?: (status: ConnStatus) => void,
+  clipUrl: string = DEFAULT_CLIP_URL,
+): () => void {
+  let state = emptyState();
+  let closed = false;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let live = false;
+
+  onStatus?.('connecting');
+
+  fetch(clipUrl)
+    .then((res) => {
+      if (!res.ok) throw new Error(`static demo: fetch failed (${res.status})`);
+      return res.text();
+    })
+    .then((text) => {
+      if (closed) return;
+      const messages = text
+        .split('\n')
+        .filter((line) => line.length > 0)
+        .map((line) => {
+          try {
+            return parseMsg(JSON.parse(line));
+          } catch {
+            return null;
+          }
+        })
+        .filter((m): m is Msg => m !== null);
+      if (messages.length === 0) {
+        console.error('connectStaticReplay: baked clip had no valid messages');
+        return;
+      }
+      schedulePlayback(messages);
+    })
+    .catch((err) => {
+      console.error('connectStaticReplay: failed to load clip', err);
+    });
+
+  function schedulePlayback(messages: Msg[]) {
+    // Every frame's timeMs, relative to the first frame's timeMs — mirrors
+    // play.go's `base := s.lines[0].TimeMs`. The snapshot (if any) always plays
+    // at offset 0, same as the Go player's first-message-is-current-state model.
+    const frameStartIndex = messages.findIndex((m) => m.type === 'frame');
+    const frameBase = frameStartIndex >= 0 ? messages[frameStartIndex].data.timeMs : 0;
+    const offsets = messages.map((m) => (m.type === 'frame' ? m.data.timeMs - frameBase : 0));
+    // Where a loop restart resumes: the first FRAME, not index 0. The synthetic
+    // baked snapshot (empty cars, the pre-playback baseline) plays exactly once,
+    // on the very first pass — re-emitting it every lap would flash the map back
+    // to empty on every loop, and production never does this either: a real
+    // replay loop restart is detected by TimeMs decreasing and only clears the
+    // rolling message buffer (internal/model/apply.go), it never re-sends a
+    // from-scratch empty snapshot.
+    const loopRestartIndex = frameStartIndex >= 0 ? frameStartIndex : 0;
+    // applyMessage drops any frame whose Rev isn't greater than the state's
+    // current Rev (CONTEXT.md: "Rev ... must never reset — not across a replay
+    // loop"). cmd/bake-static bakes Rev as 1..N for one pass, so replaying the
+    // same baked messages verbatim on lap 2 would have every frame's Rev <= the
+    // Rev the first lap already reached, silently dropped as stale — freezing
+    // the map after one lap. Mirror play.go's `fr.Rev = ln.Frame.Rev + loop*s.max`:
+    // bump every frame's Rev by (completed laps * the highest baked Rev) so Rev
+    // keeps climbing forever, exactly like the real writer does across a loop.
+    const maxRev = messages.reduce((max, m) => (m.type === 'frame' ? Math.max(max, m.data.rev) : max), 0);
+    let lapsCompleted = 0;
+
+    let loopStart = Date.now();
+
+    const playFrom = (i: number) => {
+      if (closed) return;
+      if (i >= messages.length) {
+        lapsCompleted++;
+        loopStart = Date.now();
+        timer = setTimeout(() => playFrom(loopRestartIndex), 0);
+        return;
+      }
+      const wait = Math.max(0, offsets[i] - (Date.now() - loopStart));
+      timer = setTimeout(() => {
+        const msg = messages[i];
+        const bumped: Msg = msg.type === 'frame' && lapsCompleted > 0
+          ? { ...msg, data: { ...msg.data, rev: msg.data.rev + lapsCompleted * maxRev } }
+          : msg;
+        state = applyMessage(state, bumped);
+        if (!live) { live = true; onStatus?.('live'); }
+        onState(state);
+        playFrom(i + 1);
+      }, wait);
+    };
+
+    playFrom(0);
+  }
+
+  return () => {
+    closed = true;
+    if (timer) clearTimeout(timer);
+  };
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -4,6 +4,9 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  // GitHub Pages project sites serve under /<repo>/, not /. docker-compose and
+  // local dev never set VITE_STATIC_DEMO, so they keep the default '/'.
+  base: process.env.VITE_STATIC_DEMO === 'true' ? '/f1-race-tracker/' : '/',
   server: {
     proxy: {
       '/ws': { target: 'ws://localhost:8080', ws: true },


### PR DESCRIPTION
## Summary

**Bet 1 — static GitHub Pages demo** (fully implemented):
- ADR-0006 records the design decision: a frontend-only replay demo on GitHub Pages, as a *third front door* alongside README/video and `docker-compose` — not a replacement, and not a reversal of the "no always-on hosting" rule (that meant cost/maintenance, not "no static artifact").
- `cmd/bake-static`: a new Go command that bakes a replay clip into wire-format NDJSON, reusing the existing `ws.EncodeSnapshot`/`ws.EncodeFrame` — no second hand-written translator.
- `web/src/realtime/staticReplay.ts`: `connectStaticReplay`, a drop-in swap for `connectRace` that reads the baked file and paces playback on real per-frame `timeMs` offsets, looping forever — including a Rev-continuity fix (bumping Rev by `completedLaps * maxRev` across loop restarts) found via live debugging, since a naive replay would've frozen the map after one lap.
- Wired into `App.tsx` behind `VITE_STATIC_DEMO`; conditional Vite `base` path; `.github/workflows/pages.yml` bakes+builds+deploys on push to `main`.
- Fixed #38 properly (a `postbuild` hook, not untracking `.gitkeep` — that would've broken the `go` CI job's `//go:embed all:dist`).
- README updated with the new front door; a temporary, tracked lychee exclusion (#41) covers the not-yet-live Pages URL until this merges and Pages is enabled.

**Bet 2 — verified live capture**: design-only this session (timing-gated to a real race weekend). The original "point ingest at OpenF1's live feed" premise was wrong — OpenF1 live needs a paid tier; the actual live path already targets F1's own feed via FastF1. Handed off as a self-contained prompt for the next Hungarian GP session (Jul 26).

**Issue sweep** (same branch, per request):
- #34 — `knowledge/domain/event-model.md` updated to match the current contract (was 4 phases stale).
- #35 — ADR-0005 for Phase 5's `stints`/`weather` fields (number reserved for this during the ADR-0006 design pass).
- #36 — committed the Phase 5 pit-wall completion plan (previously only a local, uncommitted file).
- #37 — triaged the 4 open Dependabot PRs: merged #40 (replaces #31) and #29 (now green), closed #30 (re-breaks the numpy 3.11 pin) and #32 (blocked on typescript-eslint's peer constraint).

Also resolved #33 (stranded branch) at the start of this session — it turned out to already be merged via #39.

## Test plan
- [x] `gofmt -l . && go vet ./... && go test ./...`
- [x] `cd web && npm run lint -- --max-warnings 0 && npm run build && npm test` (85/85 tests)
- [x] `python -m pytest ingest bench`
- [x] Every task went through independent spec-compliance + code-quality subagent review; a final holistic review across all 17 commits caught one gap (missing `.gitignore` entry for the locally-baked static-demo output), fixed.
- [x] Merged latest `origin/main` in, re-ran the full gate clean.
- [ ] **Manual, post-merge:** enable *Settings → Pages → Source → GitHub Actions* (one-time, can't be done from a workflow file), then confirm the deploy at https://natcat38.github.io/f1-race-tracker/ and remove the lychee exclusion (#41).