### PR TITLE
ci: remove the now-unneeded lychee exclusion for the static demo URL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,13 +101,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: lycheeverse/lychee-action@v2
         with:
-          # The static-demo link in README.md 404s until the Pages workflow
-          # (.github/workflows/pages.yml) has deployed at least once post-merge
-          # and Settings > Pages > Source is set to "GitHub Actions" — both
-          # happen after this PR merges, not before. Remove this --exclude once
-          # https://natcat38.github.io/f1-race-tracker/ is confirmed live —
-          # tracked in issue #41.
-          args: "--no-progress --exclude-loopback --exclude 'https://natcat38\\.github\\.io/f1-race-tracker/?$' README.md CONTEXT.md docs/*.md docs/adr/**/*.md"
+          args: "--no-progress --exclude-loopback README.md CONTEXT.md docs/*.md docs/adr/**/*.md"
           fail: true
 
   docker:


### PR DESCRIPTION
Closes #41 — https://natcat38.github.io/f1-race-tracker/ is confirmed live (deploy green, page renders, gzip serving). This PR's own `docs-links` CI run is the proof: it now checks the link for real instead of skipping it.