### PR TITLE
chore(deps): npm audit fix — brace-expansion, nanoid, postcss

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1419,9 +1419,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2421,9 +2421,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -2568,9 +2568,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.19",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
-      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -2588,7 +2588,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
Unblocks CI. `Dependency vulnerability scan` is a **required** status check, so these advisories were blocking *every* PR on this repo — not just the one that happened to surface them.

## Not caused by any code change

Main last ran green on 2026-07-24; these advisories were published since. I re-ran the security job on **untouched main** and it fails identically, so this is time-based advisory drift against a live database, not a regression.

## The bumps

| Package | Change | Severity | Advisory |
|---|---|---|---|
| `brace-expansion` | 5.0.8 → 5.0.9 | high | [GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895) — DoS via unbounded intermediate arrays |
| `nanoid` | 3.3.16 → 3.3.18 | high | [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) — custom generators loop indefinitely when size is 0 |
| `postcss` | 8.5.19 → 8.5.26 | moderate | [GHSA-fxqj-rqcc-2cmp](https://github.com/advisories/GHSA-fxqj-rqcc-2cmp) — arbitrary `.map` read when `from` is unset |

All three are transitive dev-tooling deps (vite → nanoid/postcss, eslint → brace-expansion). Plain `npm audit fix`, **no `--force`** — patch bumps only, `package.json` untouched, lockfile-only diff (10 lines).

## Verification

Ran the web job's exact steps locally against the new lockfile:

- `npm ci` → **found 0 vulnerabilities**
- `npm run lint -- --max-warnings 0` → clean
- `npm run build` → succeeds
- `npm test` → 7 files, 85 tests passed

Once this lands, [#53](https://github.com/natcat38/f1-race-tracker/pull/53) (Go↔Python contract drift check) becomes mergeable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)