### PR TITLE
docs: declare a purpose for every source directory

### DIFF
--- a/FILE-MAP.md
+++ b/FILE-MAP.md
@@ -10,22 +10,22 @@ docstring — an orientation gap, not an omission by the generator.
 
 | Directory | Source files | Purpose |
 | --- | ---: | --- |
-| `cmd/bake-static` | 2 |  |
-| `cmd/genclip` | 1 |  |
-| `cmd/loadtest` | 3 |  |
-| `cmd/server` | 1 |  |
+| `cmd/bake-static` | 2 | main is the bake-static command, which bakes a replay clip into newline-delimited WebSocket envelopes for the GitHub Pages static demo. |
+| `cmd/genclip` | 1 | main is the genclip command, which synthesises a circular-track replay clip (.jsonl) of fake cars for testing the feed pipeline without live F1 data. |
+| `cmd/loadtest` | 3 | main is the loadtest command, which drives the concurrency sweeps recorded in BENCHMARKS.md. |
+| `cmd/server` | 1 | main is the server command, which runs as either the gateway (WebSocket fan-out) or replay (Redis feed writer) role depending on config.Role. |
 | `internal/app` | 7 | app wires the replay source, the bus, and the hub into runnable roles. |
 | `internal/bus` | 2 | bus is the Redis seam: snapshot store + frame pub/sub. |
-| `internal/config` | 2 |  |
+| `internal/config` | 2 | config loads and validates the gateway/replay process's environment configuration. |
 | `internal/feed/replay` | 2 | replay reads a .jsonl clip and replays it as a frame stream. |
 | `internal/model` | 5 | model is the normalised contract shared by every layer (and, later, Python). |
 | `internal/ws` | 7 | ws is the gateway-side WebSocket fan-out hub. |
 | `ingest` | 14 | FastF1 → JSONL clip recorder. |
-| `bench` | 2 |  |
-| `web/src` | 3 |  |
-| `web/src/components` | 17 |  |
-| `web/src/hooks` | 6 |  |
-| `web/src/realtime` | 4 |  |
-| `web/src/state` | 7 |  |
+| `bench` | 2 | Drive the loadtest sweeps behind BENCHMARKS.md by running cmd/loadtest at increasing concurrency and recording gateway resource usage. |
+| `web/src` | 3 | The React app shell: mounts the root component, wires the live WebSocket or static-replay data source into race state, and lays out the dashboard panels. |
+| `web/src/components` | 17 | The dashboard's presentational components — map, timing tower, standings, telemetry, comms, race control, ghost/compare overlays, and their shared layout/formatting helpers. |
+| `web/src/hooks` | 6 | React hooks that derive UI-facing state (staleness, gap/lap history, smoothed car positions, comms playback) from the raw RaceState stream. |
+| `web/src/realtime` | 4 | The frontend's data-source connections: a reconnecting live WebSocket and a paced static-replay reader, both feeding the same RaceState reducer. |
+| `web/src/state` | 7 | The frontend's race state: wire message types, the applyMessage reducer, and the comms/ghost sub-state it composes. |
 
-17 source directories, 85 files, 11 without a declared purpose.
+17 source directories, 85 files, 0 without a declared purpose.

--- a/bench/run.py
+++ b/bench/run.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Sweep WebSocket load levels against the gateway, sample docker stats for the
+"""Drive the loadtest sweeps behind BENCHMARKS.md by running cmd/loadtest at increasing concurrency and recording gateway resource usage.
+
+Sweep WebSocket load levels against the gateway, sample docker stats for the
 gateway container, write bench/results.csv, and render bench/results.png.
 
 Usage:

--- a/cmd/bake-static/main.go
+++ b/cmd/bake-static/main.go
@@ -1,3 +1,5 @@
+// Package main is the bake-static command, which bakes a replay clip into newline-delimited WebSocket envelopes for the GitHub Pages static demo.
+//
 // Command bake-static reads a replay clip and writes it as a sequence of
 // WebSocket wire envelopes — the same {type,data} shape internal/ws/frame.go
 // encodes for real clients — to a newline-delimited JSON file. The GitHub

--- a/cmd/genclip/main.go
+++ b/cmd/genclip/main.go
@@ -1,3 +1,4 @@
+// Package main is the genclip command, which synthesises a circular-track replay clip (.jsonl) of fake cars for testing the feed pipeline without live F1 data.
 package main
 
 import (

--- a/cmd/loadtest/main.go
+++ b/cmd/loadtest/main.go
@@ -1,3 +1,5 @@
+// Package main is the loadtest command, which drives the concurrency sweeps recorded in BENCHMARKS.md.
+//
 // Command loadtest opens many concurrent WebSocket connections to the gateway and
 // measures end-to-end fan-out latency (now - frame.T) per received frame.
 package main

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,3 +1,4 @@
+// Package main is the server command, which runs as either the gateway (WebSocket fan-out) or replay (Redis feed writer) role depending on config.Role.
 package main
 
 import (

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,3 +1,4 @@
+// Package config loads and validates the gateway/replay process's environment configuration.
 package config
 
 import (

--- a/scripts/gen_file_map.py
+++ b/scripts/gen_file_map.py
@@ -57,9 +57,33 @@ def _py_doc(path):
     cands = [f for f in path.glob("*.py") if not f.name.startswith(("test_", "check_"))]
     for f in sorted(cands, key=lambda p: p.stat().st_size, reverse=True):
         src = f.read_text(encoding="utf-8", errors="replace")
+        # Skip a shebang and any encoding/comment preamble: the docstring is
+        # still the module docstring when `#!/usr/bin/env python3` precedes it.
+        src = re.sub(r"\A(?:\s*#[^\n]*\n)+", "", src)
         m = re.match(r'\s*(?:"""|\'\'\')(.*?)(?:"""|\'\'\')', src, re.S)
         if m and m.group(1).strip():
             return _first_sentence(m.group(1).strip().splitlines()[0])
+    return ""
+
+
+def _ts_doc(path):
+    """First `/** ... @packageDocumentation */` block in a .ts/.tsx file.
+
+    TSDoc's @packageDocumentation is the direct analogue of Go's `// Package x`:
+    it marks a comment as describing the whole module rather than the next
+    symbol, so no convention had to be invented for the TypeScript trees.
+    """
+    for f in sorted([*path.glob("*.ts"), *path.glob("*.tsx")]):
+        if ".test." in f.name:
+            continue
+        src = f.read_text(encoding="utf-8", errors="replace")
+        m = re.match(r"\s*/\*\*(.*?)\*/", src, re.S)
+        if m and "@packageDocumentation" in m.group(1):
+            body = m.group(1).replace("@packageDocumentation", "")
+            lines = [ln.strip().lstrip("*").strip() for ln in body.splitlines()]
+            text = " ".join(ln for ln in lines if ln)
+            if text:
+                return _first_sentence(text)
     return ""
 
 
@@ -68,7 +92,7 @@ def _describe(path):
         return _go_doc(path)
     if any(path.glob("*.py")):
         return _py_doc(path)
-    return ""  # no TS/TSX doc convention in this repo — left blank on purpose
+    return _ts_doc(path)
 
 
 def _dirs():

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,3 +1,7 @@
+/**
+ * The React app shell: mounts the root component, wires the live WebSocket or static-replay data source into race state, and lays out the dashboard panels.
+ * @packageDocumentation
+ */
 import { useEffect, useState } from 'react';
 import { connectRace, type ConnStatus } from './realtime/socket';
 import { connectStaticReplay } from './realtime/staticReplay';

--- a/web/src/components/Panel.tsx
+++ b/web/src/components/Panel.tsx
@@ -1,3 +1,7 @@
+/**
+ * The dashboard's presentational components — map, timing tower, standings, telemetry, comms, race control, ghost/compare overlays, and their shared layout/formatting helpers.
+ * @packageDocumentation
+ */
 import type { ReactNode } from 'react';
 
 // Panel is the shared instrument frame: a carbon-bordered box with an

--- a/web/src/hooks/useStale.ts
+++ b/web/src/hooks/useStale.ts
@@ -1,3 +1,7 @@
+/**
+ * React hooks that derive UI-facing state (staleness, gap/lap history, smoothed car positions, comms playback) from the raw RaceState stream.
+ * @packageDocumentation
+ */
 import { useEffect, useRef, useState } from 'react';
 import type { RaceState } from '../state/race';
 

--- a/web/src/realtime/socket.ts
+++ b/web/src/realtime/socket.ts
@@ -1,3 +1,7 @@
+/**
+ * The frontend's data-source connections: a reconnecting live WebSocket and a paced static-replay reader, both feeding the same RaceState reducer.
+ * @packageDocumentation
+ */
 import { applyMessage, emptyState, parseMsg, type RaceState } from '../state/race';
 
 export type ConnStatus = 'connecting' | 'live' | 'reconnecting';

--- a/web/src/state/race.ts
+++ b/web/src/state/race.ts
@@ -1,3 +1,7 @@
+/**
+ * The frontend's race state: wire message types, the applyMessage reducer, and the comms/ghost sub-state it composes.
+ * @packageDocumentation
+ */
 export interface Point { x: number; y: number }
 export interface Car {
   driverNum: number; code: string; team: string; pos: number; lap?: number;


### PR DESCRIPTION
Closes the gap [#55](https://github.com/natcat38/f1-race-tracker/pull/55) made visible. `FILE-MAP.md` reported **11 of 17** source directories declaring nothing; this fills all 11.

## Each language's own convention, not a new one

| Tree | Convention used |
|---|---|
| `cmd/*` ×4, `internal/config` | `// Package X ...` Go doc comment |
| `bench/run.py` | module docstring |
| `web/src` ×5 | TSDoc block tagged `@packageDocumentation` |

`@packageDocumentation` is TSDoc's own marker for "this comment describes the whole module rather than the next symbol" — the direct analogue of Go's package doc. Nothing was invented, and no per-directory README files were added.

## Two generator fixes

- `gen_file_map.py` learns to read the TSDoc form.
- Its Python docstring match no longer anchors at byte 0. A `#!/usr/bin/env python3` shebang defeated it, silently blanking any executable module — `bench/run.py` hit exactly this. Caught while writing the docs; the shebang stays and the generator adapts, rather than the reverse.

## Result

```
17 source directories, 85 files, 0 without a declared purpose.
```

An agent can now read `FILE-MAP.md` and know what every tree in the repo is for, without opening a single source file.

## Verification

`gofmt -l` clean · `go build ./...` · `go vet ./...` · `ruff check ingest bench scripts` clean · `pytest` 21 passed · `eslint --max-warnings 0` clean · `vitest` 85 passed · `gen_file_map.py --check` current.

🤖 Generated with [Claude Code](https://claude.com/claude-code)