### PR TITLE
fix(scripts): harden @packageDocumentation detection in the file-map generator

### DIFF
--- a/scripts/gen_file_map.py
+++ b/scripts/gen_file_map.py
@@ -73,13 +73,19 @@ def _ts_doc(path):
     it marks a comment as describing the whole module rather than the next
     symbol, so no convention had to be invented for the TypeScript trees.
     """
+    tag = re.compile(r"^\s*\*?\s*@packageDocumentation\s*$", re.M)
     for f in sorted([*path.glob("*.ts"), *path.glob("*.tsx")]):
         if ".test." in f.name:
             continue
         src = f.read_text(encoding="utf-8", errors="replace")
-        m = re.match(r"\s*/\*\*(.*?)\*/", src, re.S)
-        if m and "@packageDocumentation" in m.group(1):
-            body = m.group(1).replace("@packageDocumentation", "")
+        # Every block comment, not just the first: a file may explain itself up
+        # top and carry the directory's package doc in a later block. The tag
+        # must also sit on its own line — a substring test would match a comment
+        # that merely mentions @packageDocumentation in prose.
+        for m in re.finditer(r"/\*\*(.*?)\*/", src, re.S):
+            if not tag.search(m.group(1)):
+                continue
+            body = tag.sub("", m.group(1))
             lines = [ln.strip().lstrip("*").strip() for ln in body.splitlines()]
             text = " ".join(ln for ln in lines if ln)
             if text:


### PR DESCRIPTION
Mirrors a fix made in `rpg-build-optimizer`'s ported generator, where both flaws actually bit.

1. **The tag was matched by substring**, so a comment that merely *mentions* `@packageDocumentation` in prose counted as a package doc. In the sibling repo the generator's own header explains the tag — so `scripts/` adopted that header as its directory description.
2. **Only the first block comment per file was examined**, so a file that explains itself up top and carries the directory's package doc in a later block was silently skipped.

The tag must now sit on its own line, and every block comment is scanned.

## No output change here

`FILE-MAP.md` regenerates byte-identical — `gen_file_map.py --check` passes untouched — because this repo's tags were already placed correctly. This is pure robustness, applied so the three repos' generators don't drift apart.

`ruff check scripts` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)