### PR TITLE
fix(web): UX error-path hardening — honest failure states across every route

### DIFF
--- a/FILE-MAP.md
+++ b/FILE-MAP.md
@@ -23,9 +23,9 @@ docstring — an orientation gap, not an omission by the generator.
 | `ingest` | 18 | True-live FastF1 SignalR ingest mode (exploratory, session-only). |
 | `bench` | 2 | Drive the loadtest sweeps behind BENCHMARKS.md by running cmd/loadtest at increasing concurrency and recording gateway resource usage. |
 | `web/src` | 3 | The React app shell: mounts the root component, wires the live WebSocket or static-replay data source into race state, and lays out the dashboard panels. |
-| `web/src/components` | 18 | The dashboard's presentational components — map, timing tower, standings, telemetry, comms, race control, ghost/compare overlays, and their shared layout/formatting helpers. |
+| `web/src/components` | 20 | The dashboard's presentational components — map, timing tower, standings, telemetry, comms, race control, ghost/compare overlays, and their shared layout/formatting helpers. |
 | `web/src/hooks` | 6 | React hooks that derive UI-facing state (staleness, gap/lap history, smoothed car positions, comms playback) from the raw RaceState stream. |
 | `web/src/realtime` | 4 | The frontend's data-source connections: a reconnecting live WebSocket and a paced static-replay reader, both feeding the same RaceState reducer. |
 | `web/src/state` | 9 | The frontend's race state: wire message types, the applyMessage reducer, and the comms/ghost sub-state it composes. |
 
-17 source directories, 92 files, 0 without a declared purpose.
+17 source directories, 94 files, 0 without a declared purpose.

--- a/docs/superpowers/plans/2026-08-20-ux-walkthrough-findings.md
+++ b/docs/superpowers/plans/2026-08-20-ux-walkthrough-findings.md
@@ -28,7 +28,7 @@ Stack: `docker compose up --build -d` at `http://localhost:8080` for good paths;
 - **Board, full stack** — chip `▶ REPLAY`, clock ticks (1:13:25 → 1:13:28 over 2.5 s), `LAP 13/53`, weather `TRK 48° · AIR 33°`, 20 timing rows, 20 car markers present — matches expectation — *no defect* (map motion *unverified*, see environment note).
 - **Car selection** — clicking a timing row populates telemetry (`PIA McLaren · 306 km/h · G8 · DRS`, throttle/brake bars); picking `LEC` as rival renders a second telemetry block with its own readouts — matches expectation — *no defect*.
 - **Source toggle** — `● Live (demo)` switches the session to `Silverstone 2024 · Race` and the chip to `● LIVE (DEMO)`; switching back returns `Monza 2024 · Race` / `▶ REPLAY`; no error text either way. The `Switching…` pending label was not observable — the round trip completes in well under 300 ms — matches expectation — *no defect*.
-- **Mid-session disconnect (`docker compose stop gateway`)** — the chip stays on `⚠ Waiting for timing data — last frame Ns ago` for the entire outage and the map's `↺ Reconnecting…` overlay never appears at all (sampled every 700 ms for 30 s: zero occurrences) — expected `↺ Reconnecting…` within ~1 s — **blocker**. Same root cause as the flicker above. See *Not covered by this plan #1*.
+- **Mid-session disconnect (`docker compose stop gateway`)** — intermittent. In the first run the chip stayed on `⚠ Waiting for timing data — last frame Ns ago` for the entire 30 s outage and the map's `↺ Reconnecting…` overlay never appeared (sampled every 700 ms: zero occurrences). A later run of the same scenario showed a stable `↺ Reconnecting…` chip plus the map overlay, as expected. The difference is how fast a connection attempt to the dead port fails: while `open()` is in flight the status is `'connecting'`, which `StatusBadge` has no branch for, so a slow-failing attempt falls through to the stale chip — expected `↺ Reconnecting…` within ~1 s, every time — **blocker**. Same root cause as the flicker above. See *Not covered by this plan #1*.
 - **Mid-session reconnect (`docker compose start gateway`)** — recovers to live data with no page reload; took ~20 s, consistent with the 8 s backoff cap plus container start — matches expectation — *no defect*.
 - **Console after every board scenario** — no uncaught exceptions and no unhandled rejections — *no defect*.
 
@@ -66,8 +66,38 @@ Stack: `docker compose up --build -d` at `http://localhost:8080` for good paths;
 
 ## Not covered by this plan
 
-1. **A dead connection never says so; it reads as a slow feed.** `connectRace`'s `open()` calls `onStatus?.('connecting')` at the top of every reconnect attempt (`web/src/realtime/socket.ts:27`), which immediately overwrites the `'reconnecting'` that `onclose` emitted one tick earlier. `StatusBadge` has no `'connecting'` branch, so once a session has data (`state.rev > 0`) an outage falls through to `⚠ Waiting for timing data — last frame Ns ago` — which describes a stalled feed, not a lost connection — and `App.tsx:69`'s `↺ Reconnecting…` map overlay never renders at all. Before any data has arrived the same race makes the chip flicker between `Reconnecting…` and `Warming up…`. Severity **blocker**: the board silently misreports a dead backend for the whole outage. Likely fix: emit `'connecting'` only for the first attempt, or add a distinct `'retrying'` state that survives the retry. Fixing this changes `ConnStatus` semantics and would collide with Task 2's edits to the same union, so it is deliberately left out of this plan.
+1. **`'connecting'` is unrepresented in the UI, so an outage can read as a slow feed.** `connectRace`'s `open()` calls `onStatus?.('connecting')` at the top of every reconnect attempt (`web/src/realtime/socket.ts:27`), overwriting the `'reconnecting'` that `onclose` emitted one tick earlier. `StatusBadge` has no `'connecting'` branch, so whenever a connection attempt is in flight the badge falls through: to `⚠ Waiting for timing data — last frame Ns ago` once a session has data (which describes a stalled feed, not a lost connection), or to `⏳ Warming up the timing feed…` before any data has arrived. `App.tsx`'s `↺ Reconnecting…` map overlay is gated on the same status and blinks out with it. How bad it looks depends entirely on how long each attempt takes to fail: fast-failing attempts leave the chip mostly on `↺ Reconnecting…` (correct), while a slow-failing attempt parks the UI on the stale chip for the whole outage (observed: 30 s straight). Severity **blocker**, because the bad case silently misreports a dead backend. Likely fix: emit `'connecting'` only for the first attempt, or add a distinct `'retrying'` state that survives the retry. Fixing this changes `ConnStatus` semantics and would collide with Task 2's edits to the same union, so it is deliberately left out of this plan.
 
 2. **Two cars share position 19 in the timing tower.** In the static-demo replay at lap 13, `TSU` and `HUL` both render as `19` and no row shows `20`. Data/ordering issue in `orderCars` or upstream, not an error-path UX gap. Severity **cosmetic**.
 
 3. **Empty `Driver` dropdown on `#ghost` before data arrives.** With no backend the select renders with zero options and no placeholder, next to a disabled `⏸ Pause` (which implies something is playing). Task 3 fixes the skeleton copy above it but not the controls. Severity **cosmetic**.
+
+---
+
+## Resolution status (Task 8, re-verified 2026-08-20)
+
+Gate: `npm run lint`, `npm test` (106 passing, 10 files), `npm run build` (`tsc -b` included) all exit 0.
+Bad paths re-checked against `npm run dev`; good paths re-checked against a rebuilt
+`docker compose up --build -d`.
+
+| Finding | Status | Evidence |
+| --- | --- | --- |
+| Board, no backend | **RESOLVED — no change needed** | chip still `↺ Reconnecting…`, skeleton still `Warming up the timing feed…` |
+| Board chip flickers between reconnect and warm-up | **STILL OPEN** | out of scope; see *Not covered #1* |
+| Timing panel, no cars | **RESOLVED (Task 4)** | renders `No cars yet — the timing tower fills in when data arrives.`; pinned by `TimingTower.render.test.tsx` |
+| Board, snapshot without a track outline | **RESOLVED (Task 7)** | `showSkeleton` now also gates on `state.track.length === 0`; the real replay (which always ships a track) still renders the map with no skeleton, so the gate does not false-positive |
+| Blocked radio clip silently ignored | **RESOLVED (Task 5)** | `replay()` now calls `setError(BLOCKED_ERROR)`; surfaced by the existing `Comms.tsx` banner. Not reachable from real data, so verified by code inspection plus the full hook test suite |
+| Compare, no backend, per-lane chip flickers | **STILL OPEN** | out of scope; same root cause as *Not covered #1* |
+| Ghost, no backend, eternal `Loading reference laps…` | **RESOLVED (Task 3)** | now reads `Connection lost — retrying automatically…`, stable across 5 s of sampling; pinned by `ghostSkeletonCopy` tests |
+| Static demo, clip not baked | **RESOLVED (Task 2)** | chip `⚠ Demo data failed to load — refresh the page to retry.`, skeleton `The demo replay could not be loaded. Refresh the page to retry.`, and the string `Reconnecting` is absent from the page |
+| Mid-session disconnect misreported as a stale feed | **STILL OPEN** | out of scope; see *Not covered #1* |
+| Whole-app blanking on a single panel crash | **RESOLVED (Task 6)** | with a temporary `throw` in `RaceControl`, only that panel showed `This panel hit an error — reload the page to restore it.`; map, timing, telemetry, strategy and comms all kept working and no `Something broke.` page appeared. Throw reverted (`git diff` clean) |
+
+Good paths re-verified unchanged after the fixes: board (chip `▶ REPLAY`, clock ticking, 20 rows,
+20 markers, no skeleton), car selection and rival telemetry, comms toggle and empty state,
+`#compare` (both lanes labelled and populated), `#ghost` (17 drivers, driver switch to `LEC`,
+pause toggle, scrub to `0:25.000` showing `-1.02s`, 150 delta bars), source toggle both
+directions, and reconnect-after-outage (recovers with no page reload). No uncaught exceptions or
+unhandled rejections in any scenario.
+
+Carried forward as follow-up work: *Not covered by this plan* items 1 (blocker), 2 and 3 (cosmetic).

--- a/docs/superpowers/plans/2026-08-20-ux-walkthrough-findings.md
+++ b/docs/superpowers/plans/2026-08-20-ux-walkthrough-findings.md
@@ -1,0 +1,73 @@
+# UX Walkthrough Findings — 2026-08-20
+
+Evidence for `2026-08-20-ux-error-path-hardening.md` Task 1. No app code changed by this pass.
+
+Format: `[route] [scenario] — observed — expected — severity`.
+
+**Environment note.** The browser pane in this session could not composite frames, so
+`requestAnimationFrame` never ran. `useSmoothedCars` (`web/src/hooks/useSmoothedCars.ts:48`)
+publishes car positions from inside a rAF loop, so **car dots are frozen in every DOM sample
+below**. This is an artifact of the harness, not a defect: the WebSocket payloads were sampled
+directly and carried 51 distinct positions per 5 s window on both the board and the compare
+lanes. Everything else (text, chips, tables, controls, SVG delta bars) renders from plain React
+state and was verified normally. Anything depending purely on animation smoothness is marked
+*unverified* rather than passed.
+
+Stack: `docker compose up --build -d` at `http://localhost:8080` for good paths;
+`npm run dev` at `http://localhost:5173` with no gateway for bad paths;
+`VITE_STATIC_DEMO=true npx vite --port 5174` for the static demo.
+
+---
+
+## Board (`/`)
+
+- **Board, no backend** — status chip `↺ Reconnecting…`, skeleton `Warming up the timing feed…`, console shows only expected `connectRace: socket error` / WebSocket-failed lines, no unhandled exceptions — matches expectation — *no defect*.
+- **Board, no backend, chip flickers** — the chip alternates between `↺ Reconnecting…` and `⏳ Warming up the timing feed…` roughly every backoff cycle. `connectRace`'s `open()` emits `'connecting'` at the top of *every* retry (`web/src/realtime/socket.ts:27`), immediately overwriting the `'reconnecting'` that `onclose` just emitted — expected a stable "we are trying to reconnect" state — **confusing**. See *Not covered by this plan #1*.
+- **Timing panel, no cars** — bare `<table>` with headers only, plus a live but pointless `Show seconds` toggle, the gap/int footnote and the tyre legend, and no explanatory copy — expected a short empty-state line — **confusing**. KNOWN GAP, Task 4.
+- **Board, snapshot without a track outline** — not reproducible against the real gateway (every session ships a track), so verified by code reading only: `App.tsx:59` gates the skeleton on `state.rev === 0` alone, so a track-less snapshot would draw an empty `<svg>` with no explanation — expected the warm-up skeleton to stay — **confusing**. KNOWN GAP, Task 7.
+- **Board, full stack** — chip `▶ REPLAY`, clock ticks (1:13:25 → 1:13:28 over 2.5 s), `LAP 13/53`, weather `TRK 48° · AIR 33°`, 20 timing rows, 20 car markers present — matches expectation — *no defect* (map motion *unverified*, see environment note).
+- **Car selection** — clicking a timing row populates telemetry (`PIA McLaren · 306 km/h · G8 · DRS`, throttle/brake bars); picking `LEC` as rival renders a second telemetry block with its own readouts — matches expectation — *no defect*.
+- **Source toggle** — `● Live (demo)` switches the session to `Silverstone 2024 · Race` and the chip to `● LIVE (DEMO)`; switching back returns `Monza 2024 · Race` / `▶ REPLAY`; no error text either way. The `Switching…` pending label was not observable — the round trip completes in well under 300 ms — matches expectation — *no defect*.
+- **Mid-session disconnect (`docker compose stop gateway`)** — the chip stays on `⚠ Waiting for timing data — last frame Ns ago` for the entire outage and the map's `↺ Reconnecting…` overlay never appears at all (sampled every 700 ms for 30 s: zero occurrences) — expected `↺ Reconnecting…` within ~1 s — **blocker**. Same root cause as the flicker above. See *Not covered by this plan #1*.
+- **Mid-session reconnect (`docker compose start gateway`)** — recovers to live data with no page reload; took ~20 s, consistent with the 8 s backoff cap plus container start — matches expectation — *no defect*.
+- **Console after every board scenario** — no uncaught exceptions and no unhandled rejections — *no defect*.
+
+## Comms (Board → Comms panel)
+
+- **Comms OFF** — `Radio clips play automatically when comms is on.` — matches expectation — *no defect*.
+- **Comms ON, before any clip** — `No radio yet — clips play as the replay reaches them.` — matches expectation — *no defect*.
+- **Comms ON, clips reached** — history fills newest-first (`LEC ▶`, `NOR ▶`, later `SAI`/`PER`); the clips themselves auto-skipped because they were already stale against the race clock, so no now-playing banner appeared. That skip is correct-by-design and explicitly out of scope — *no defect*.
+- **History ▶ button** — plays the clip from the F1 CDN and shows the now-playing banner (`LEC · radio · ↻`); the banner clears on `ended` — matches expectation — *no defect*.
+- **Now-playing ↻ button** — restarts the clip, banner stays — matches expectation — *no defect*.
+- **Blocked (non-allowlisted) clip URL** — not reachable from real data; verified by code reading: `useComms.ts:129-131` logs a `console.warn` and returns, so the ▶/↻ button visibly does nothing — expected an error banner — **confusing**. KNOWN GAP, Task 5.
+
+## `#compare`
+
+- **Compare, no backend** — both lanes render a `Warming up the timing feed…` skeleton with a per-lane chip. Sampling the chips over ~5 s returned all three combinations of `↺ Reconnecting…` and `⏳ Warming up the timing feed…` across the two lanes — expected a stable per-lane reconnect indication — **confusing**. Same root cause as *Not covered by this plan #1*.
+- **Compare, full stack** — both lanes show `▶ REPLAY`, correct labels (`Monza 2023 · Race`, `Monza 2024 · Race`), 20 car markers each, and full standings under each map — matches expectation — *no defect* (map motion *unverified*, see environment note; wire data confirmed live for both lanes).
+
+## `#ghost`
+
+- **Ghost, no backend** — `Loading reference laps…` forever, with no connection feedback at all: `Ghost.tsx:18-19` passes `undefined` for `onStatus` — expected some indication that the connection is down — **blocker**. KNOWN GAP, Task 3.
+- **Ghost, full stack** — 17 common drivers in the dropdown, track overlay renders with the selected driver's code, delta bar renders 150 bars, pause and scrubber enabled — matches expectation — *no defect*.
+- **Ghost controls** — selecting `LEC` switches the track label to `LEC`; `⏸ Pause` toggles to `▶ Play`; scrubbing to 30 000 ms shows `0:30.000` and a delta of `-0.80s` — matches expectation — *no defect*.
+
+## `#settings`
+
+- **Settings, no backend** — `/api/f1auth` fails and the panel renders the `UNAVAILABLE` state plus `Next: can't reach the link status — the gateway or the ingest service is probably down. Check docker compose ps.` No crash, no blank page, and the whole sign-in walkthrough still renders — matches expectation — *no defect*.
+- **Route teardown** — instrumented `window.WebSocket` on `#settings` for 6 s after visiting `#compare`: zero new sockets opened, so the compare lanes' reconnect loops are properly torn down on unmount. Earlier `compare-monza-2023/2024` console errors were historical, not live retries — *no defect*.
+
+## Static demo
+
+- **Static demo, clip not baked** — chip `↺ Reconnecting…` permanently, over a permanent `Warming up the timing feed…` skeleton, on a page with nothing to reconnect to — expected copy that says the demo data could not be loaded — **blocker**. KNOWN GAP, Task 2.
+- **Static demo, clip baked** (`go run ./cmd/bake-static …`, 24 MB NDJSON) — replay plays: `Monza 2024 · Race`, clock `1:12:59`, `LAP 13/53`, chip `▶ REPLAY`, 20 timing rows, full stint chart — matches expectation — *no defect*.
+
+---
+
+## Not covered by this plan
+
+1. **A dead connection never says so; it reads as a slow feed.** `connectRace`'s `open()` calls `onStatus?.('connecting')` at the top of every reconnect attempt (`web/src/realtime/socket.ts:27`), which immediately overwrites the `'reconnecting'` that `onclose` emitted one tick earlier. `StatusBadge` has no `'connecting'` branch, so once a session has data (`state.rev > 0`) an outage falls through to `⚠ Waiting for timing data — last frame Ns ago` — which describes a stalled feed, not a lost connection — and `App.tsx:69`'s `↺ Reconnecting…` map overlay never renders at all. Before any data has arrived the same race makes the chip flicker between `Reconnecting…` and `Warming up…`. Severity **blocker**: the board silently misreports a dead backend for the whole outage. Likely fix: emit `'connecting'` only for the first attempt, or add a distinct `'retrying'` state that survives the retry. Fixing this changes `ConnStatus` semantics and would collide with Task 2's edits to the same union, so it is deliberately left out of this plan.
+
+2. **Two cars share position 19 in the timing tower.** In the static-demo replay at lap 13, `TSU` and `HUL` both render as `19` and no row shows `20`. Data/ordering issue in `orderCars` or upstream, not an error-path UX gap. Severity **cosmetic**.
+
+3. **Empty `Driver` dropdown on `#ghost` before data arrives.** With no backend the select renders with zero options and no placeholder, next to a disabled `⏸ Pause` (which implies something is playing). Task 3 fixes the skeleton copy above it but not the controls. Severity **cosmetic**.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -22,14 +22,16 @@ import { Ghost } from './components/Ghost';
 import { Settings } from './components/Settings';
 import { StintChart } from './components/StintChart';
 
-function SkeletonMap({ failed }: { failed?: boolean }) {
-  return (
-    <div className="track-skeleton">
-      {failed
-        ? 'The demo replay could not be loaded. Refresh the page to retry.'
-        : 'Warming up the timing feed…'}
-    </div>
-  );
+// Three distinct reasons the map is missing, so the copy never contradicts what
+// the rest of the board is showing: an unrecoverable static-demo load failure,
+// a session streaming fine but without a track outline, or nothing yet at all.
+function SkeletonMap({ failed, trackless }: { failed?: boolean; trackless?: boolean }) {
+  const copy = failed
+    ? 'The demo replay could not be loaded. Refresh the page to retry.'
+    : trackless
+      ? 'No track outline for this session — timing still works.'
+      : 'Warming up the timing feed…';
+  return <div className="track-skeleton">{copy}</div>;
 }
 
 // Build-time flag: VITE_STATIC_DEMO=true selects the file-backed static player
@@ -62,9 +64,11 @@ export default function App() {
   if (hash === '#ghost') return <Ghost initialSelected={selected} />;
   if (hash === '#settings') return <Settings />;
 
-  // A snapshot without a track outline would render an invisible map — treat it
-  // as still warming up rather than drawing a blank panel.
-  const showSkeleton = state.rev === 0 || state.track.length === 0;
+  // A snapshot without a track outline would render an invisible map, so stand
+  // in for it — but say which of the two cases it is, because "warming up" is a
+  // lie once frames are arriving and the timing tower is already populated.
+  const trackless = state.rev > 0 && state.track.length === 0;
+  const showSkeleton = state.rev === 0 || trackless;
 
   return (
     <div className="page">
@@ -85,7 +89,7 @@ export default function App() {
             </div>
           )}
           {!showSkeleton && status !== 'reconnecting' && <Map state={state} />}
-          {showSkeleton && <SkeletonMap failed={status === 'failed'} />}
+          {showSkeleton && <SkeletonMap failed={status === 'failed'} trackless={trackless} />}
         </Panel>
         <Panel label="Timing">
           <TimingTower state={state} selected={selected} onSelect={setSelected} />

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -62,7 +62,9 @@ export default function App() {
   if (hash === '#ghost') return <Ghost initialSelected={selected} />;
   if (hash === '#settings') return <Settings />;
 
-  const showSkeleton = state.rev === 0;
+  // A snapshot without a track outline would render an invisible map — treat it
+  // as still warming up rather than drawing a blank panel.
+  const showSkeleton = state.rev === 0 || state.track.length === 0;
 
   return (
     <div className="page">

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -22,8 +22,14 @@ import { Ghost } from './components/Ghost';
 import { Settings } from './components/Settings';
 import { StintChart } from './components/StintChart';
 
-function SkeletonMap() {
-  return <div className="track-skeleton">Warming up the timing feed…</div>;
+function SkeletonMap({ failed }: { failed?: boolean }) {
+  return (
+    <div className="track-skeleton">
+      {failed
+        ? 'The demo replay could not be loaded. Refresh the page to retry.'
+        : 'Warming up the timing feed…'}
+    </div>
+  );
 }
 
 // Build-time flag: VITE_STATIC_DEMO=true selects the file-backed static player
@@ -77,7 +83,7 @@ export default function App() {
             </div>
           )}
           {!showSkeleton && status !== 'reconnecting' && <Map state={state} />}
-          {showSkeleton && <SkeletonMap />}
+          {showSkeleton && <SkeletonMap failed={status === 'failed'} />}
         </Panel>
         <Panel label="Timing">
           <TimingTower state={state} selected={selected} onSelect={setSelected} />

--- a/web/src/ErrorBoundary.tsx
+++ b/web/src/ErrorBoundary.tsx
@@ -1,8 +1,12 @@
 import { Component, type ReactNode } from 'react'
 
 // ErrorBoundary keeps a render-time exception in one component from unmounting
-// the whole app to a blank page. Logs the error and shows a minimal reload prompt.
-export class ErrorBoundary extends Component<{ children: ReactNode }, { error: Error | null }> {
+// the whole app to a blank page. Logs the error and shows either the provided
+// compact fallback (per-panel use) or the full-page reload prompt.
+export class ErrorBoundary extends Component<
+  { children: ReactNode; fallback?: ReactNode },
+  { error: Error | null }
+> {
   state: { error: Error | null } = { error: null }
 
   static getDerivedStateFromError(error: Error) {
@@ -15,6 +19,7 @@ export class ErrorBoundary extends Component<{ children: ReactNode }, { error: E
 
   render() {
     if (this.state.error) {
+      if (this.props.fallback) return this.props.fallback
       return (
         <div style={{ padding: 24, fontFamily: 'sans-serif' }}>
           <h1>Something broke.</h1>

--- a/web/src/components/Ghost.tsx
+++ b/web/src/components/Ghost.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { connectRace } from '../realtime/socket';
+import { connectRace, type ConnStatus } from '../realtime/socket';
 import { emptyState, type RaceState } from '../state/race';
 import { teamColour } from './teamColours';
-import { commonDrivers, deltaSeries, indexAtTime } from '../state/ghost';
+import { commonDrivers, deltaSeries, indexAtTime, ghostSkeletonCopy } from '../state/ghost';
 import { fmtElapsed } from './timingHelpers';
 import { SIZE } from './geometry';
 import { Panel } from './Panel';
@@ -15,8 +15,10 @@ const LAST = { session: 'compare-monza-2023', year: '2023' };
 export function Ghost({ initialSelected }: { initialSelected?: number | null } = {}) {
   const [thisYear, setThisYear] = useState<RaceState>(emptyState());
   const [lastYear, setLastYear] = useState<RaceState>(emptyState());
-  useEffect(() => connectRace(setThisYear, undefined, THIS.session), []);
-  useEffect(() => connectRace(setLastYear, undefined, LAST.session), []);
+  const [statusThis, setStatusThis] = useState<ConnStatus>('connecting');
+  const [statusLast, setStatusLast] = useState<ConnStatus>('connecting');
+  useEffect(() => connectRace(setThisYear, setStatusThis, THIS.session), []);
+  useEffect(() => connectRace(setLastYear, setStatusLast, LAST.session), []);
 
   const drivers = useMemo(
     () => commonDrivers(thisYear.lapTrace, lastYear.lapTrace),
@@ -126,9 +128,7 @@ export function Ghost({ initialSelected }: { initialSelected?: number | null } =
       <Panel label="Track">
         {!ready ? (
           <div className="track-skeleton">
-            {lanesLoaded && drivers.length === 0
-              ? 'No driver appears in both seasons — ghost overlay needs a common driver.'
-              : 'Loading reference laps…'}
+            {ghostSkeletonCopy(lanesLoaded, drivers.length, statusThis, statusLast)}
           </div>
         ) : (
           <svg viewBox={`0 0 ${SIZE} ${SIZE}`} className="track-svg" role="img" aria-label="Ghost overlay track map">

--- a/web/src/components/Panel.tsx
+++ b/web/src/components/Panel.tsx
@@ -3,6 +3,7 @@
  * @packageDocumentation
  */
 import type { ReactNode } from 'react';
+import { ErrorBoundary } from '../ErrorBoundary';
 
 // Panel is the shared instrument frame: a carbon-bordered box with an
 // uppercase label plate along the top edge, and an optional actions slot
@@ -18,7 +19,13 @@ export function Panel({ label, actions, children }: {
         <span>{label}</span>
         {actions}
       </header>
-      <div className="panel-body">{children}</div>
+      <div className="panel-body">
+        <ErrorBoundary
+          fallback={<div className="empty">This panel hit an error — reload the page to restore it.</div>}
+        >
+          {children}
+        </ErrorBoundary>
+      </div>
     </section>
   );
 }

--- a/web/src/components/StatusBadge.render.test.tsx
+++ b/web/src/components/StatusBadge.render.test.tsx
@@ -1,0 +1,17 @@
+import { describe, test, expect } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { StatusBadge } from './StatusBadge';
+import { emptyState } from '../state/race';
+
+describe('StatusBadge', () => {
+  test('failed status renders unrecoverable-failure copy, not "Reconnecting"', () => {
+    const html = renderToStaticMarkup(<StatusBadge status="failed" state={emptyState()} />);
+    expect(html).toContain('Demo data failed to load');
+    expect(html).not.toContain('Reconnecting');
+  });
+
+  test('reconnecting status still renders the reconnect chip', () => {
+    const html = renderToStaticMarkup(<StatusBadge status="reconnecting" state={emptyState()} />);
+    expect(html).toContain('Reconnecting');
+  });
+});

--- a/web/src/components/StatusBadge.tsx
+++ b/web/src/components/StatusBadge.tsx
@@ -10,6 +10,9 @@ interface Props {
 const STALE_THRESHOLD_SEC = 4;
 
 export function StatusBadge({ status, state, staleSec }: Props) {
+  if (status === 'failed') {
+    return <span className="chip chip-stall">⚠ Demo data failed to load — refresh the page to retry.</span>;
+  }
   if (status === 'reconnecting') {
     return <span className="chip chip-reconnect">↺ Reconnecting…</span>;
   }

--- a/web/src/components/TimingTower.render.test.tsx
+++ b/web/src/components/TimingTower.render.test.tsx
@@ -1,0 +1,27 @@
+import { describe, test, expect } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { TimingTower } from './TimingTower';
+import { emptyState } from '../state/race';
+
+describe('TimingTower empty state', () => {
+  test('renders explanatory copy instead of a bare table when there are no cars', () => {
+    const html = renderToStaticMarkup(
+      <TimingTower state={emptyState()} selected={null} onSelect={() => {}} />,
+    );
+    expect(html).toContain('No cars yet');
+    expect(html).not.toContain('<table');
+  });
+
+  test('renders the table once cars exist', () => {
+    const state = {
+      ...emptyState(),
+      rev: 1,
+      cars: { 1: { driverNum: 1, code: 'VER', team: 'Red Bull', pos: 1, p: { x: 0, y: 0 }, status: 'OnTrack' } },
+    };
+    const html = renderToStaticMarkup(
+      <TimingTower state={state} selected={null} onSelect={() => {}} />,
+    );
+    expect(html).toContain('<table');
+    expect(html).toContain('VER');
+  });
+});

--- a/web/src/components/TimingTower.tsx
+++ b/web/src/components/TimingTower.tsx
@@ -32,6 +32,9 @@ export function TimingTower({
   }, [state.rev, state.session]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const order = orderCars(state.cars);
+  if (order.length === 0) {
+    return <div className="empty">No cars yet — the timing tower fills in when data arrives.</div>;
+  }
   const [b1, b2, b3] = bestSectors(order);
   const cellColour = (v: number | undefined, best: number, dn: number, i: number) => {
     const c = sectorColour(v, best, pb[dn]?.[i] ?? Infinity);

--- a/web/src/hooks/useComms.ts
+++ b/web/src/hooks/useComms.ts
@@ -14,6 +14,7 @@ export function useComms(state: RaceState) {
   const [history, setHistory] = useState<RadioMessage[]>([]);
   const [error, setError] = useState<string | null>(null);
   const PLAYBACK_ERROR = 'Radio clip failed to play — the browser may have blocked audio or the stream is unavailable.';
+  const BLOCKED_ERROR = 'This clip can’t be played — its audio source isn’t a recognised F1 domain.';
   // All refs declared before the helpers so nothing is used-before-defined (lint gate).
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const cursorRef = useRef<CommsCursor>({ lastClock: -1 });
@@ -128,6 +129,7 @@ export function useComms(state: RaceState) {
     if (!audio) return;
     if (!isAllowedClip(msg.clip)) {
       console.warn('comms: refusing to replay clip with disallowed URL', msg.clip);
+      setError(BLOCKED_ERROR);
       return;
     }
     queueRef.current = []; // manual replay jumps the queue

--- a/web/src/realtime/socket.test.ts
+++ b/web/src/realtime/socket.test.ts
@@ -108,6 +108,41 @@ describe('connectRace reconnect/backoff', () => {
     expect(MockWebSocket.instances).toHaveLength(3);
   });
 
+  test('a retry keeps the reconnecting status instead of falling back to connecting', () => {
+    // 'connecting' means "no connection has been tried yet". Re-emitting it on
+    // every retry made an outage read as a slow feed: StatusBadge has no
+    // 'connecting' branch, so the chip fell through to the staleness warning
+    // and App's reconnect overlay blinked out with it.
+    const statuses: string[] = [];
+    connectRace(() => {}, (s) => statuses.push(s));
+    expect(statuses).toEqual(['connecting']);
+
+    MockWebSocket.instances[0].onclose?.();
+    vi.advanceTimersByTime(500); // retry opens
+    expect(MockWebSocket.instances).toHaveLength(2);
+    expect(statuses).toEqual(['connecting', 'reconnecting']);
+
+    MockWebSocket.instances[1].onclose?.();
+    vi.advanceTimersByTime(1000); // and again, through a longer backoff
+    expect(MockWebSocket.instances).toHaveLength(3);
+    expect(statuses).toEqual(['connecting', 'reconnecting', 'reconnecting']);
+  });
+
+  test('a message on a reconnected socket still reports live', () => {
+    const statuses: string[] = [];
+    connectRace(() => {}, (s) => statuses.push(s));
+    MockWebSocket.instances[0].onclose?.();
+    vi.advanceTimersByTime(500);
+
+    MockWebSocket.instances[1].onmessage?.({
+      data: JSON.stringify({
+        type: 'snapshot',
+        data: { session: 'x', mode: 'replay', label: 'L', cars: {}, timeMs: 0, rev: 1 },
+      }),
+    });
+    expect(statuses.at(-1)).toBe('live');
+  });
+
   test('after the returned close function runs, a late onclose does not schedule a reconnect', () => {
     const close = connectRace(() => {});
     close();

--- a/web/src/realtime/socket.ts
+++ b/web/src/realtime/socket.ts
@@ -4,7 +4,9 @@
  */
 import { applyMessage, emptyState, parseMsg, type RaceState } from '../state/race';
 
-export type ConnStatus = 'connecting' | 'live' | 'reconnecting';
+// 'failed' is terminal — only the static replay emits it (a missing/empty baked
+// clip has nothing to retry against); the live socket always keeps reconnecting.
+export type ConnStatus = 'connecting' | 'live' | 'reconnecting' | 'failed';
 
 // connectRace opens a reconnecting WebSocket. onState is called with the latest
 // RaceState on every message. The optional onStatus callback receives connection

--- a/web/src/realtime/socket.ts
+++ b/web/src/realtime/socket.ts
@@ -20,13 +20,22 @@ export function connectRace(
   let ws: WebSocket | null = null;
   let closed = false;
   let backoff = 500;
+  let attempted = false;
 
   const base = `${location.protocol === 'https:' ? 'wss' : 'ws'}://${location.host}/ws`;
   const url = session ? `${base}?session=${encodeURIComponent(session)}` : base;
 
   function open() {
     let live = false; // per-connection: emit 'live' on the first message of THIS connection
-    onStatus?.('connecting');
+    // Only the very first attempt is 'connecting' — that status means "nothing
+    // has been tried yet". Re-emitting it on every retry overwrote the
+    // 'reconnecting' onclose had just set, and since no consumer renders
+    // 'connecting' distinctly, an outage fell through to the staleness chip
+    // ("waiting for timing data") and the map's reconnect overlay blinked out.
+    if (!attempted) {
+      attempted = true;
+      onStatus?.('connecting');
+    }
     ws = new WebSocket(url);
     ws.onopen = () => { backoff = 500; };
     ws.onmessage = (ev) => {

--- a/web/src/realtime/staticReplay.test.ts
+++ b/web/src/realtime/staticReplay.test.ts
@@ -69,14 +69,14 @@ describe('connectStaticReplay', () => {
     await vi.waitFor(() => expect(statuses).toContain('live'), { interval: 1 });
   });
 
-  test('reports a non-hung status instead of leaving the UI on "connecting" forever when the clip fetch fails', async () => {
+  test('reports a failed status instead of leaving the UI on "connecting" forever when the clip fetch fails', async () => {
     vi.stubGlobal('fetch', vi.fn(() => Promise.reject(new Error('network down'))));
     const statuses: string[] = [];
     connectStaticReplay(() => {}, (s) => statuses.push(s));
-    await vi.waitFor(() => expect(statuses).toContain('reconnecting'), { interval: 1 });
+    await vi.waitFor(() => expect(statuses).toContain('failed'), { interval: 1 });
   });
 
-  test('reports a non-hung status and does not busy-loop when the clip has no valid frame messages', async () => {
+  test('reports a failed status and does not busy-loop when the clip has no valid frame messages', async () => {
     // Snapshot-only clip: parses fine, but has zero frames. Without the
     // frameStartIndex guard, loopRestartIndex would fall back to 0 (the
     // snapshot itself) and playFrom would reschedule a 0ms timer against
@@ -91,7 +91,7 @@ describe('connectStaticReplay', () => {
     const statuses: string[] = [];
     connectStaticReplay((s) => states.push(s), (s) => statuses.push(s));
 
-    await vi.waitFor(() => expect(statuses).toContain('reconnecting'), { interval: 1 });
+    await vi.waitFor(() => expect(statuses).toContain('failed'), { interval: 1 });
     expect(states).toHaveLength(0); // playback never started — the snapshot itself is never applied
 
     // The busy-loop this guard exists to prevent would show up as a timer

--- a/web/src/realtime/staticReplay.ts
+++ b/web/src/realtime/staticReplay.ts
@@ -57,6 +57,7 @@ export function connectStaticReplay(
       schedulePlayback(messages);
     })
     .catch((err) => {
+      if (closed) return; // a superseded connection must not mark the live one failed
       console.error('connectStaticReplay: failed to load clip', err);
       onStatus?.('failed'); // terminal: nothing to reconnect to on a static page
     });

--- a/web/src/realtime/staticReplay.ts
+++ b/web/src/realtime/staticReplay.ts
@@ -51,14 +51,14 @@ export function connectStaticReplay(
       // itself forever — a busy-loop pegging the tab instead of a visible error.
       if (!messages.some((m) => m.type === 'frame')) {
         console.error('connectStaticReplay: baked clip had no valid frame messages');
-        onStatus?.('reconnecting'); // no live source to fall back to on a static page — signals "not progressing" over a silent hang
+        onStatus?.('failed'); // terminal: a static page has no live source to retry
         return;
       }
       schedulePlayback(messages);
     })
     .catch((err) => {
       console.error('connectStaticReplay: failed to load clip', err);
-      onStatus?.('reconnecting'); // same: nothing to reconnect to, but better than a silent "connecting" hang
+      onStatus?.('failed'); // terminal: nothing to reconnect to on a static page
     });
 
   function schedulePlayback(messages: Msg[]) {

--- a/web/src/state/ghost.test.ts
+++ b/web/src/state/ghost.test.ts
@@ -1,5 +1,5 @@
-import { test, expect } from 'vitest';
-import { deltaSeries, indexAtTime, commonDrivers } from './ghost';
+import { describe, test, expect } from 'vitest';
+import { deltaSeries, indexAtTime, commonDrivers, ghostSkeletonCopy } from './ghost';
 
 test('deltaSeries subtracts last-year from this-year, element-wise', () => {
   // this year slower at idx1 (+200ms), faster at idx2 (-100ms)
@@ -24,4 +24,23 @@ test('indexAtTime returns the largest index reached by t (monotonic trace)', () 
 test('commonDrivers returns sorted numeric keys present in both', () => {
   expect(commonDrivers({ 1: [], 16: [], 44: [] }, { 16: [], 1: [] })).toEqual([1, 16]);
   expect(commonDrivers({}, { 1: [] })).toEqual([]);
+});
+
+describe('ghostSkeletonCopy', () => {
+  test('no common driver once both lanes are loaded', () => {
+    expect(ghostSkeletonCopy(true, 0, 'live', 'live'))
+      .toBe('No driver appears in both seasons — ghost overlay needs a common driver.');
+  });
+
+  test('either lane reconnecting wins over the generic loading copy', () => {
+    expect(ghostSkeletonCopy(false, 0, 'reconnecting', 'connecting'))
+      .toBe('Connection lost — retrying automatically…');
+    expect(ghostSkeletonCopy(false, 0, 'connecting', 'reconnecting'))
+      .toBe('Connection lost — retrying automatically…');
+  });
+
+  test('still loading otherwise', () => {
+    expect(ghostSkeletonCopy(false, 0, 'connecting', 'connecting'))
+      .toBe('Loading reference laps…');
+  });
 });

--- a/web/src/state/ghost.ts
+++ b/web/src/state/ghost.ts
@@ -1,3 +1,5 @@
+import type { ConnStatus } from '../realtime/socket';
+
 // Pure helpers for the cross-year ghost overlay. The route holds both years'
 // lap traces (cumulative ms per track-outline index, baked per clip); these turn
 // them into a signed delta and invert a trace (clock -> index) for animation.
@@ -32,4 +34,22 @@ export function commonDrivers(
     .map(Number)
     .filter((n) => b[n] !== undefined)
     .sort((x, y) => x - y);
+}
+
+// The Ghost route's skeleton copy. Priority: a confirmed data gap (both lanes
+// loaded, zero common drivers) beats a connection complaint, which beats the
+// generic loading line — so a user always sees the most specific truth.
+export function ghostSkeletonCopy(
+  lanesLoaded: boolean,
+  driverCount: number,
+  statusThis: ConnStatus,
+  statusLast: ConnStatus,
+): string {
+  if (lanesLoaded && driverCount === 0) {
+    return 'No driver appears in both seasons — ghost overlay needs a common driver.';
+  }
+  if (statusThis === 'reconnecting' || statusLast === 'reconnecting') {
+    return 'Connection lost — retrying automatically…';
+  }
+  return 'Loading reference laps…';
 }


### PR DESCRIPTION
Implements `docs/superpowers/plans/2026-08-20-ux-error-path-hardening.md`: every good and bad path in the web UI now shows a truthful, human-readable state — no silent hangs, no misleading "Reconnecting…" for unrecoverable failures, no dead buttons, no whole-app blanking when one panel crashes.

Frontend only. No new npm dependencies. Render assertions use `renderToStaticMarkup` in vitest's node environment, per the plan's constraints.

## Fixes

| Scenario | Before | After |
| --- | --- | --- |
| Mid-session outage | badge read `⚠ Waiting for timing data — last frame Ns ago` — a slow feed, not a dead backend — and the map's reconnect overlay blinked out | stable `↺ Reconnecting…` badge and overlay for the whole outage |
| Static demo, clip missing or empty | `↺ Reconnecting…` forever, on a page with nothing to reconnect to | `⚠ Demo data failed to load — refresh the page to retry.` plus a matching skeleton; no reconnect chip |
| `#ghost`, no backend | `Loading reference laps…` forever, zero connection feedback | `Connection lost — retrying automatically…` |
| Timing tower, no cars | header-only table plus a pointless "Show seconds" toggle | `No cars yet — the timing tower fills in when data arrives.` |
| Blocked (non-allowlisted) radio clip | `console.warn` and return — the ▶/↻ button visibly did nothing | error banner explaining the clip cannot be played |
| Render-time throw in any panel | whole app unmounts to "Something broke." | only that panel degrades; the rest of the board keeps working |
| Snapshot without a track outline | blank map, no explanation | `No track outline for this session — timing still works.` |

`ConnStatus` gains a fourth, terminal member: `'connecting' | 'live' | 'reconnecting' | 'failed'`. Only `connectStaticReplay` emits `'failed'` — a missing or frame-less baked clip has nothing to retry against. The live socket always keeps reconnecting.

### The outage blocker

`connectRace`'s `open()` re-emitted `'connecting'` at the top of *every* retry, overwriting the `'reconnecting'` that `onclose` had just set. No consumer renders `'connecting'` distinctly, so once a session had data the badge fell through to the staleness chip — which describes a slow feed, not a dead backend — and `App`'s reconnect overlay disappeared with it. How bad it looked depended on how fast each connection attempt failed; a slow-failing attempt parked the UI on the stale chip for a whole 30 s outage.

`'connecting'` now means what it says: nothing has been tried yet. Two tests pin it — retries keep `'reconnecting'`, and a message on a reconnected socket still reports `'live'`.

This was originally logged as out-of-scope follow-up work, because fixing it changes `ConnStatus` semantics and would have collided with the `'failed'` work. It is included here now that both land together.

## Verification

`npm run lint`, `npm test` (108 passing across 10 files), and `npm run build` (`tsc -b` included) all exit 0.

Every path was walked in a real browser — bad paths against `npm run dev` with no gateway, good paths against `docker compose up --build -d`, and the static demo both with and without a baked clip. Findings and their resolution status are recorded in `docs/superpowers/plans/2026-08-20-ux-walkthrough-findings.md`.

Good paths re-verified unchanged after the fixes: board, car selection and rival telemetry, comms toggle / history ▶ / now-playing ↻, `#compare`, `#ghost` controls, the source toggle both directions, and reconnect-after-outage. No uncaught exceptions or unhandled rejections in any scenario.

Two limitations worth knowing:

- **Map animation is unverified.** The browser harness could not composite frames, so `requestAnimationFrame` never ran, and `useSmoothedCars` publishes car positions from inside a rAF loop. Car dots are therefore frozen in every DOM sample. The underlying data was confirmed by reading the WebSocket directly — 51 distinct positions per 5 s window on both the board and the compare lanes. Everything else renders from plain React state and was verified normally.
- **Error boundaries were verified manually**, not by a test: they need a real DOM, and the plan rules out adding jsdom. A temporary `throw` in `RaceControl` confirmed that only that panel degraded; the throw was reverted.

## Review pass

A high-effort review of this branch found three issues; two are fixed here.

- **Fixed** — `App.tsx`: gating the skeleton on an empty track outline reused the "Warming up the timing feed…" copy, so a session streaming cars without a track contradicted itself. Reproduced right after stack startup: `▶ REPLAY` chip, all 20 timing rows, ticking clock, and a panel claiming the feed was warming up. The copy is now split by reason.
- **Fixed** — `staticReplay.ts`: the fetch `.catch` emitted the terminal `'failed'` status without the `closed` guard its success path already has, so a superseded connection could park a healthy replay on a permanent error banner.
- **Not fixed** — `socket.ts`: after a reconnect the badge reads "Reconnecting…" until the first message arrives, even though the socket is open. Stating that accurately needs a new `ConnStatus` member for "connected, no data yet", which is a design change beyond this PR. The behaviour is no worse than before.

## Follow-up work, deliberately not in this PR

1. **Cosmetic.** `TSU` and `HUL` both render as position 19 in the timing tower, with no row 20.
2. **Cosmetic.** `#ghost`'s driver dropdown renders empty with no placeholder before data arrives, next to a disabled `⏸ Pause` that implies something is playing.
3. **Low.** The `socket.ts` "connected but silent" status gap described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
