### PR TITLE
fix(web): the three follow-ups from the UX error-path walkthrough

### DIFF
--- a/web/src/components/Ghost.tsx
+++ b/web/src/components/Ghost.tsx
@@ -166,8 +166,11 @@ export function Ghost({ initialSelected }: { initialSelected?: number | null } =
           <select
             value={resolvedSelected ?? ''}
             onChange={(e) => setSelected(Number(e.target.value))}
+            disabled={drivers.length === 0}
             style={{ background: 'var(--asphalt)', color: 'var(--chalk)', border: '1px solid var(--edge)', padding: '4px 8px', borderRadius: 4 }}
           >
+            {/* An empty dropdown reads as "no drivers exist"; say we are waiting instead. */}
+            {drivers.length === 0 && <option value="">Waiting for driver data…</option>}
             {drivers.map((n) => {
               const c = thisYear.cars[n] ?? lastYear.cars[n];
               return <option key={n} value={n}>{c?.code ?? n}</option>;
@@ -179,7 +182,9 @@ export function Ghost({ initialSelected }: { initialSelected?: number | null } =
             </span>
           )}
           <button className="btn" onClick={() => setPaused((p) => !p)} disabled={!ready}>
-            {paused ? '▶ Play' : '⏸ Pause'}
+            {/* Before playback exists there is nothing to pause — offering Pause
+                implies something is running. Show the inert Play instead. */}
+            {paused || !ready ? '▶ Play' : '⏸ Pause'}
           </button>
           <input
             type="range"

--- a/web/src/components/TimingTower.test.ts
+++ b/web/src/components/TimingTower.test.ts
@@ -91,6 +91,25 @@ describe('orderCars', () => {
     const cars = { 1: car({ driverNum: 1, code: 'VER', pos: 2 }), 44: car({ driverNum: 44, code: 'HAM', pos: 1 }) };
     expect(orderCars(cars).map((c) => c.code)).toEqual(['HAM', 'VER']);
   });
+
+  it('breaks a duplicate pos by laps completed, not driver number', () => {
+    // The Monza 2024 clip reports TSU and HUL both at pos 19 in every frame,
+    // with no 20 — TSU is five laps down. Ascending driver number would put
+    // TSU (22) ahead of HUL (27); laps completed puts them in running order.
+    const cars = {
+      22: car({ driverNum: 22, code: 'TSU', pos: 19, lap: 7 }),
+      27: car({ driverNum: 27, code: 'HUL', pos: 19, lap: 12 }),
+    };
+    expect(orderCars(cars).map((c) => c.code)).toEqual(['HUL', 'TSU']);
+  });
+
+  it('falls back to driver number when pos and lap are both tied', () => {
+    const cars = {
+      27: car({ driverNum: 27, code: 'HUL', pos: 19, lap: 12 }),
+      22: car({ driverNum: 22, code: 'TSU', pos: 19, lap: 12 }),
+    };
+    expect(orderCars(cars).map((c) => c.code)).toEqual(['TSU', 'HUL']);
+  });
 });
 
 describe('bestSectors', () => {

--- a/web/src/components/TimingTower.tsx
+++ b/web/src/components/TimingTower.tsx
@@ -77,7 +77,10 @@ export function TimingTower({
       </thead>
       <tbody>
         {order.map((c, idx) => {
-          const isLeader = c.pos === 1;
+          // Number rows by their place in the sorted order, not the raw feed
+          // pos: a duplicated pos would otherwise print the same number twice
+          // and skip one entirely.
+          const isLeader = idx === 0;
           const ahead = order[idx - 1];
           const isSel = c.driverNum === selected;
           const status = statusLabel(c.status);
@@ -97,7 +100,7 @@ export function TimingTower({
               }}
               style={c.status === 'Out' ? { opacity: 0.5 } : undefined}
             >
-              <td>{c.pos}</td>
+              <td>{idx + 1}</td>
               <td><b>{c.code}</b></td>
               {status ? (
                 <>

--- a/web/src/components/timingHelpers.ts
+++ b/web/src/components/timingHelpers.ts
@@ -96,8 +96,14 @@ export function statusLabel(status: string): string | undefined {
 }
 
 // orderCars returns the cars sorted by running position.
+// The feed is not guaranteed to hand out unique positions — the Monza 2024 clip
+// reports two cars at pos 19 (and no 20) in every frame. Tie-break on laps
+// completed so the running order is still right, then driver number so the
+// result is stable rather than dependent on object key order.
 export function orderCars(cars: RaceState['cars']): Car[] {
-  return Object.values(cars).sort((a, b) => a.pos - b.pos);
+  return Object.values(cars).sort(
+    (a, b) => a.pos - b.pos || (b.lap ?? 0) - (a.lap ?? 0) || a.driverNum - b.driverNum,
+  );
 }
 
 // bestSectors finds the session-best (min across all cars) for each sector this frame.

--- a/web/src/realtime/socket.test.ts
+++ b/web/src/realtime/socket.test.ts
@@ -128,6 +128,30 @@ describe('connectRace reconnect/backoff', () => {
     expect(statuses).toEqual(['connecting', 'reconnecting', 'reconnecting']);
   });
 
+  test('a reopened socket reports connecting again, so it is not still "reconnecting"', () => {
+    // Open but silent is not the same as retrying: the badge should fall through
+    // to its warming-up/staleness copy, not keep claiming a lost connection.
+    const statuses: string[] = [];
+    connectRace(() => {}, (s) => statuses.push(s));
+    MockWebSocket.instances[0].onclose?.();
+    vi.advanceTimersByTime(500);
+    expect(statuses.at(-1)).toBe('reconnecting');
+
+    MockWebSocket.instances[1].onopen?.();
+    expect(statuses.at(-1)).toBe('connecting');
+  });
+
+  test('a failing retry never reaches onopen, so it stays reconnecting', () => {
+    const statuses: string[] = [];
+    connectRace(() => {}, (s) => statuses.push(s));
+    for (const ms of [500, 1000, 2000]) {
+      MockWebSocket.instances.at(-1)!.onclose?.();
+      vi.advanceTimersByTime(ms);
+    }
+    expect(statuses.at(-1)).toBe('reconnecting');
+    expect(statuses.filter((s) => s === 'connecting')).toHaveLength(1); // the initial attempt only
+  });
+
   test('a message on a reconnected socket still reports live', () => {
     const statuses: string[] = [];
     connectRace(() => {}, (s) => statuses.push(s));

--- a/web/src/realtime/socket.ts
+++ b/web/src/realtime/socket.ts
@@ -27,17 +27,25 @@ export function connectRace(
 
   function open() {
     let live = false; // per-connection: emit 'live' on the first message of THIS connection
-    // Only the very first attempt is 'connecting' — that status means "nothing
-    // has been tried yet". Re-emitting it on every retry overwrote the
-    // 'reconnecting' onclose had just set, and since no consumer renders
-    // 'connecting' distinctly, an outage fell through to the staleness chip
-    // ("waiting for timing data") and the map's reconnect overlay blinked out.
+    // Only the FIRST attempt is 'connecting' here. Re-emitting it at the top of
+    // every retry overwrote the 'reconnecting' onclose had just set, and since
+    // no consumer renders 'connecting' distinctly, an outage fell through to
+    // the staleness chip ("waiting for timing data") and the map's reconnect
+    // overlay blinked out — a dead backend read as a merely slow one.
     if (!attempted) {
       attempted = true;
       onStatus?.('connecting');
     }
     ws = new WebSocket(url);
-    ws.onopen = () => { backoff = 500; };
+    ws.onopen = () => {
+      backoff = 500;
+      // Back to 'connecting': the socket is established but no data has crossed
+      // it yet, so consumers should show their warming-up/staleness copy rather
+      // than keep claiming we are still retrying. 'live' follows on the first
+      // message. Safe to emit here (unlike at the top of open()) because this
+      // only fires on a connection that actually succeeded.
+      onStatus?.('connecting');
+    };
     ws.onmessage = (ev) => {
       let parsed: unknown;
       try {


### PR DESCRIPTION
Closes out the three items left as follow-up work in `docs/superpowers/plans/2026-08-20-ux-walkthrough-findings.md` after #63.

## 1. An open-but-silent socket said "Reconnecting…"

`connectRace` only ever emitted a status from `onclose` and from the first connection attempt, so after a reconnect the badge kept claiming a lost connection until the first message arrived. On a sparse live session that gap can last seconds.

`ws.onopen` now reports `'connecting'` again — the socket is established but no data has crossed it, so consumers fall through to their warming-up/staleness copy, which is the accurate statement. Emitting here is safe in a way that emitting at the top of `open()` was not: it only fires on a connection that actually succeeded, so a failing retry still stays on `'reconnecting'`. Both halves are pinned by tests.

## 2. Two cars shared position 19

Not a rendering bug — the feed does not guarantee unique positions. The Monza 2024 clip reports TSU and HUL both at `pos: 19`, with no 20, in **all 4320 frames**.

Two changes:

- `orderCars` tie-breaks on laps completed, then driver number. This matters beyond cosmetics: TSU is five laps down, so ascending driver number was putting the slower car *ahead*. HUL is genuinely 19th.
- The `#` column renders the row's place in the sorted order instead of the raw `pos`, so it can no longer print the same number twice and skip one.

Verified against the live replay: rows now read a contiguous 1–20 with `…18 RIC, 19 HUL, 20 TSU`.

## 3. Ghost's driver dropdown was empty with no placeholder

An empty `<select>` reads as "no drivers exist" rather than "not loaded yet", and it sat beside a disabled `⏸ Pause` implying something was playing. The dropdown now shows a disabled `Waiting for driver data…` option, and the button reads `▶ Play` until there is something to pause. Both revert to normal once data arrives.

## Verification

`npm run lint`, `npm test` (112 passing, up from 108), and `npm run build` all exit 0.

All three confirmed in a real browser against `docker compose` — including that the outage badge stays stably on `↺ Reconnecting…` (no regression from change 1), that recovery still works without a reload, and that the ghost controls behave normally once both lanes load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)