### PR TITLE
fix(web): token consolidation and accessibility pass

### DIFF
--- a/FILE-MAP.md
+++ b/FILE-MAP.md
@@ -23,9 +23,9 @@ docstring — an orientation gap, not an omission by the generator.
 | `ingest` | 18 | True-live FastF1 SignalR ingest mode (exploratory, session-only). |
 | `bench` | 2 | Drive the loadtest sweeps behind BENCHMARKS.md by running cmd/loadtest at increasing concurrency and recording gateway resource usage. |
 | `web/src` | 3 | The React app shell: mounts the root component, wires the live WebSocket or static-replay data source into race state, and lays out the dashboard panels. |
-| `web/src/components` | 20 | The dashboard's presentational components — map, timing tower, standings, telemetry, comms, race control, ghost/compare overlays, and their shared layout/formatting helpers. |
-| `web/src/hooks` | 6 | React hooks that derive UI-facing state (staleness, gap/lap history, smoothed car positions, comms playback) from the raw RaceState stream. |
+| `web/src/components` | 22 | The dashboard's presentational components — map, timing tower, standings, telemetry, comms, race control, ghost/compare overlays, and their shared layout/formatting helpers. |
+| `web/src/hooks` | 7 | React hooks that derive UI-facing state (staleness, gap/lap history, smoothed car positions, comms playback) from the raw RaceState stream. |
 | `web/src/realtime` | 4 | The frontend's data-source connections: a reconnecting live WebSocket and a paced static-replay reader, both feeding the same RaceState reducer. |
 | `web/src/state` | 9 | The frontend's race state: wire message types, the applyMessage reducer, and the comms/ghost sub-state it composes. |
 
-17 source directories, 94 files, 0 without a declared purpose.
+17 source directories, 97 files, 0 without a declared purpose.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -13,6 +13,7 @@ import { SourceToggle } from './components/SourceToggle';
 import { Comms } from './components/Comms';
 import { RaceControl } from './components/RaceControl';
 import { Panel } from './components/Panel';
+import { Route } from './components/Route';
 import { StatusRail } from './components/StatusRail';
 import { useStale } from './hooks/useStale';
 import { useLapHistory } from './hooks/useLapHistory';
@@ -71,11 +72,14 @@ export default function App() {
   const showSkeleton = state.rev === 0 || trackless;
 
   return (
-    <div className="page">
-      <StatusRail active="board" state={state} status={status} staleSec={staleSec}>
-        {!STATIC_DEMO && <SourceToggle state={state} />}
-      </StatusRail>
-
+    <Route
+      title={`Race board${state.label ? ` — ${state.label}` : ''}`}
+      rail={
+        <StatusRail active="board" state={state} status={status} staleSec={staleSec}>
+          {!STATIC_DEMO && <SourceToggle state={state} />}
+        </StatusRail>
+      }
+    >
       <div className="board-top">
         <Panel label="Track">
           {status === 'reconnecting' && !showSkeleton && (
@@ -117,6 +121,6 @@ export default function App() {
           <RaceControl state={state} />
         </Panel>
       </div>
-    </div>
+    </Route>
   );
 }

--- a/web/src/ErrorBoundary.tsx
+++ b/web/src/ErrorBoundary.tsx
@@ -19,9 +19,11 @@ export class ErrorBoundary extends Component<
 
   render() {
     if (this.state.error) {
-      if (this.props.fallback) return this.props.fallback
+      if (this.props.fallback) {
+        return <div role="alert">{this.props.fallback}</div>
+      }
       return (
-        <div style={{ padding: 24, fontFamily: 'sans-serif' }}>
+        <div role="alert" style={{ padding: 24, fontFamily: 'sans-serif' }}>
           <h1>Something broke.</h1>
           <p>Reload the page. If it keeps happening, check the browser console.</p>
         </div>

--- a/web/src/components/Comms.tsx
+++ b/web/src/components/Comms.tsx
@@ -21,13 +21,13 @@ export function Comms({ state }: { state: RaceState }) {
         className={enabled ? 'btn btn-active' : 'btn'}
         style={{ justifySelf: 'start' }}
       >
-        {enabled ? '📻 Comms ON' : '📻 Comms OFF'}
+        {enabled ? 'Comms ON' : 'Comms OFF'}
       </button>
 
       {enabled && nowPlaying && (
         <div style={{
           display: 'flex', alignItems: 'center', gap: 8, padding: '8px 12px',
-          background: 'var(--asphalt)', borderRadius: 4, fontSize: 13,
+          background: 'var(--asphalt)', borderRadius: 4, fontSize: 'var(--fs-md)',
         }}>
           <span style={{ color: colourFor(nowPlaying.driverNum), fontWeight: 700 }}>
             {codeFor(nowPlaying.driverNum)}
@@ -35,8 +35,8 @@ export function Comms({ state }: { state: RaceState }) {
           <span style={{ color: 'var(--slate)' }}>radio</span>
           <button
             onClick={() => replay(nowPlaying)}
-            className="btn"
-            style={{ border: 'none', padding: '0 4px' }}
+            className="btn btn-icon"
+            style={{ border: 'none' }}
             aria-label="Replay current clip"
           >↻</button>
         </div>
@@ -47,13 +47,13 @@ export function Comms({ state }: { state: RaceState }) {
           {history.map((m, i) => (
             <div key={`${m.timeMs}-${i}`} style={{
               display: 'flex', alignItems: 'center', gap: 8,
-              fontSize: 12, color: 'var(--slate)',
+              fontSize: 'var(--fs-sm)', color: 'var(--slate)',
             }}>
               <span style={{ color: colourFor(m.driverNum), fontWeight: 700 }}>{codeFor(m.driverNum)}</span>
               <button
                 onClick={() => replay(m)}
-                className="btn"
-                style={{ border: 'none', padding: '0 4px' }}
+                className="btn btn-icon"
+                style={{ border: 'none' }}
                 aria-label={`Play ${codeFor(m.driverNum)} radio`}
               >▶</button>
             </div>
@@ -67,9 +67,11 @@ export function Comms({ state }: { state: RaceState }) {
       {enabled && !nowPlaying && history.length === 0 && (
         <div className="empty">No radio yet — clips play as the replay reaches them.</div>
       )}
-      {error && (
-        <div className="empty" style={{ color: '#ff8c00' }}>{error}</div>
-      )}
+      {/* Announced, not just shown: a blocked or failed clip is the only feedback
+          a click on ▶/↻ gives, and the button itself does not change. */}
+      <div role="status" aria-live="polite">
+        {error && <div className="empty" style={{ color: 'var(--amber)' }}>{error}</div>}
+      </div>
     </div>
   );
 }

--- a/web/src/components/Compare.tsx
+++ b/web/src/components/Compare.tsx
@@ -5,6 +5,7 @@ import { Map } from './Map';
 import { Standings } from './Standings';
 import { Panel } from './Panel';
 import { StatusRail } from './StatusRail';
+import { Route } from './Route';
 import { StatusBadge } from './StatusBadge';
 import { useStale } from '../hooks/useStale';
 
@@ -38,13 +39,15 @@ function Lane({ session, year }: { session: string; year: string }) {
 
 export function Compare() {
   return (
-    <div className="page">
-      <StatusRail active="compare" note="Fixed historical replay — Monza 2023 vs 2024" />
+    <Route
+      title="Compare — Monza 2023 vs 2024"
+      rail={<StatusRail active="compare" note="Fixed historical replay — Monza 2023 vs 2024" />}
+    >
       <div className="compare-lanes">
         {PAIR.map((p) => (
           <Lane key={p.session} session={p.session} year={p.year} />
         ))}
       </div>
-    </div>
+    </Route>
   );
 }

--- a/web/src/components/Ghost.tsx
+++ b/web/src/components/Ghost.tsx
@@ -6,7 +6,10 @@ import { commonDrivers, deltaSeries, indexAtTime, ghostSkeletonCopy } from '../s
 import { fmtElapsed } from './timingHelpers';
 import { SIZE } from './geometry';
 import { Panel } from './Panel';
+import { TrackPath } from './TrackPath';
+import { useReducedMotion } from '../hooks/useReducedMotion';
 import { StatusRail } from './StatusRail';
+import { Route } from './Route';
 
 const BAR_H = 90;
 const THIS = { session: 'compare-monza-2024', year: '2024' };
@@ -41,7 +44,10 @@ export function Ghost({ initialSelected }: { initialSelected?: number | null } =
   // live frames unused). tMsRef mirrors tMs so pause/resume/scrub can re-anchor
   // the rAF loop without waiting on a stale closure value.
   const [tMs, setTMs] = useState(0);
-  const [paused, setPaused] = useState(false);
+  // Reduced motion: the lap does not auto-play. The scrubber still works, so the
+  // overlay stays fully usable — the user drives the clock instead of a loop.
+  const reducedMotion = useReducedMotion();
+  const [paused, setPaused] = useState(reducedMotion);
   const tMsRef = useRef(0);
   const rafRef = useRef<number | undefined>(undefined);
   const startRef = useRef(0);
@@ -65,7 +71,7 @@ export function Ghost({ initialSelected }: { initialSelected?: number | null } =
   // continues from the frozen position instead of jumping forward by however
   // long it was paused.
   useEffect(() => {
-    if (!loopMs || paused) return;
+    if (!loopMs || paused || reducedMotion) return;
     startRef.current = performance.now() - tMsRef.current;
     const tick = (now: number) => {
       const v = (now - startRef.current) % loopMs;
@@ -77,7 +83,7 @@ export function Ghost({ initialSelected }: { initialSelected?: number | null } =
     return () => { if (rafRef.current) cancelAnimationFrame(rafRef.current); };
     // resolvedSelected is included so a driver switch always re-anchors startRef,
     // even in the edge case where two drivers happen to share the same loopMs.
-  }, [loopMs, paused, resolvedSelected]);
+  }, [loopMs, paused, resolvedSelected, reducedMotion]);
 
   function scrub(v: number) {
     tMsRef.current = v;
@@ -119,12 +125,15 @@ export function Ghost({ initialSelected }: { initialSelected?: number | null } =
   const ghost = ready ? track[Math.min(idxLast, track.length - 1)] : undefined;
 
   return (
-    <div className="page">
-      <StatusRail
-        active="ghost"
-        note={`${THIS.year} solid vs ${LAST.year} ghost · fastest lap (approx)`}
-      />
-
+    <Route
+      title={`Lap delta overlay — ${THIS.year} vs ${LAST.year}`}
+      rail={
+        <StatusRail
+          active="ghost"
+          note={`${THIS.year} solid vs ${LAST.year} ghost · fastest lap (approx)`}
+        />
+      }
+    >
       <Panel label="Track">
         {!ready ? (
           <div className="track-skeleton">
@@ -132,13 +141,12 @@ export function Ghost({ initialSelected }: { initialSelected?: number | null } =
           </div>
         ) : (
           <svg viewBox={`0 0 ${SIZE} ${SIZE}`} className="track-svg" role="img" aria-label="Ghost overlay track map">
-            <path d={trackPath} fill="none" stroke="#333" strokeWidth={10} strokeLinejoin="round" />
-            <path d={trackPath} fill="none" stroke="#1a1a1a" strokeWidth={6} strokeLinejoin="round" />
+            <TrackPath d={trackPath} />
             {/* ghost (last year) — translucent */}
             <circle cx={ghost!.x * SIZE} cy={ghost!.y * SIZE} r={7} fill={colour} opacity={0.4} stroke="#000" strokeWidth={1} />
             {/* solid (this year) */}
             <circle cx={solid!.x * SIZE} cy={solid!.y * SIZE} r={7} fill={colour} stroke="#fff" strokeWidth={1.5} />
-            <text x={solid!.x * SIZE + 10} y={solid!.y * SIZE + 4} fill="#eee" fontSize={11}>{code}</text>
+            <text x={solid!.x * SIZE + 10} y={solid!.y * SIZE + 4} fill="var(--track-label)" fontSize="var(--fs-xs)">{code}</text>
           </svg>
         )}
       </Panel>
@@ -152,18 +160,19 @@ export function Ghost({ initialSelected }: { initialSelected?: number | null } =
               const h = (Math.abs(d) / maxAbs) * (BAR_H / 2);
               const x = (i / delta.length) * SIZE;
               const y = d > 0 ? BAR_H / 2 - h : BAR_H / 2;
-              return <rect key={i} x={x} y={y} width={Math.max(1, SIZE / delta.length)} height={h} fill={d > 0 ? '#ff5252' : '#4caf50'} />;
+              return <rect key={i} x={x} y={y} width={Math.max(1, SIZE / delta.length)} height={h} fill={d > 0 ? 'var(--bad)' : 'var(--good)'} />;
             })}
             {/* playback cursor at this-year's current fraction */}
-            <line x1={(cursorIdx / delta.length) * SIZE} y1={0} x2={(cursorIdx / delta.length) * SIZE} y2={BAR_H} stroke="#fff" strokeWidth={1.5} />
+            <line x1={(cursorIdx / delta.length) * SIZE} y1={0} x2={(cursorIdx / delta.length) * SIZE} y2={BAR_H} stroke="var(--chalk)" strokeWidth={1.5} />
           </svg>
         </Panel>
       )}
 
       <Panel label="Controls">
         <div className="ghost-controls">
-          <label style={{ fontSize: 'var(--fs-lg)' }}>Driver</label>
+          <label htmlFor="ghost-driver" style={{ fontSize: 'var(--fs-lg)' }}>Driver</label>
           <select
+            id="ghost-driver"
             value={resolvedSelected ?? ''}
             onChange={(e) => setSelected(Number(e.target.value))}
             disabled={drivers.length === 0}
@@ -177,7 +186,7 @@ export function Ghost({ initialSelected }: { initialSelected?: number | null } =
             })}
           </select>
           {ready && (
-            <span style={{ fontSize: 'var(--fs-xl)', color: dNow > 0 ? '#ff5252' : '#4caf50' }}>
+            <span style={{ fontSize: 'var(--fs-xl)', color: dNow > 0 ? 'var(--bad)' : 'var(--good)' }}>
               {dNow > 0 ? '+' : ''}{dNow.toFixed(2)}s
             </span>
           )}
@@ -200,6 +209,6 @@ export function Ghost({ initialSelected }: { initialSelected?: number | null } =
           <span className="rail-clock">{fmtElapsed(tMs)}</span>
         </div>
       </Panel>
-    </div>
+    </Route>
   );
 }

--- a/web/src/components/Map.tsx
+++ b/web/src/components/Map.tsx
@@ -1,4 +1,5 @@
 import type { RaceState } from '../state/race';
+import { TrackPath } from './TrackPath';
 import { useSmoothedCars } from '../hooks/useSmoothedCars';
 import { teamColour } from './teamColours';
 import { SIZE } from './geometry';
@@ -10,12 +11,11 @@ export function Map({ state }: { state: RaceState }) {
     : '';
   return (
     <svg viewBox={`0 0 ${SIZE} ${SIZE}`} className="track-svg" role="img" aria-label="Track map with live car positions">
-      {trackPath && <path d={trackPath} fill="none" stroke="#333" strokeWidth={10} strokeLinejoin="round" />}
-      {trackPath && <path d={trackPath} fill="none" stroke="#1a1a1a" strokeWidth={6} strokeLinejoin="round" />}
+      <TrackPath d={trackPath} />
       {cars.map((c) => (
         <g key={c.driverNum} opacity={c.status === 'Pit' ? 0.35 : c.status === 'Out' ? 0.5 : 1}>
           <circle cx={c.p.x * SIZE} cy={c.p.y * SIZE} r={7} fill={teamColour[c.team] ?? '#bbb'} stroke="#000" strokeWidth={1} />
-          <text x={c.p.x * SIZE + 10} y={c.p.y * SIZE + 4} fill="#eee" fontSize={11}>{c.code}</text>
+          <text x={c.p.x * SIZE + 10} y={c.p.y * SIZE + 4} fill="var(--track-label)" fontSize="var(--fs-xs)">{c.code}</text>
         </g>
       ))}
     </svg>

--- a/web/src/components/Panel.tsx
+++ b/web/src/components/Panel.tsx
@@ -16,7 +16,7 @@ export function Panel({ label, actions, children }: {
   return (
     <section className="panel">
       <header className="panel-plate">
-        <span>{label}</span>
+        <h2>{label}</h2>
         {actions}
       </header>
       <div className="panel-body">

--- a/web/src/components/RaceControl.tsx
+++ b/web/src/components/RaceControl.tsx
@@ -1,14 +1,14 @@
 import type { RaceState } from '../state/race';
-import { fmtClock } from './timingHelpers';
+import { fmtClock, TYRE_COLOUR } from './timingHelpers';
 
 const MAX_SHOWN = 8;
 
 // Category labels/colours for FastF1's race-control feed. Falls back to an
 // uppercased raw category for anything not in this table rather than hiding it.
 const CATEGORY: Record<string, { label: string; colour: string }> = {
-  Flag: { label: 'FLAG', colour: '#e8c84a' },
-  SafetyCar: { label: 'SAFETY CAR', colour: '#ff8c00' },
-  Drs: { label: 'DRS', colour: '#3bb273' },
+  Flag: { label: 'FLAG', colour: TYRE_COLOUR.MEDIUM },
+  SafetyCar: { label: 'SAFETY CAR', colour: 'var(--amber)' },
+  Drs: { label: 'DRS', colour: 'var(--good)' },
   CarEvent: { label: 'CAR', colour: 'var(--chalk)' },
   Other: { label: 'NOTE', colour: 'var(--slate)' },
 };
@@ -25,10 +25,10 @@ export function RaceControl({ state }: { state: RaceState }) {
         const cat = CATEGORY[m.category] ?? { label: m.category.toUpperCase(), colour: 'var(--chalk)' };
         return (
         <div key={`${m.rev}-${i}`} style={{
-          display: 'flex', alignItems: 'baseline', gap: 8, fontSize: 12, color: 'var(--slate)',
+          display: 'flex', alignItems: 'baseline', gap: 8, fontSize: 'var(--fs-sm)', color: 'var(--slate)',
         }}>
-          <span style={{ fontVariantNumeric: 'tabular-nums', fontSize: 10 }}>{fmtClock(m.t)}</span>
-          <span style={{ color: cat.colour, fontWeight: 700, fontSize: 10, letterSpacing: '0.08em' }}>
+          <span style={{ fontVariantNumeric: 'tabular-nums', fontSize: 'var(--fs-2xs)' }}>{fmtClock(m.t)}</span>
+          <span style={{ color: cat.colour, fontWeight: 700, fontSize: 'var(--fs-2xs)', letterSpacing: '0.08em' }}>
             {cat.label}
           </span>
           <span>{m.message}</span>

--- a/web/src/components/Route.tsx
+++ b/web/src/components/Route.tsx
@@ -1,0 +1,21 @@
+import type { ReactNode } from 'react';
+
+// Route is the shared page frame: the skip link (first focusable element on
+// every route), the route's own <h1> — visually hidden because the status rail
+// already carries the brand — and the <main> landmark the skip link targets.
+// Panel titles are <h2> beneath it, so every route has one unbroken heading
+// chain instead of a grid of untitled boxes.
+export function Route({ title, rail, children }: {
+  title: string;
+  rail: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <div className="page">
+      <a className="skip-link" href="#main">Skip to content</a>
+      <h1 className="visually-hidden">{title}</h1>
+      {rail}
+      <main id="main" className="route-main">{children}</main>
+    </div>
+  );
+}

--- a/web/src/components/Settings.tsx
+++ b/web/src/components/Settings.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Panel } from './Panel';
 import { StatusRail } from './StatusRail';
+import { Route } from './Route';
 import { parseAuthStatus, relativeExpiry, type AuthStatus } from '../state/f1auth';
 
 const POLL_MS = 5000;
@@ -78,9 +79,10 @@ export function Settings() {
   const noSubscription = auth.state === 'linked' && auth.tier !== 'active';
 
   return (
-    <div className="page">
-      <StatusRail active="settings" note="F1TV link — beta" />
-
+    <Route
+      title="F1TV account link"
+      rail={<StatusRail active="settings" note="F1TV link — beta" />}
+    >
       <Panel
         label="F1TV Link — beta"
         actions={<span className={CHIP[auth.state]}>{CHIP_LABEL[auth.state]}</span>}
@@ -167,6 +169,6 @@ export function Settings() {
           </>
         )}
       </Panel>
-    </div>
+    </Route>
   );
 }

--- a/web/src/components/SourceToggle.tsx
+++ b/web/src/components/SourceToggle.tsx
@@ -51,7 +51,9 @@ export function SourceToggle({ state }: { state: RaceState }) {
           </button>
         ))}
       </div>
-      {error && <span className="src-error">{error}</span>}
+      <span role="status" aria-live="polite">
+        {error && <span className="src-error">{error}</span>}
+      </span>
     </div>
   );
 }

--- a/web/src/components/StatusBadge.tsx
+++ b/web/src/components/StatusBadge.tsx
@@ -9,6 +9,8 @@ interface Props {
 
 const STALE_THRESHOLD_SEC = 4;
 
+// The chip is wrapped in a polite live region by StatusRail, so every branch
+// below is announced when it changes rather than only being visible.
 export function StatusBadge({ status, state, staleSec }: Props) {
   if (status === 'failed') {
     return <span className="chip chip-stall">⚠ Demo data failed to load — refresh the page to retry.</span>;

--- a/web/src/components/StatusRail.tsx
+++ b/web/src/components/StatusRail.tsx
@@ -44,10 +44,12 @@ export function StatusRail({
           {state.weather && (
             <span className="rail-lap" title="Baked from session weather data">
               TRK {state.weather.trackTempC.toFixed(0)}° · AIR {state.weather.airTempC.toFixed(0)}°
-              {state.weather.rainfall && <span style={{ color: '#3671C6' }}> · RAIN</span>}
+              {state.weather.rainfall && <span style={{ color: 'var(--rain)' }}> · RAIN</span>}
             </span>
           )}
-          <StatusBadge status={status ?? 'connecting'} state={state} staleSec={staleSec} />
+          <span role="status" aria-live="polite">
+            <StatusBadge status={status ?? 'connecting'} state={state} staleSec={staleSec} />
+          </span>
         </>
       )}
       {note && <span className="rail-note">{note}</span>}

--- a/web/src/components/StintChart.tsx
+++ b/web/src/components/StintChart.tsx
@@ -26,13 +26,15 @@ function StintChartInner({ state }: { state: RaceState }) {
   return (
     <div style={{ display: 'grid', gap: 3 }}>
       {order.map((c) => (
-        <div key={c.driverNum} style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 11 }}>
+        <div key={c.driverNum} style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 'var(--fs-xs)' }}>
           <span style={{ width: 28, flexShrink: 0 }}>{c.code}</span>
           <div style={{ position: 'relative', flex: 1, height: 10, background: 'var(--edge)', borderRadius: 2 }}>
             {state.stints[c.driverNum].map((s, i) => (
               <div
                 key={i}
                 title={`${s.compound} · laps ${s.startLap}-${s.endLap}`}
+                role="img"
+                aria-label={`${c.code}: ${s.compound.toLowerCase()} tyres, laps ${s.startLap} to ${s.endLap}`}
                 style={{
                   position: 'absolute',
                   left: `${((s.startLap - 1) / total) * 100}%`,
@@ -45,19 +47,21 @@ function StintChartInner({ state }: { state: RaceState }) {
             ))}
             {!!leaderLap && (
               <div
+                role="img"
+                aria-label={`Leader is on lap ${leaderLap}`}
                 style={{
                   position: 'absolute',
                   left: `${((leaderLap - 1) / total) * 100}%`,
                   top: -1, bottom: -1,
                   width: 1,
-                  background: '#fff',
+                  background: 'var(--chalk)',
                 }}
               />
             )}
           </div>
         </div>
       ))}
-      <div className="empty" style={{ fontSize: 10, marginTop: 2 }}>
+      <div className="empty" style={{ fontSize: 'var(--fs-2xs)', marginTop: 2 }}>
         Full-race stint plan baked from session data — the replay window sits inside it.
       </div>
     </div>

--- a/web/src/components/TelemetryPanel.tsx
+++ b/web/src/components/TelemetryPanel.tsx
@@ -1,12 +1,18 @@
 import type { Car, RaceState } from '../state/race';
 import { fmtLap, fmtGap, type LapHistory, type GapHistory } from './timingHelpers';
 
-function Bar({ label, value }: { label: string; value: number }) {
+// Throttle and brake are opposite inputs, so they read as opposite colours —
+// both bars being green made a full-brake trace look like a full-throttle one
+// at a glance.
+function Bar({ label, value, tone }: { label: string; value: number; tone: 'good' | 'bad' }) {
   return (
-    <div style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 12 }}>
+    <div style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 'var(--fs-sm)' }}>
       <span style={{ width: 64, color: 'var(--slate)' }}>{label}</span>
       <div style={{ flex: 1, height: 8, background: 'var(--edge)', borderRadius: 4 }}>
-        <div style={{ width: `${Math.max(0, Math.min(100, value))}%`, height: '100%', background: '#3bb273', borderRadius: 4 }} />
+        <div style={{
+          width: `${Math.max(0, Math.min(100, value))}%`, height: '100%',
+          background: tone === 'good' ? 'var(--good)' : 'var(--bad)', borderRadius: 4,
+        }} />
       </div>
       <span style={{ width: 36, textAlign: 'right' }}>{value}</span>
     </div>
@@ -17,23 +23,47 @@ function Bar({ label, value }: { label: string; value: number }) {
 // green = faster — the stint-degradation squint test. Reused for the gap
 // trend too, where the same colouring reads as "closing" (green) vs
 // "opening" (red).
-function Sparkline({ values }: { values: (number | undefined)[] }) {
+function Sparkline({ values, label }: { values: (number | undefined)[]; label: string }) {
   const known = values.filter((v): v is number => v != null);
   if (known.length === 0) return null;
   const min = Math.min(...known), max = Math.max(...known);
   const span = max - min || 1;
   return (
-    <svg width={values.length * 15} height={24} role="img" aria-label="Trend">
+    <svg width={values.length * 15} height={24} role="img" aria-label={label}>
       {values.map((v, i) => {
         if (v == null) return null;
         const h = 4 + ((v - min) / span) * 18;
         const prev = values[i - 1];
         const slower = i > 0 && prev != null && v > prev;
+        // Colour alone would be the only signal for a red/green-blind reader, so
+        // the worse bars also carry a hatch overlay — a shape difference that
+        // survives any palette.
         return (
-          <rect key={i} x={i * 15} y={24 - h} width={11} height={h}
-                fill={slower ? '#e1342e' : '#3bb273'} />
+          <g key={i}>
+            <rect x={i * 15} y={24 - h} width={11} height={h}
+                  fill={slower ? 'var(--bad)' : 'var(--good)'} />
+            {slower && (
+              <rect x={i * 15} y={24 - h} width={11} height={h}
+                    fill="url(#spark-hatch)" />
+            )}
+          </g>
         );
       })}
+    </svg>
+  );
+}
+
+// One shared hatch pattern for every Sparkline on the page.
+function SparkHatch() {
+  return (
+    <svg width={0} height={0} aria-hidden="true" style={{ position: 'absolute' }}>
+      <defs>
+        <pattern id="spark-hatch" patternUnits="userSpaceOnUse" width={4} height={4}
+                 patternTransform="rotate(45)">
+          <rect width={4} height={4} fill="none" />
+          <line x1={0} y1={0} x2={0} y2={4} stroke="var(--asphalt)" strokeWidth={1.5} />
+        </pattern>
+      </defs>
     </svg>
   );
 }
@@ -43,27 +73,31 @@ function CarTelemetry({ car, history, gapHistory }: {
 }) {
   return (
     <div style={{ display: 'grid', gap: 8, minWidth: 200 }}>
-      <div style={{ fontSize: 14 }}>
+      <div style={{ fontSize: 'var(--fs-lg)' }}>
         <b>{car.code}</b> <span style={{ color: 'var(--slate)' }}>{car.team}</span>
       </div>
-      <div style={{ fontFamily: 'var(--display)', fontSize: 28 }}>
-        {car.speed ?? 0} <span style={{ fontSize: 14, color: 'var(--slate)' }}>km/h</span>
+      <div style={{ fontFamily: 'var(--display)', fontSize: 'var(--fs-hero)' }}>
+        {car.speed ?? 0} <span style={{ fontSize: 'var(--fs-lg)', color: 'var(--slate)' }}>km/h</span>
         <span style={{ marginLeft: 16 }}>G{car.gear ?? 0}</span>
-        {car.drs ? <span style={{ marginLeft: 16, color: '#3bb273' }}>DRS</span> : <span style={{ marginLeft: 16, color: 'var(--edge)' }}>DRS</span>}
+        {/* The off state used --edge (a border colour, 1.2:1) and was effectively
+            invisible; --dim reads as deliberately-off at 3.4:1. */}
+        <span style={{ marginLeft: 16, color: car.drs ? 'var(--good)' : 'var(--dim)' }}>
+          DRS
+        </span>
       </div>
-      <Bar label="Throttle" value={car.throttle ?? 0} />
-      <Bar label="Brake" value={car.brake ?? 0} />
+      <Bar label="Throttle" value={car.throttle ?? 0} tone="good" />
+      <Bar label="Brake" value={car.brake ?? 0} tone="bad" />
       {history && history.length >= 2 && (
-        <div style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 12 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 'var(--fs-sm)' }}>
           <span style={{ width: 64, color: 'var(--slate)' }}>Laps</span>
-          <Sparkline values={history} />
+          <Sparkline values={history} label={`${car.code} lap time trend`} />
           <span>{fmtLap(history[history.length - 1])}</span>
         </div>
       )}
       {gapHistory && gapHistory.length >= 2 && (
-        <div style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 12 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 'var(--fs-sm)' }}>
           <span style={{ width: 64, color: 'var(--slate)' }}>Gap</span>
-          <Sparkline values={gapHistory} />
+          <Sparkline values={gapHistory} label={`${car.code} gap trend`} />
           <span>{fmtGap(gapHistory[gapHistory.length - 1])}</span>
         </div>
       )}
@@ -93,14 +127,15 @@ export function TelemetryPanel({
   const others = Object.values(state.cars).filter((c) => c.driverNum !== car.driverNum);
   return (
     <div style={{ display: 'grid', gap: 8 }}>
+      <SparkHatch />
       {others.length > 0 && onRivalChange && (
-        <label style={{ fontSize: 11, color: 'var(--slate)', display: 'flex', alignItems: 'center', gap: 6 }}>
+        <label style={{ fontSize: 'var(--fs-xs)', color: 'var(--slate)', display: 'flex', alignItems: 'center', gap: 6 }}>
           vs
           <select
             value={rival ?? ''}
             onChange={(e) => onRivalChange(e.target.value ? Number(e.target.value) : null)}
             className="btn"
-            style={{ fontSize: 11 }}
+            style={{ fontSize: 'var(--fs-xs)' }}
           >
             <option value="">— none —</option>
             {others.map((c) => (

--- a/web/src/components/TimingTower.test.ts
+++ b/web/src/components/TimingTower.test.ts
@@ -129,8 +129,8 @@ describe('updatePersonalBests', () => {
 
 describe('sectorColour', () => {
   it('purple for session-best, green for personal-best, undefined otherwise', () => {
-    expect(sectorColour(25900, 25900, 25900)).toBe('#b14aff'); // session-best wins
-    expect(sectorColour(26100, 25900, 26100)).toBe('#3bb273'); // personal-best only
+    expect(sectorColour(25900, 25900, 25900)).toBe('var(--best-session)'); // session-best wins
+    expect(sectorColour(26100, 25900, 26100)).toBe('var(--good)'); // personal-best only
     expect(sectorColour(26500, 25900, 26100)).toBeUndefined();
     expect(sectorColour(undefined, 25900, 26100)).toBeUndefined();
   });

--- a/web/src/components/TimingTower.tsx
+++ b/web/src/components/TimingTower.tsx
@@ -3,7 +3,7 @@ import type { RaceState } from '../state/race';
 import {
   fmtLap, fmtSec, fmtGap, gapLabel, intLabel,
   orderCars, bestSectors, updatePersonalBests, sectorColour, sectorDelta,
-  TYRE_COLOUR, tyreLabel, statusLabel, sectorDeltaVs, fmtSigned,
+  TYRE_COLOUR, tyreLabel, statusLabel, sectorDeltaVs, fmtSigned, sectorMark,
 } from './timingHelpers';
 import type { Bests } from './timingHelpers';
 
@@ -40,6 +40,8 @@ export function TimingTower({
     const c = sectorColour(v, best, pb[dn]?.[i] ?? Infinity);
     return c ? { color: c } : undefined;
   };
+  const cellMark = (v: number | undefined, best: number, dn: number, i: number) =>
+    sectorMark(v, best, pb[dn]?.[i] ?? Infinity);
   // With a reference car selected, every OTHER row's delta compares against
   // that car's same sector (the rival-relative question a race engineer asks)
   // instead of this driver's own personal best.
@@ -55,7 +57,7 @@ export function TimingTower({
     <button
       onClick={() => setSecondsMode((m) => !m)}
       className="btn"
-      style={{ marginBottom: 6, fontSize: 11, padding: '2px 8px' }}
+      style={{ marginBottom: 6, fontSize: 'var(--fs-xs)', padding: '2px 8px' }}
     >
       {secondsMode ? 'Show laps' : 'Show seconds'}
     </button>
@@ -87,10 +89,13 @@ export function TimingTower({
           return (
             <tr
               key={c.driverNum}
-              className="tt-row"
+              // No aria-selected: a plain <tr> is not in a grid/listbox, so the
+              // attribute is invalid ARIA there. Selection shows as a class, and
+              // the row keeps its own accessible pressed-state via the button role.
+              className={isSel ? 'tt-row tt-row-selected' : 'tt-row'}
               role="button"
               tabIndex={0}
-              aria-selected={isSel}
+              aria-pressed={isSel}
               onClick={() => onSelect(c.driverNum)}
               onKeyDown={(e) => {
                 if (e.key === 'Enter' || e.key === ' ') {
@@ -104,7 +109,7 @@ export function TimingTower({
               <td><b>{c.code}</b></td>
               {status ? (
                 <>
-                  <td style={{ color: c.status === 'Pit' ? '#e8c84a' : 'var(--slate)' }}>{status}</td>
+                  <td style={{ color: c.status === 'Pit' ? TYRE_COLOUR.MEDIUM : 'var(--slate)' }}>{status}</td>
                   <td>—</td>
                 </>
               ) : (
@@ -120,14 +125,23 @@ export function TimingTower({
               </td>
               {([[c.s1Ms, b1, 0], [c.s2Ms, b2, 1], [c.s3Ms, b3, 2]] as const).map(([v, best, i]) => {
                 const d = cellDelta(v, c.driverNum, i);
+                const mark = cellMark(v, best, c.driverNum, i);
                 const rivalMode = !!refCar && c.driverNum !== selected;
                 return (
                   <td key={i} style={cellColour(v, best, c.driverNum, i)}>
                     {fmtSec(v)}
+                    {mark && (
+                      <sup
+                        style={{ fontSize: 'var(--fs-3xs)', marginLeft: 2 }}
+                        title={mark === 'S' ? 'Session best' : 'Personal best'}
+                      >
+                        {mark}
+                      </sup>
+                    )}
                     {d !== undefined && (
                       <sup style={{
-                        fontSize: 9, marginLeft: 3,
-                        color: rivalMode ? (d < 0 ? '#3bb273' : 'var(--slate)') : 'var(--slate)',
+                        fontSize: 'var(--fs-3xs)', marginLeft: 3,
+                        color: rivalMode && d < 0 ? 'var(--good)' : 'var(--slate)',
                       }}>
                         {rivalMode ? fmtSigned(d) : fmtGap(d)}
                       </sup>
@@ -141,11 +155,11 @@ export function TimingTower({
       </tbody>
     </table>
     </div>
-    <div className="empty" style={{ fontSize: 10, marginTop: 4 }}>
+    <div className="empty" style={{ fontSize: 'var(--fs-2xs)', marginTop: 4 }}>
       Gap / Int are estimates derived from track position, not official timing.
       {refCar && ` Click a row to set the reference car — sector deltas compare against ${refCar.code}.`}
     </div>
-    <div className="empty" style={{ fontSize: 10, marginTop: 2, display: 'flex', gap: 10 }}>
+    <div className="empty" style={{ fontSize: 'var(--fs-2xs)', marginTop: 2, display: 'flex', gap: 10 }}>
       {([['SOFT', 'S Soft'], ['MEDIUM', 'M Medium'], ['HARD', 'H Hard'],
          ['INTERMEDIATE', 'I Inter'], ['WET', 'W Wet']] as const).map(([t, label]) => (
         <span key={t} style={{ color: TYRE_COLOUR[t] }}>{label}</span>

--- a/web/src/components/TrackPath.tsx
+++ b/web/src/components/TrackPath.tsx
@@ -1,0 +1,12 @@
+// The circuit outline, drawn as a casing stroke under a surface stroke so the
+// track reads as a road rather than a line. Shared by the board map and the
+// ghost overlay, which previously carried identical hardcoded copies.
+export function TrackPath({ d }: { d: string }) {
+  if (!d) return null;
+  return (
+    <>
+      <path d={d} fill="none" stroke="var(--track-edge)" strokeWidth={10} strokeLinejoin="round" />
+      <path d={d} fill="none" stroke="var(--track-fill)" strokeWidth={6} strokeLinejoin="round" />
+    </>
+  );
+}

--- a/web/src/components/timingHelpers.ts
+++ b/web/src/components/timingHelpers.ts
@@ -132,8 +132,9 @@ export function updatePersonalBests(prev: Bests, cars: Car[]): Bests {
   return next;
 }
 
-const PURPLE = '#b14aff'; // session-best
-const GREEN = '#3bb273';  // personal-best
+// Tokens, not hexes, so a palette change reaches the sector cells too.
+const PURPLE = 'var(--best-session)'; // session-best
+const GREEN = 'var(--good)';          // personal-best
 
 // sectorColour returns the cell colour for a sector value: purple if it ties the
 // session-best, else green if it ties this driver's personal-best, else none.
@@ -143,6 +144,18 @@ export function sectorColour(
   if (!v || v <= 0) return undefined;
   if (v === sessionBest) return PURPLE;
   if (v === personalBest) return GREEN;
+  return undefined;
+}
+
+// sectorMark is the same information as sectorColour, as a glyph: colour alone
+// would leave a purple/green best sector indistinguishable to a colour-blind
+// reader. 'S' = session best, 'P' = personal best.
+export function sectorMark(
+  v: number | undefined, sessionBest: number, personalBest: number,
+): 'S' | 'P' | undefined {
+  if (!v || v <= 0) return undefined;
+  if (v === sessionBest) return 'S';
+  if (v === personalBest) return 'P';
   return undefined;
 }
 

--- a/web/src/hooks/useReducedMotion.ts
+++ b/web/src/hooks/useReducedMotion.ts
@@ -1,0 +1,20 @@
+import { useSyncExternalStore } from 'react';
+
+const QUERY = '(prefers-reduced-motion: reduce)';
+
+function subscribe(onChange: () => void) {
+  if (typeof matchMedia !== 'function') return () => {};
+  const mq = matchMedia(QUERY);
+  mq.addEventListener('change', onChange);
+  return () => mq.removeEventListener('change', onChange);
+}
+
+const getSnapshot = () => typeof matchMedia === 'function' && matchMedia(QUERY).matches;
+
+// CSS handles the declarative animations; this is for the two places motion is
+// driven from JS (the map's rAF interpolation and the ghost's playback loop),
+// which a media query cannot reach. Subscribed rather than read once, so a
+// mid-session OS change takes effect without a reload.
+export function useReducedMotion(): boolean {
+  return useSyncExternalStore(subscribe, getSnapshot, () => false);
+}

--- a/web/src/hooks/useSmoothedCars.ts
+++ b/web/src/hooks/useSmoothedCars.ts
@@ -1,11 +1,13 @@
 import { useEffect, useRef, useState } from 'react';
 import type { Car, RaceState, Point } from '../state/race';
+import { useReducedMotion } from './useReducedMotion';
 
 // Returns cars with positions interpolated at display refresh rate.
 // Cars glide from their previous position to their current position over one
 // frame interval (~100 ms at 10 Hz), keeping motion smooth at the display's
 // native refresh rate.
 export function useSmoothedCars(state: RaceState): Car[] {
+  const reducedMotion = useReducedMotion();
   const from = useRef<Record<number, Point>>({});
   const to = useRef<Record<number, Point>>({});
   const tFrom = useRef(0);
@@ -34,6 +36,9 @@ export function useSmoothedCars(state: RaceState): Car[] {
   // published to state so the component re-renders at the display's native
   // refresh rate with smooth motion.
   useEffect(() => {
+    // Reduced motion: no interpolation loop at all (see the return below, which
+    // hands back each frame's reported positions directly).
+    if (reducedMotion) return;
     let raf = 0;
     const loop = () => {
       const now = performance.now();
@@ -49,7 +54,10 @@ export function useSmoothedCars(state: RaceState): Car[] {
     };
     raf = requestAnimationFrame(loop);
     return () => cancelAnimationFrame(raf);
-  }, []);
+  }, [reducedMotion]);
 
-  return smoothed;
+  // Cars jump straight to each frame's reported position — still a positional
+  // update every 100ms, just without the continuous per-refresh glide. Derived
+  // rather than synced into state, so there is no second render per frame.
+  return reducedMotion ? Object.values(state.cars) : smoothed;
 }

--- a/web/src/styles/components.css
+++ b/web/src/styles/components.css
@@ -1,7 +1,38 @@
+/* Skip link — first focusable element on every route. Off-screen until
+   focused, then pinned top-left over the rail. */
+
+.skip-link {
+  position: absolute;
+  left: var(--sp-2);
+  top: var(--sp-2);
+  z-index: 10;
+  transform: translateY(-200%);
+  background: var(--chalk);
+  color: var(--asphalt);
+  padding: var(--sp-2) var(--sp-3);
+  border-radius: 4px;
+  font-family: var(--display);
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.skip-link:focus {
+  transform: translateY(0);
+}
+
 /* Page shell */
 
 .page {
+  position: relative;
   padding: var(--sp-4) var(--sp-6);
+  display: grid;
+  gap: var(--sp-6);
+}
+
+/* The <main> landmark inherits the page grid so wrapping the panels in it
+   does not change any spacing. */
+.route-main {
   display: grid;
   gap: var(--sp-6);
 }
@@ -82,6 +113,11 @@
   text-transform: uppercase;
 }
 
+.rail-tab:hover:not(.rail-tab-active) {
+  background: rgba(233, 237, 241, 0.06);
+  border-color: var(--slate);
+}
+
 .rail-tab-active {
   background: var(--chalk);
   color: var(--asphalt);
@@ -90,7 +126,7 @@
 
 .rail-tab-sub {
   font-family: var(--data);
-  font-size: 10px;
+  font-size: var(--fs-2xs);
   font-weight: 400;
   letter-spacing: 0;
   text-transform: none;
@@ -115,9 +151,12 @@
   letter-spacing: 0.02em;
 }
 
+/* --onair is the brand red but only 3.4:1 as text over its own wash. The wash
+   stays (it carries the brand); the label uses --bad, which measures 4.9:1
+   over this exact composite. */
 .chip-live {
   background: rgba(225, 6, 0, 0.15);
-  color: var(--onair);
+  color: var(--bad);
 }
 
 .chip-replay {
@@ -154,10 +193,17 @@
   border-bottom: 1px solid var(--edge);
   font-family: var(--display);
   font-weight: 600;
-  font-size: var(--fs-xs);
+  font-size: var(--fs-sm);
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--slate);
+}
+
+.panel-plate h2 {
+  margin: 0;
+  font: inherit;
+  letter-spacing: inherit;
+  color: inherit;
 }
 
 .panel-body {
@@ -175,6 +221,22 @@
   border-radius: 4px;
   font-family: var(--data);
   font-size: var(--fs-md);
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.btn:hover:not(:disabled):not(.btn-active) {
+  background: rgba(233, 237, 241, 0.06);
+  border-color: var(--slate);
+}
+
+/* Icon-only controls (comms ▶/↻): square up toward a 44px target without
+   changing the text buttons around them. */
+.btn-icon {
+  min-width: 36px;
+  min-height: 36px;
+  padding: var(--sp-2);
+  line-height: 1;
 }
 
 .btn:disabled {
@@ -189,7 +251,7 @@
 }
 
 .src-error {
-  color: var(--onair);
+  color: var(--bad);
   font-family: var(--data);
   font-size: var(--fs-sm);
 }
@@ -250,7 +312,7 @@
   background: rgba(233, 237, 241, 0.04);
 }
 
-.tt-row[aria-selected="true"] {
+.tt-row-selected {
   background: var(--edge);
 }
 
@@ -325,4 +387,51 @@
   .chip {
     transition: background 200ms, color 200ms;
   }
+}
+
+/* Range input — the default Windows chrome is light even under color-scheme:
+   dark, so the ghost scrubber gets an explicit dark track and thumb. */
+
+.ghost-controls input[type="range"] {
+  appearance: none;
+  -webkit-appearance: none;
+  background: transparent;
+  height: 20px;
+  cursor: pointer;
+}
+
+.ghost-controls input[type="range"]:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.ghost-controls input[type="range"]::-webkit-slider-runnable-track {
+  height: 4px;
+  border-radius: 2px;
+  background: var(--edge);
+}
+
+.ghost-controls input[type="range"]::-moz-range-track {
+  height: 4px;
+  border-radius: 2px;
+  background: var(--edge);
+}
+
+.ghost-controls input[type="range"]::-webkit-slider-thumb {
+  appearance: none;
+  -webkit-appearance: none;
+  width: 14px;
+  height: 14px;
+  margin-top: -5px;
+  border-radius: 50%;
+  background: var(--chalk);
+  border: 1px solid var(--asphalt);
+}
+
+.ghost-controls input[type="range"]::-moz-range-thumb {
+  width: 14px;
+  height: 14px;
+  border: 1px solid var(--asphalt);
+  border-radius: 50%;
+  background: var(--chalk);
 }

--- a/web/src/styles/tokens.css
+++ b/web/src/styles/tokens.css
@@ -1,11 +1,33 @@
 :root {
+  /* Native form controls, scrollbars and select popups follow this. Without it
+     Windows renders light chrome inside a dark page. */
+  color-scheme: dark;
+
   --asphalt: #0B0D10;  /* page background */
   --carbon:  #14171C;  /* panel background */
   --edge:    #232A33;  /* 1px borders, dividers */
   --chalk:   #E9EDF1;  /* primary text */
   --slate:   #8A94A0;  /* secondary text */
-  --amber:   #FFB000;  /* ATTENTION ONLY: stall, reconnect, flags */
-  --onair:   #E10600;  /* LIVE indicator only */
+  --dim:     #646D79;  /* deliberately-off states (DRS inactive) — 3.4:1 on carbon */
+  --amber:   #FFB000;  /* ATTENTION ONLY: stall, reconnect, flags, safety car */
+  --onair:   #E10600;  /* F1 brand red — FILLS ONLY (the LIVE chip wash). Too dark
+                          for text on carbon at 3.6:1; use --bad for red text. */
+
+  /* Semantic pair for "better/worse" readouts: DRS on, throttle vs brake,
+     faster/slower sparkline bars, ghost delta sign, error text.
+     Contrast on --carbon: --good 6.7:1, --bad 5.2:1. --bad also clears 4.5:1
+     over the .chip-live wash (4.9:1). Verified with WCAG relative-luminance
+     math, not by eye. */
+  --good: #3BB273;
+  --bad:  #FF4238;
+
+  --best-session: #B14AFF;  /* purple sector — session best (4.5:1 on carbon) */
+  --rain: #5AB0F0;  /* weather readout — deliberately NOT Red Bull's #3671C6 */
+
+  /* Track map chrome, shared by the board map and the ghost overlay. */
+  --track-edge:  #333333;  /* outer casing stroke */
+  --track-fill:  #1A1A1A;  /* inner surface stroke */
+  --track-label: #EEEEEE;  /* driver code beside a car marker */
 
   --display: 'Chakra Petch', system-ui, sans-serif;
   --data: 'Martian Mono Variable', 'Martian Mono', ui-monospace, Consolas, monospace;
@@ -16,6 +38,8 @@
   --sp-4: 16px;
   --sp-6: 24px;
 
+  --fs-3xs: 9px;
+  --fs-2xs: 10px;
   --fs-xs: 11px;
   --fs-sm: 12px;
   --fs-md: 13px;
@@ -41,4 +65,17 @@ body {
 :focus-visible {
   outline: 2px solid var(--chalk);
   outline-offset: 2px;
+}
+
+/* Available to screen readers and keyboard focus, invisible on screen. */
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
 }


### PR DESCRIPTION
Acts on a repo-wide triple design review (ui-ux-pro-max, Anthropic frontend-design, Vercel web-design-guidelines). All three agreed on no redesign, so the pit-wall aesthetic is untouched — this is consolidation plus an accessibility and contrast pass.

## Tokens

- `--good` / `--bad` replace four different green/red pairs that had drifted apart across `TelemetryPanel`, `Ghost`, `RaceControl` and `Comms`; the ad-hoc orange routes through the existing `--amber`.
- New `--dim` (deliberately-off states), `--rain` (the old rain colour was *exactly* Red Bull's team colour, so weather and a team read identically), `--best-session`, and `--track-*` for map chrome.
- Every inline `fontSize` and both px `font-size` rules in CSS move onto the `--fs-*` scale, extended with `--fs-3xs` (9px) and `--fs-2xs` (10px). A sweep confirms none are left.
- `TrackPath` extracts the casing/surface stroke pair that the board map and the ghost overlay each carried their own copy of.

`TYRE_COLOUR` and `teamColour` keep their hexes deliberately — those are F1's own palettes, not UI values.

## Accessibility

- A new `Route` shell gives every route a skip link (first focusable element), a visually-hidden `<h1>`, and a `<main>` landmark for the skip link to target. Panel titles become `<h2>`, which also un-orphans the `<h3>` in Settings. Verified in-browser: all four routes read `h1 → h2 → h3` with exactly one `main#main`.
- Polite live regions on the status chip, the source-switch error, comms playback errors, and `role="alert"` on the error-boundary fallback. The comms one matters most — a blocked clip's banner was the *only* feedback a ▶/↻ click gave.
- `<tr role="button" aria-selected>` is invalid ARIA on a plain table row (no grid/listbox ancestor). Selection is now a class plus `aria-pressed`, with the CSS selector updated to match; keyboard handling is unchanged.
- The ghost driver `<select>` gets a real label association.

## Contrast

Computed with WCAG relative-luminance math rather than judged by eye:

| element | before | after |
| --- | --- | --- |
| LIVE chip label | 3.37:1 | **4.86:1** |
| `.src-error` text | 3.62:1 | **5.21:1** |
| DRS off-state | 1.24:1 (`--edge`, a border colour) | **3.43:1** (`--dim`) |

The brand wash on the LIVE chip stays — it carries the identity. Only the label colour changes. The review flagged the chip; the same measurement showed `--onair` also failed as `.src-error` text, so it is now documented as fill-only.

Where colour was the sole signal, there is now a redundant cue: sector bests carry an `S`/`P` glyph, slower sparkline bars carry a hatch overlay, and throttle/brake are opposite colours instead of both green (a full-brake trace previously looked like a full-throttle one).

## Motion and interaction

`useReducedMotion` (built on `useSyncExternalStore`) reaches the two animations driven from JS, which a CSS media query cannot: the map snaps to each frame instead of interpolating, and the ghost lap defaults to paused with the scrubber still fully live.

Verified in-browser by temporarily forcing the hook on: ghost held at `0:00.000` with a `▶ Play` button, and the map's car dots updated straight from state. The override was reverted.

Also: `:hover` on `.btn` and `.rail-tab`, `color-scheme: dark` (Windows was rendering light native select popups and scrollbars inside a dark page), `touch-action` and tap-highlight reset on `.btn`, larger comms icon targets, and a dark-styled range input.

## Polish

Distinct sparkline aria-labels, stint bars get `aria-label` rather than being title-attribute-only, the decorative 📻 is dropped, and the panel plate goes 11px → 12px.

## Verification

`npm run lint`, `npm test` (112 passing), `npm run build` and the FILE-MAP check all pass. Walked all four routes in a real browser against `docker compose`.

One thing this does **not** cover: normal (non-reduced) map animation still could not be watched, because the browser harness cannot composite frames and so never runs `requestAnimationFrame`. That path is unchanged by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)