### PR TITLE
fix(ingest): flush pending radio refs to a trailing frame at stream end

### DIFF
--- a/docs/adr/0008-live-radio-rides-frames.md
+++ b/docs/adr/0008-live-radio-rides-frames.md
@@ -55,3 +55,28 @@ file `SignalRClient` already writes (`CAPTURE_OUT`): a single real session settl
   earlier clips from the history panel, and the list is tiny.
 - **Fire live clips on the clock anyway, with a widened window** — the lag is unbounded
   (clips can publish minutes late); any window wide enough is a window that misfires.
+
+## Amended 2026-08 — refs pending at stream end (issue #62)
+
+"Refs ride frames" quietly assumed a frame would always follow. Both `_replay_capture`
+and `_run_live_signalr` only drained `pending_radio` inside the position-sample publish
+path — so a capture/stream that ended shortly after a `TeamRadio` message, or a ref that
+arrived before any `Position.z` data had flowed, sat in `pending_radio` and was dropped
+silently when the process exited. Two genuine options, same as the original decision:
+
+1. **Emit a trailing frame** on shutdown / end-of-capture carrying the pending refs.
+   Faithful to "refs ride frames": already-connected clients get them without needing
+   to reconnect.
+2. **Fold the remainder into the snapshot only** (`SET` without `PUBLISH`) — cheaper,
+   but invisible to already-connected clients until they reconnect, which contradicts
+   the "refs ride frames, snapshot accumulates" split above.
+
+Chose **option 1**. Both ingest paths now flush `pending_radio` into one extra frame on
+their way out — `_replay_capture` after its event loop ends, `_run_live_signalr` in a
+`finally` around `client.start()` so it runs on every exit path (Ctrl-C, the SignalR
+client's own no-data timeout, or an exception propagating through). That frame bumps
+`rev` once more than the stream otherwise would have and carries no new car data; it
+reuses the last known car list rather than emitting an empty or invented one, so it
+stays well-formed against the `Frame` contract. The one case still deliberately dropped
+— a `TeamRadio` payload that arrived before `SessionInfo.Path` ever did, so its clip URL
+could never be resolved — is now logged at `WARNING` instead of vanishing silently.

--- a/ingest/live_signalr.py
+++ b/ingest/live_signalr.py
@@ -294,6 +294,49 @@ def _session_path_from_payload(payload):
     return ""
 
 
+def _publish_trailing_radio_frame(r, session, snapshot, rev, time_ms, cars_list, radio):
+    """Emit one extra frame carrying only pending radio refs, at stream end.
+
+    Both `_replay_capture` and `_run_live_signalr` only drain `pending_radio`
+    inside the position-sample publish path, so refs collected after the last
+    published frame (a capture/stream ending shortly after a TeamRadio message,
+    or one arriving before any position data flows) were previously dropped
+    silently at process exit (issue #62). Call this once, on the way out,
+    with whatever refs are still pending.
+
+    Bumps `rev` once more than the stream otherwise would have and carries no
+    new car data — ADR-0008's amendment accepts this trade-off in exchange for
+    already-connected clients actually receiving the refs. `cars_list` is the
+    latest known car list (may be empty if no position data ever arrived); we
+    reuse it rather than inventing data, so the frame stays well-formed against
+    the event model (Frame.Cars has no `omitempty`, so `[]` is the correct
+    empty representation, not `None`).
+    """
+    rev += 1
+    snapshot['radio'] = snapshot.get('radio', []) + radio
+    snapshot['rev'] = rev
+    if time_ms > snapshot.get('timeMs', 0):
+        snapshot['timeMs'] = time_ms
+    frame = build_frame(session, rev, snapshot['timeMs'], cars_list, radio=radio)
+    r.set(snap_key(session), json.dumps(snapshot, separators=(",", ":")))
+    r.publish(frames_chan(session), json.dumps(frame, separators=(",", ":")))
+    _log.info(
+        f"Published trailing frame at stream end with {len(radio)} pending "
+        "radio ref(s) that had not yet ridden a frame"
+    )
+    return rev
+
+
+def _log_dropped_deferred_radio(deferred_radio):
+    """Log (rather than silently drop) TeamRadio payloads that never got a
+    SessionInfo.Path to resolve clip URLs against, at stream end."""
+    if deferred_radio:
+        _log.warning(
+            f"Dropping {len(deferred_radio)} TeamRadio payload(s) at stream end: "
+            "SessionInfo.Path never arrived, so clip URLs could never be resolved"
+        )
+
+
 def _replay_capture(r, session: str, label: str, capture_path: str) -> None:
     """Replay a saved SignalR capture file through the Redis contract.
 
@@ -510,6 +553,19 @@ def _replay_capture(r, session: str, label: str, capture_path: str) -> None:
         r.set(snap_key(session), json.dumps(snapshot, separators=(",", ":")))
         r.publish(frames_chan(session), json.dumps(frame, separators=(",", ":")))
 
+    # Issue #62: refs collected after the loop's last publish (the capture ends
+    # shortly after a TeamRadio message, or one arrived before any position data)
+    # would otherwise be dropped silently. `session_s` still holds the last
+    # event's session-relative time (the loop always runs at least once here —
+    # an empty `events` list returns earlier), so the trailing frame's timeMs
+    # keeps advancing rather than rewinding.
+    if pending_radio:
+        rev = _publish_trailing_radio_frame(
+            r, session, snapshot, rev, int(session_s * 1000),
+            list(latest_cars.values()), list(pending_radio))
+        pending_radio.clear()
+    _log_dropped_deferred_radio(deferred_radio)
+
     _log.info(f"Capture replay complete. Published {rev - starting_rev(r, session)} frames")
 
 
@@ -699,6 +755,18 @@ def _run_live_signalr(r, session: str, label: str) -> None:
         client.start()
     except KeyboardInterrupt:
         _log.info("Stopped by user")
+    finally:
+        # Issue #62: client.start() returning — by Ctrl-C, the 2-minute no-data
+        # timeout (session ended), or any other reason — must not silently drop
+        # radio refs collected since the last position-triggered publish. Runs
+        # on every exit path, including an exception propagating past here.
+        if pending_radio:
+            rev_holder[0] = _publish_trailing_radio_frame(
+                r, session, snapshot_holder[0], rev_holder[0],
+                int(time.time() * 1000), list(latest_cars.values()),
+                list(pending_radio))
+            pending_radio.clear()
+        _log_dropped_deferred_radio(deferred_radio)
 
 
 # ---------------------------------------------------------------------------

--- a/ingest/live_signalr.py
+++ b/ingest/live_signalr.py
@@ -337,6 +337,42 @@ def _log_dropped_deferred_radio(deferred_radio):
         )
 
 
+def _shutdown_flush_radio(r, session, snapshot, rev, latest_cars, pending_radio, deferred_radio):
+    """`_run_live_signalr`'s shutdown-time radio flush: best-effort trailing
+    frame, then the deferred-drop log line — unconditionally. Returns the
+    (possibly bumped) rev.
+
+    Pulled out of the `finally` block so it can be driven directly in tests
+    without needing a real or faked SignalRClient, and so the ordering
+    guarantee (flush attempt, then deferred logging, no matter what) lives in
+    one place.
+
+    Called from a `finally` around `client.start()`: if that call raised
+    because Redis itself died (or is simply unreachable), an unguarded
+    `_publish_trailing_radio_frame` here would raise a *second* exception —
+    becoming the misleading proximate error in place of whatever
+    client.start() actually raised, and skipping `_log_dropped_deferred_radio`
+    entirely. Both defeat issue #62's "logged, never silent" guarantee. So the
+    flush is caught and logged at WARNING instead, and the deferred-drop log
+    always runs; the original exception from client.start(), if any, is
+    untouched by this function and propagates normally once `finally` exits.
+    """
+    if pending_radio:
+        n_pending = len(pending_radio)
+        try:
+            rev = _publish_trailing_radio_frame(
+                r, session, snapshot, rev, int(time.time() * 1000),
+                list(latest_cars.values()), list(pending_radio))
+            pending_radio.clear()
+        except Exception as exc:
+            _log.warning(
+                f"Failed to publish trailing frame: {n_pending} pending "
+                f"radio ref(s) lost at stream end: {exc}"
+            )
+    _log_dropped_deferred_radio(deferred_radio)
+    return rev
+
+
 def _replay_capture(r, session: str, label: str, capture_path: str) -> None:
     """Replay a saved SignalR capture file through the Redis contract.
 
@@ -759,14 +795,12 @@ def _run_live_signalr(r, session: str, label: str) -> None:
         # Issue #62: client.start() returning — by Ctrl-C, the 2-minute no-data
         # timeout (session ended), or any other reason — must not silently drop
         # radio refs collected since the last position-triggered publish. Runs
-        # on every exit path, including an exception propagating past here.
-        if pending_radio:
-            rev_holder[0] = _publish_trailing_radio_frame(
-                r, session, snapshot_holder[0], rev_holder[0],
-                int(time.time() * 1000), list(latest_cars.values()),
-                list(pending_radio))
-            pending_radio.clear()
-        _log_dropped_deferred_radio(deferred_radio)
+        # on every exit path, including an exception propagating past here (see
+        # _shutdown_flush_radio's docstring for why the flush itself must be
+        # best-effort here, unlike _replay_capture's — this one is a `finally`).
+        rev_holder[0] = _shutdown_flush_radio(
+            r, session, snapshot_holder[0], rev_holder[0], latest_cars,
+            pending_radio, deferred_radio)
 
 
 # ---------------------------------------------------------------------------

--- a/ingest/test_capture_replay.py
+++ b/ingest/test_capture_replay.py
@@ -23,7 +23,7 @@ pytest.importorskip("fastf1", reason="needs fastf1 for LiveTimingData; not insta
 
 sys.path.insert(0, os.path.dirname(__file__))
 
-from live_signalr import _replay_capture  # noqa: E402
+from live_signalr import _replay_capture, _shutdown_flush_radio  # noqa: E402
 
 CAPTURE_PATH = os.path.join(os.path.dirname(__file__), "tests", "capture_sample.txt")
 CAPTURE_PATH_RADIO_TAIL = os.path.join(
@@ -45,6 +45,15 @@ class FakeRedis:
 
     def publish(self, channel, message):
         self.published.append((channel, message))
+
+
+class FailingPublishRedis(FakeRedis):
+    """FakeRedis whose publish() always raises — simulates Redis dying (or
+    being unreachable) at the exact moment of the shutdown-time trailing-frame
+    flush, for PR #68's review fix."""
+
+    def publish(self, channel, message):
+        raise ConnectionError("simulated Redis outage")
 
 
 def test_replay_capture_populates_timing_and_tyre_fields():
@@ -144,7 +153,68 @@ def test_replay_capture_flushes_trailing_radio_at_capture_end():
     assert trailing["timeMs"] >= all_published[0]["timeMs"]
 
 
+def test_shutdown_flush_survives_redis_failure_without_masking_original_exception(caplog):
+    """PR #68 review fix: `_run_live_signalr`'s shutdown flush (`_shutdown_flush_radio`,
+    called from a `finally` around client.start()) must be best-effort.
+
+    If client.start() raised because Redis itself died — or Redis is simply
+    unreachable at shutdown — an unguarded flush would raise a *second*
+    exception from inside that `finally`. That both (a) becomes a misleading
+    proximate error in place of whatever client.start() actually raised, and
+    (b) skips the deferred-drop log line entirely, defeating issue #62's
+    "logged, never silent" guarantee for a *different* reason than the one
+    it was built to cover.
+
+    Reproduces that shape directly (a real `try/finally` around a raising
+    "client.start()", exactly as in `_run_live_signalr`) with a Redis stand-in
+    whose publish() always raises, and checks all three things: the WARNING
+    for the lost pending refs, the deferred-drop WARNING still firing
+    afterward, and the *original* exception — not a Redis one — propagating.
+    """
+    r = FailingPublishRedis()
+    snapshot = {"session": "test-session", "mode": "live", "cars": {}, "radio": [],
+                "rev": 5, "timeMs": 1000}
+    pending_radio = [{"timeMs": 1500, "driverNum": 1,
+                       "clip": "https://livetiming.formula1.com/static/x/MAXVER01.mp3"}]
+    # Contrived (the real code never has both non-empty from the same run — deferred
+    # only ever drains *into* pending), but _shutdown_flush_radio takes them as two
+    # independent parameters, and both must be handled correctly regardless.
+    deferred_radio = [{"Captures": [{"Utc": "2024-09-01T12:59:10Z", "RacingNumber": "1",
+                                      "Path": "TeamRadio/UNRESOLVED.mp3"}]}]
+
+    def client_start():
+        raise RuntimeError("SignalR stream died (simulated Redis connection loss)")
+
+    caught = None
+    with caplog.at_level("WARNING", logger="live_signalr"):
+        try:
+            try:
+                client_start()
+            finally:
+                # Mirrors _run_live_signalr's `finally` block exactly.
+                _shutdown_flush_radio(
+                    r, "test-session", snapshot, 5, {}, pending_radio, deferred_radio)
+        except RuntimeError as exc:
+            caught = exc
+
+    assert caught is not None, "the original exception must still propagate"
+    assert "SignalR stream died" in str(caught), (
+        "the flush's own Redis failure must not replace the original exception "
+        f"as the proximate error, got: {caught!r}"
+    )
+
+    messages = [rec.message for rec in caplog.records]
+    assert any("Failed to publish trailing frame" in m and "1 pending" in m for m in messages), messages
+    assert any("Dropping 1 TeamRadio payload" in m for m in messages), messages
+
+    # The failed flush must not have thrown away the refs it failed to deliver.
+    assert pending_radio, "pending radio refs must survive a failed flush, not be dropped"
+
+
 if __name__ == "__main__":
+    # test_shutdown_flush_survives_redis_failure_without_masking_original_exception
+    # takes pytest's `caplog` fixture, so it can't be called directly here — run
+    # this file through pytest to exercise it.
     test_replay_capture_populates_timing_and_tyre_fields()
     test_replay_capture_delivers_live_radio_on_frames()
     test_replay_capture_flushes_trailing_radio_at_capture_end()

--- a/ingest/test_capture_replay.py
+++ b/ingest/test_capture_replay.py
@@ -26,6 +26,8 @@ sys.path.insert(0, os.path.dirname(__file__))
 from live_signalr import _replay_capture  # noqa: E402
 
 CAPTURE_PATH = os.path.join(os.path.dirname(__file__), "tests", "capture_sample.txt")
+CAPTURE_PATH_RADIO_TAIL = os.path.join(
+    os.path.dirname(__file__), "tests", "capture_sample_radio_tail.txt")
 
 
 class FakeRedis:
@@ -100,8 +102,51 @@ def test_replay_capture_delivers_live_radio_on_frames():
     assert len(framed[0]["radio"]) == 2, framed[0]
 
 
+TAIL_CLIP = ("https://livetiming.formula1.com/static/"
+             "2024/2024-09-01_Italian_Grand_Prix/2024-09-01_Race/TeamRadio/"
+             "MAXVER01_1_20240901_130000.mp3")
+
+
+def test_replay_capture_flushes_trailing_radio_at_capture_end():
+    """Radio arriving after the last position-triggered frame must still reach
+    subscribers (issue #62). capture_sample_radio_tail.txt's *last* event is a
+    TeamRadio message — unlike capture_sample.txt, which ends on Position.z — so
+    with the pre-fix code (refs only drained inside the position-publish branch)
+    that ref never rides any frame and is silently dropped at replay end.
+    """
+    r = FakeRedis()
+    _replay_capture(r, "test-session", "Test Capture", CAPTURE_PATH_RADIO_TAIL)
+
+    snap = json.loads(r.store["snapshot:test-session"])
+    refs = snap.get("radio", [])
+    assert len(refs) == 1, f"expected the trailing TeamRadio ref to reach the snapshot, got {refs}"
+    assert refs[0]["clip"] == TAIL_CLIP, refs
+    assert refs[0]["driverNum"] == 1, refs
+
+    all_published = [json.loads(msg) for _, msg in r.published]
+    assert len(all_published) >= 2, (
+        "expected the Position.z sample's own frame plus a separate trailing "
+        f"radio-only frame, got {all_published}"
+    )
+    trailing = all_published[-1]
+    assert trailing.get("radio", []) and len(trailing["radio"]) == 1, trailing
+    assert trailing["radio"][0]["clip"] == TAIL_CLIP, trailing
+
+    # The trailing frame carries no new car data — it reuses the last known
+    # car list (from the one Position.z sample) rather than emitting nothing
+    # or something malformed against the Frame contract.
+    assert trailing["cars"], "expected the trailing frame to reuse the last known car list"
+    assert trailing["cars"][0]["driverNum"] == 1
+
+    # rev keeps advancing past the last regular frame (the trailing frame is a
+    # real, later frame, not a rewind), and timeMs does not go backwards.
+    assert trailing["rev"] > all_published[0]["rev"]
+    assert trailing["timeMs"] >= all_published[0]["timeMs"]
+
+
 if __name__ == "__main__":
     test_replay_capture_populates_timing_and_tyre_fields()
     test_replay_capture_delivers_live_radio_on_frames()
+    test_replay_capture_flushes_trailing_radio_at_capture_end()
     print("capture-replay field-coverage self-check PASSED")
     sys.exit(0)

--- a/ingest/tests/capture_sample_radio_tail.txt
+++ b/ingest/tests/capture_sample_radio_tail.txt
@@ -1,0 +1,5 @@
+["SessionStatus", {"StatusSeries": [{"Utc": "2024-09-01T13:00:00.000Z", "SessionStatus": "Started"}]}, "2024-09-01T13:00:00.000Z"]
+["DriverList", {"1": {"RacingNumber": "1", "Tla": "VER", "TeamName": "Red Bull Racing"}}, "2024-09-01T13:00:00.000Z"]
+["SessionInfo", {"Path": "2024/2024-09-01_Italian_Grand_Prix/2024-09-01_Race/"}, "2024-09-01T13:00:00.000Z"]
+["Position.z", {"Position": [{"Timestamp": "2024-09-01T13:00:00.300Z", "Entries": {"1": {"X": 1000, "Y": 2000, "Z": 0, "Status": "OnTrack"}}}]}, "2024-09-01T13:00:00.300Z"]
+["TeamRadio", {"Captures": [{"Utc": "2024-09-01T13:00:00.5Z", "RacingNumber": "1", "Path": "TeamRadio/MAXVER01_1_20240901_130000.mp3"}]}, "2024-09-01T13:00:00.600Z"]


### PR DESCRIPTION
## Summary

Closes #62

- \`pending_radio\` was only drained inside the position-sample publish branch of \`_replay_capture\` / \`_run_live_signalr\`, so radio refs collected after the last published frame (capture/stream ends shortly after a \`TeamRadio\` message, or one arrives before any \`Position.z\` data flows) were silently dropped at process exit.
- Implements the evaluator's chosen option 1 from the issue: emit a **trailing frame** on shutdown / end-of-capture carrying the pending refs, keeping "refs ride frames" true for already-connected clients instead of leaving them blind until reconnect (option 2).
- Applied to both ingest paths:
  - \`_replay_capture\`: flushes after its event loop ends.
  - \`_run_live_signalr\`: flushes in a \`finally\` wrapped around \`client.start()\`, so it fires on every exit path (Ctrl-C, the SignalR client's own no-data timeout, or an exception propagating through).
- The trailing frame reuses the last known car list (never invents data) and bumps \`rev\` once more; \`timeMs\` never rewinds.
- \`TeamRadio\` payloads that never got a \`SessionInfo.Path\` to resolve a clip URL against (still parked in \`deferred_radio\` at shutdown) are now logged at \`WARNING\` instead of vanishing without a trace.
- Amends \`docs/adr/0008-live-radio-rides-frames.md\` with the tail case, following the existing amendment convention used in ADR-0003.

## Test plan

- [x] Added \`ingest/tests/capture_sample_radio_tail.txt\` — a fixture whose *last* event is \`TeamRadio\` (the existing \`capture_sample.txt\` ends on \`Position.z\`, so it can't cover this).
- [x] Added \`test_replay_capture_flushes_trailing_radio_at_capture_end\` in \`ingest/test_capture_replay.py\`.
- [x] Confirmed red→green: stashed the \`live_signalr.py\` fix, ran the new test — failed with \`AssertionError: expected the trailing TeamRadio ref to reach the snapshot, got []\`. Restored the fix — test passes.
- [x] \`python -m pytest .\` in \`ingest/\` — 43 passed.
- [x] \`ruff check ingest bench\` (ruff 0.14.5) — All checks passed.
- [x] \`python scripts/gen_file_map.py --check\` — FILE-MAP.md is current (new file is a \`.txt\` fixture, outside \`SOURCE_SUFFIXES\`, so no regen needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)