### PR TITLE
fix(scripts): make FILE-MAP ingest description stable, not size-based

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,9 @@ jobs:
         run: pip install ruff==0.14.5 && ruff check ingest bench
       - name: FILE-MAP is current
         run: python scripts/gen_file_map.py --check
+      - name: scripts self-checks (pytest)
+        run: python -m pytest .
+        working-directory: scripts
 
       - name: ingest self-checks (pytest)
         run: python -m pytest .

--- a/FILE-MAP.md
+++ b/FILE-MAP.md
@@ -20,7 +20,7 @@ docstring — an orientation gap, not an omission by the generator.
 | `internal/feed/replay` | 2 | replay reads a .jsonl clip and replays it as a frame stream. |
 | `internal/model` | 5 | model is the normalised contract shared by every layer (and, later, Python). |
 | `internal/ws` | 7 | ws is the gateway-side WebSocket fan-out hub. |
-| `ingest` | 18 | True-live FastF1 SignalR ingest mode (exploratory, session-only). |
+| `ingest` | 19 | Records FastF1 sessions to JSONL replay clips and runs the true-live SignalR ingest path. |
 | `bench` | 2 | Drive the loadtest sweeps behind BENCHMARKS.md by running cmd/loadtest at increasing concurrency and recording gateway resource usage. |
 | `web/src` | 3 | The React app shell: mounts the root component, wires the live WebSocket or static-replay data source into race state, and lays out the dashboard panels. |
 | `web/src/components` | 22 | The dashboard's presentational components — map, timing tower, standings, telemetry, comms, race control, ghost/compare overlays, and their shared layout/formatting helpers. |
@@ -28,4 +28,4 @@ docstring — an orientation gap, not an omission by the generator.
 | `web/src/realtime` | 4 | The frontend's data-source connections: a reconnecting live WebSocket and a paced static-replay reader, both feeding the same RaceState reducer. |
 | `web/src/state` | 9 | The frontend's race state: wire message types, the applyMessage reducer, and the comms/ghost sub-state it composes. |
 
-17 source directories, 97 files, 0 without a declared purpose.
+17 source directories, 98 files, 0 without a declared purpose.

--- a/ingest/__init__.py
+++ b/ingest/__init__.py
@@ -1,0 +1,9 @@
+"""Records FastF1 sessions to JSONL replay clips and runs the true-live SignalR ingest path.
+
+This file exists to give the directory a stable, deliberate one-line purpose for
+FILE-MAP.md (scripts/gen_file_map.py's _py_pkg_doc) instead of letting the
+description flip to whichever module happens to be the largest — see issue #61.
+It is not meant to be imported: ingest/ modules import each other as plain
+top-level modules (e.g. `from live_signalr import ...`), and pytest is invoked
+as `pytest .` from inside ingest/, so this file carries no other behaviour.
+"""

--- a/scripts/gen_file_map.py
+++ b/scripts/gen_file_map.py
@@ -52,17 +52,48 @@ def _go_doc(path):
     return ""
 
 
+def _docstring_first_line(f):
+    """First line of f's module docstring, past any shebang/comment preamble."""
+    src = f.read_text(encoding="utf-8", errors="replace")
+    # Skip a shebang and any encoding/comment preamble: the docstring is
+    # still the module docstring when `#!/usr/bin/env python3` precedes it.
+    src = re.sub(r"\A(?:\s*#[^\n]*\n)+", "", src)
+    m = re.match(r'\s*(?:"""|\'\'\')(.*?)(?:"""|\'\'\')', src, re.S)
+    if m and m.group(1).strip():
+        return _first_sentence(m.group(1).strip().splitlines()[0])
+    return ""
+
+
+def _py_pkg_doc(path):
+    """Module docstring of <path>/__init__.py, if the directory declares one.
+
+    Mirrors _go_doc / _ts_doc: a package docstring is a deliberate declaration
+    of what the *directory* is for, so it takes precedence over guessing from
+    whichever module happens to be the largest (see _py_doc) — that heuristic
+    flips a directory's description whenever an unrelated file grows past
+    another one, which is not a signal of anything (#61).
+    """
+    init = path / "__init__.py"
+    if not init.is_file():
+        return ""
+    return _docstring_first_line(init)
+
+
 def _py_doc(path):
-    """Module docstring of the most substantial non-test .py file in the dir."""
-    cands = [f for f in path.glob("*.py") if not f.name.startswith(("test_", "check_"))]
+    """Module docstring of the most substantial non-test .py file in the dir.
+
+    Fallback for directories with no __init__.py package docstring (see
+    _py_pkg_doc) — used only when a directory hasn't declared its own purpose.
+    """
+    cands = [
+        f
+        for f in path.glob("*.py")
+        if f.name != "__init__.py" and not f.name.startswith(("test_", "check_"))
+    ]
     for f in sorted(cands, key=lambda p: p.stat().st_size, reverse=True):
-        src = f.read_text(encoding="utf-8", errors="replace")
-        # Skip a shebang and any encoding/comment preamble: the docstring is
-        # still the module docstring when `#!/usr/bin/env python3` precedes it.
-        src = re.sub(r"\A(?:\s*#[^\n]*\n)+", "", src)
-        m = re.match(r'\s*(?:"""|\'\'\')(.*?)(?:"""|\'\'\')', src, re.S)
-        if m and m.group(1).strip():
-            return _first_sentence(m.group(1).strip().splitlines()[0])
+        doc = _docstring_first_line(f)
+        if doc:
+            return doc
     return ""
 
 
@@ -97,7 +128,7 @@ def _describe(path):
     if any(path.glob("*.go")):
         return _go_doc(path)
     if any(path.glob("*.py")):
-        return _py_doc(path)
+        return _py_pkg_doc(path) or _py_doc(path)
     return _ts_doc(path)
 
 

--- a/scripts/test.ps1
+++ b/scripts/test.ps1
@@ -13,6 +13,10 @@ Write-Host "== Web: npm test ==" -ForegroundColor Cyan
 Push-Location (Join-Path $root "web")
 try { npm test; if ($LASTEXITCODE -ne 0) { throw "npm test failed" } } finally { Pop-Location }
 
+Write-Host "== Python: pytest scripts ==" -ForegroundColor Cyan
+& $py -m pytest (Join-Path $root "scripts")
+if ($LASTEXITCODE -ne 0) { throw "pytest scripts failed" }
+
 Write-Host "== Python: pytest ingest ==" -ForegroundColor Cyan
 & $py -m pytest (Join-Path $root "ingest")
 if ($LASTEXITCODE -ne 0) { throw "pytest ingest failed" }

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -12,6 +12,9 @@ echo "== Go: go test ./... =="
 echo "== Web: npm test =="
 (cd "$root/web" && npm test)
 
+echo "== Python: pytest scripts =="
+"$py" -m pytest "$root/scripts"
+
 echo "== Python: pytest ingest =="
 "$py" -m pytest "$root/ingest"
 

--- a/scripts/test_gen_file_map.py
+++ b/scripts/test_gen_file_map.py
@@ -1,0 +1,80 @@
+"""Self-check for scripts/gen_file_map.py's Python directory-purpose precedence.
+
+Collectable by pytest (`pytest scripts`) AND runnable directly
+(`python scripts/test_gen_file_map.py`), same as the ingest/bench self-checks.
+
+Covers issue #61: a directory's one-line purpose must come from its own
+`__init__.py` module docstring when one exists, and only fall back to the
+largest-non-test-file heuristic when it doesn't — so adding lines to an
+unrelated module in the directory can never flip the description.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from gen_file_map import _describe, _py_doc, _py_pkg_doc  # noqa: E402
+
+
+def _write(path, name, text):
+    (path / name).write_text(text, encoding="utf-8")
+
+
+def test_pkg_doc_wins_over_larger_sibling_file(tmp_path):
+    # The __init__.py docstring is short; the sibling module is much larger.
+    # Precedence must still go to the package docstring (this is the bug from
+    # #61: byte count used to decide the winner).
+    _write(tmp_path, "__init__.py", '"""Directory-level purpose statement."""\n')
+    _write(
+        tmp_path,
+        "big_module.py",
+        '"""A much bigger module with its own, unrelated docstring.\n\n'
+        + ("padding line.\n" * 200)
+        + '"""\n',
+    )
+    assert _describe(tmp_path) == "Directory-level purpose statement."
+
+
+def test_falls_back_to_largest_file_when_no_pkg_doc(tmp_path):
+    # No __init__.py at all: behaves exactly like the old heuristic.
+    assert _py_pkg_doc(tmp_path) == ""
+    _write(tmp_path, "small.py", '"""Small module."""\n')
+    _write(tmp_path, "large.py", '"""Large module.\n\n' + ("padding.\n" * 50) + '"""\n')
+    assert _describe(tmp_path) == "Large module."
+    assert _py_doc(tmp_path) == "Large module."
+
+
+def test_pkg_doc_ignored_when_empty(tmp_path):
+    # An __init__.py with no docstring (or an empty one) is not a declaration —
+    # fall through to the largest-file heuristic exactly as if it were absent.
+    _write(tmp_path, "__init__.py", "# no docstring here\n")
+    _write(tmp_path, "only.py", '"""Only real docstring in the directory."""\n')
+    assert _py_pkg_doc(tmp_path) == ""
+    assert _describe(tmp_path) == "Only real docstring in the directory."
+
+
+def test_init_py_excluded_from_largest_file_fallback(tmp_path):
+    # Even if __init__.py itself is the largest file and carries no usable
+    # docstring, it must not be picked up by the largest-file scan either —
+    # it is the package marker, not a candidate module.
+    _write(tmp_path, "__init__.py", "# " + ("x" * 5000) + "\n")
+    _write(tmp_path, "tiny.py", '"""The real answer."""\n')
+    assert _describe(tmp_path) == "The real answer."
+
+
+def test_growing_one_module_does_not_change_a_directory_with_a_pkg_doc(tmp_path):
+    # Regression for the exact scenario in #61: ingest/live_signalr.py grew and
+    # flipped the directory description. With a package docstring declared,
+    # growing any sibling module must be a no-op for _describe's result.
+    _write(tmp_path, "__init__.py", '"""Stable directory purpose."""\n')
+    _write(tmp_path, "a.py", '"""A."""\n')
+    before = _describe(tmp_path)
+    _write(tmp_path, "a.py", '"""A, but now much longer.\n\n' + ("more.\n" * 500) + '"""\n')
+    after = _describe(tmp_path)
+    assert before == after == "Stable directory purpose."
+
+
+if __name__ == "__main__":
+    import pytest
+
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

- `scripts/gen_file_map.py`'s `_py_doc` picked a directory's one-line Purpose from whichever non-test `.py` file happened to be **largest**, so growing `ingest/live_signalr.py` silently flipped the `ingest` row in `FILE-MAP.md` (issue #61).
- Adds `_py_pkg_doc`, which reads `<dir>/__init__.py`'s module docstring first — mirroring how `_go_doc` reads the deliberate `// Package x ...` declaration and `_ts_doc` reads `@packageDocumentation` — falling back to the largest-file heuristic only when a directory declares no package docstring.
- Adds `ingest/__init__.py` with a docstring describing the directory as a whole (records FastF1 sessions to JSONL clips *and* runs the true-live SignalR ingest path), so the `ingest` row no longer depends on file size.
- Adds `scripts/test_gen_file_map.py`, a pytest self-check (collectible and directly runnable, matching the `ingest`/`bench` house style) covering the precedence rule: package docstring wins over the largest-file fallback, an empty/missing `__init__.py` docstring falls through correctly, `__init__.py` itself is excluded from the largest-file scan, and growing an unrelated sibling module doesn't change a directory's declared description.
- Wires `scripts self-checks (pytest)` into CI's `contract` job and into `scripts/test.sh` / `scripts/test.ps1`, the same way `ingest`/`bench` are already run.

## Verification

```
$ python scripts/gen_file_map.py --check
FILE-MAP.md is current

$ (cd ingest && python -m pytest . -q)
..........................................                               [100%]
42 passed in 14.79s

$ (cd bench && python -m pytest . -q)
...                                                                      [100%]
3 passed in 0.38s

$ python -m pytest scripts -q
.....                                                                    [100%]
5 passed in 0.53s

$ ruff check ingest bench   # ruff==0.14.5, matches CI
All checks passed!
```

`FILE-MAP.md`'s `ingest` row now reads: *"Records FastF1 sessions to JSONL replay clips and runs the true-live SignalR ingest path."* (19 source files, up from 18 — `__init__.py` itself is counted; the file-count line at the bottom of `FILE-MAP.md` was regenerated and reflects this).

Confirmed `ingest/__init__.py` doesn't break anything: `ingest/` modules import each other as plain top-level modules (`from live_signalr import ...`, etc.) with an explicit `sys.path.insert(0, os.path.dirname(__file__))` safety net in a couple of test files, and `pytest .` is invoked from inside `ingest/` in CI — both still resolve correctly with the package marker present (verified empirically before writing the real file).

## Test plan

- [x] `python scripts/gen_file_map.py --check` passes
- [x] `python -m pytest .` passes in `ingest/` (42 passed, same as baseline)
- [x] `python -m pytest .` passes in `bench/` (unaffected, sanity-checked)
- [x] `python -m pytest scripts` passes (new self-check, 5 passed)
- [x] `ruff check ingest bench` passes (ruff==0.14.5, CI's pin)
- [x] `FILE-MAP.md` regenerated; `ingest` row and file-count line verified by hand

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)