### PR TITLE
fix(security): secrets out of image layers, loopback gateway, hardened OKF workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,3 +10,6 @@ cache/
 *.out
 .playwright-mcp/
 *.png
+# Never bake credentials into image layers (Dockerfile does COPY . .)
+secrets/
+.env

--- a/.github/workflows/okf.yml
+++ b/.github/workflows/okf.yml
@@ -3,6 +3,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest
@@ -12,6 +15,6 @@ jobs:
         with:
           node-version: '20'
       - name: Validate knowledge/ bundle against the house standard
-        uses: natcat38/okf-portfolio-standard@v1
+        uses: natcat38/okf-portfolio-standard@bfc3f188263f0e16adc7e8961000a4ff0fc618d9 # v1
         with:
           path: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,5 +52,7 @@ services:
       ROLE: gateway
       REDIS_URL: redis://redis:6379
       SESSION_KEY: replay       # initial source the gateway fans out
-    ports: ["8080:8080"]
+    # Loopback only: every auth control (origin allowlist, Sec-Fetch-Site guard)
+    # assumes a single local operator, so don't publish LAN-wide.
+    ports: ["127.0.0.1:8080:8080"]
     depends_on: [redis, replay, live]


### PR DESCRIPTION
Fixes the three actionable findings from the repo-wide security review (full report kept locally in reviews/security.md, not committed):

- **High — token in Docker layers:** `.dockerignore` now excludes `secrets/` and `.env`. Previously `Dockerfile`'s `COPY . .` baked the operator's real F1TV token (`secrets/fastf1/f1auth.json`) into an intermediate build layer of all four images built from the root Dockerfile, recoverable via `docker history --no-trunc`. Existing local images built before this fix should be rebuilt (`docker compose build --no-cache`) if the token was present.
- **Medium — gateway published LAN-wide:** the gateway is now bound to `127.0.0.1:8080`. The origin allowlist and `Sec-Fetch-Site` guard assume a single local operator; `coder/websocket` accepts an absent `Origin`, so non-browser LAN clients were previously unrestricted.
- **Medium — OKF workflow permissions:** `okf.yml` now grants `contents: read` (was repo-default) and pins `natcat38/okf-portfolio-standard` to a commit SHA instead of the mutable `v1` tag.

Claims verified during the review (no change needed): no hardcoded secrets, token never logged / never sent to the frontend, signalrcore `--no-deps` handling sound, non-root containers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)