### PR TITLE
fix: reconcile positions on every publish path and read the leader off the running order

### DIFF
--- a/FILE-MAP.md
+++ b/FILE-MAP.md
@@ -20,12 +20,12 @@ docstring — an orientation gap, not an omission by the generator.
 | `internal/feed/replay` | 2 | replay reads a .jsonl clip and replays it as a frame stream. |
 | `internal/model` | 5 | model is the normalised contract shared by every layer (and, later, Python). |
 | `internal/ws` | 7 | ws is the gateway-side WebSocket fan-out hub. |
-| `ingest` | 19 | Records FastF1 sessions to JSONL replay clips and runs the true-live SignalR ingest path. |
+| `ingest` | 20 | Records FastF1 sessions to JSONL replay clips and runs the true-live SignalR ingest path. |
 | `bench` | 2 | Drive the loadtest sweeps behind BENCHMARKS.md by running cmd/loadtest at increasing concurrency and recording gateway resource usage. |
 | `web/src` | 3 | The React app shell: mounts the root component, wires the live WebSocket or static-replay data source into race state, and lays out the dashboard panels. |
-| `web/src/components` | 24 | The dashboard's presentational components — map, timing tower, standings, telemetry, comms, race control, ghost/compare overlays, and their shared layout/formatting helpers. |
+| `web/src/components` | 25 | The dashboard's presentational components — map, timing tower, standings, telemetry, comms, race control, ghost/compare overlays, and their shared layout/formatting helpers. |
 | `web/src/hooks` | 7 | React hooks that derive UI-facing state (staleness, gap/lap history, smoothed car positions, comms playback) from the raw RaceState stream. |
 | `web/src/realtime` | 4 | The frontend's data-source connections: a reconnecting live WebSocket and a paced static-replay reader, both feeding the same RaceState reducer. |
-| `web/src/state` | 9 | The frontend's race state: wire message types, the applyMessage reducer, and the comms/ghost sub-state it composes. |
+| `web/src/state` | 10 | The frontend's race state: wire message types, the applyMessage reducer, and the comms/ghost sub-state it composes. |
 
-17 source directories, 100 files, 0 without a declared purpose.
+17 source directories, 103 files, 0 without a declared purpose.

--- a/ingest/live.py
+++ b/ingest/live.py
@@ -26,6 +26,8 @@ import time
 
 import redis
 
+from resample import reconcile_positions
+
 
 def snap_key(s):
     return f"snapshot:{s}"
@@ -58,6 +60,14 @@ def build_snapshot(session, label, track, radio, lap_trace, stints, total_laps, 
 
 
 def build_frame(session, rev, time_ms, cars, messages=None, weather=None, radio=None):
+    # Every publish path in this package goes through here, so the unique-and-
+    # contiguous 1..N position invariant (#66) is enforced at this one choke
+    # point rather than at each call site — one of which (live_signalr.py's
+    # trailing radio frame) had already forgotten it. Sorts `cars` into running
+    # order and renumbers each dict's 'pos' IN PLACE; callers that fold the same
+    # dicts into a snapshot therefore see the reconciled value too. Idempotent,
+    # so an already-reconciled list (a baked clip) passes through unchanged.
+    cars = reconcile_positions(cars)
     frame = {
         "session": session, "rev": rev,
         "t": int(time.time() * 1000), "timeMs": time_ms, "cars": cars,

--- a/ingest/live_signalr.py
+++ b/ingest/live_signalr.py
@@ -145,7 +145,7 @@ from live import (
     build_frame,
 )
 from radio import live_radio_refs
-from resample import reconcile_positions, UNKNOWN_POS
+from resample import UNKNOWN_POS
 
 # Live team-radio clips resolve against this + SessionInfo.Path (ADR-0003 amended).
 STATIC_BASE = "https://livetiming.formula1.com"
@@ -295,6 +295,33 @@ def _session_path_from_payload(payload):
     return ""
 
 
+def _publish_frame(r, session, snapshot, rev, time_ms, latest_cars, running_positions, radio):
+    """Fold this frame's cars into the snapshot, store it, and publish the frame.
+
+    The reconcile-then-publish sequence `_replay_capture` and `_run_live_signalr`
+    both run on every rate-limited publish, in one place so the two can't drift.
+
+    `latest_cars`' dicts PERSIST across publishes (and are the very objects the
+    snapshot holds), while build_frame's reconciliation renumbers 'pos' in place.
+    So each car's raw feed position is re-stamped from `running_positions` first:
+    without it, a driver with no fresh Position.z sample this cycle would feed its
+    previous reconciled RANK back in as if it were raw feed data, letting its rank
+    stick or drift away from what the feed actually said.
+    """
+    for num_str, car in latest_cars.items():
+        car['pos'] = running_positions.get(num_str, UNKNOWN_POS)
+    # build_frame reconciles 'pos' into a unique, contiguous 1..N (see its comment).
+    frame = build_frame(session, rev, time_ms, list(latest_cars.values()), radio=radio)
+    for c in frame['cars']:
+        snapshot['cars'][str(c['driverNum'])] = c
+    snapshot['timeMs'] = time_ms
+    snapshot['rev'] = rev
+    if radio:
+        snapshot['radio'] = snapshot.get('radio', []) + radio
+    r.set(snap_key(session), json.dumps(snapshot, separators=(",", ":")))
+    r.publish(frames_chan(session), json.dumps(frame, separators=(",", ":")))
+
+
 def _publish_trailing_radio_frame(r, session, snapshot, rev, time_ms, cars_list, radio):
     """Emit one extra frame carrying only pending radio refs, at stream end.
 
@@ -311,7 +338,10 @@ def _publish_trailing_radio_frame(r, session, snapshot, rev, time_ms, cars_list,
     latest known car list (may be empty if no position data ever arrived); we
     reuse it rather than inventing data, so the frame stays well-formed against
     the event model (Frame.Cars has no `omitempty`, so `[]` is the correct
-    empty representation, not `None`).
+    empty representation, not `None`). Those cars go out reconciled like every
+    other frame's: build_frame does it, so this path can't ship the raw
+    duplicate/gapped/UNKNOWN_POS values it used to when the stream ended before
+    the rate limiter ever let a regular frame out.
     """
     rev += 1
     snapshot['radio'] = snapshot.get('radio', []) + radio
@@ -573,27 +603,10 @@ def _replay_capture(r, session: str, label: str, capture_path: str) -> None:
 
         last_publish = now
         rev += 1
-        time_ms = int(session_s * 1000)
-        # Reconcile 'pos' once per frame across all drivers (#66): each car's raw
-        # 'pos' above is an independent per-driver lookup into running_positions,
-        # so values can collide, leave gaps, or carry the UNKNOWN_POS sentinel.
-        # Mutates the car dicts in place, so the reconciled pos also lands in
-        # `snapshot` below (same dict references).
-        cars_list = reconcile_positions(list(latest_cars.values()))
-
-        for c in cars_list:
-            snapshot['cars'][str(c['driverNum'])] = c
-        snapshot['timeMs'] = time_ms
-        snapshot['rev'] = rev
-
         radio = list(pending_radio)
         pending_radio.clear()
-        if radio:
-            snapshot['radio'] = snapshot.get('radio', []) + radio
-
-        frame = build_frame(session, rev, time_ms, cars_list, radio=radio)
-        r.set(snap_key(session), json.dumps(snapshot, separators=(",", ":")))
-        r.publish(frames_chan(session), json.dumps(frame, separators=(",", ":")))
+        _publish_frame(r, session, snapshot, rev, int(session_s * 1000),
+                       latest_cars, running_positions, radio)
 
     # Issue #62: refs collected after the loop's last publish (the capture ends
     # shortly after a TeamRadio message, or one arrived before any position data)
@@ -760,23 +773,11 @@ def _run_live_signalr(r, session: str, label: str) -> None:
             last_publish[0] = now
 
             rev_holder[0] += 1
-            rev = rev_holder[0]
-            t_ms = int(time.time() * 1000)
-            # Reconcile 'pos' once per frame across all drivers (#66) — see the
-            # matching comment in _replay_capture above.
-            cars_list = reconcile_positions(list(latest_cars.values()))
-            snap = snapshot_holder[0]
-            for c in cars_list:
-                snap['cars'][str(c['driverNum'])] = c
-            snap['timeMs'] = t_ms
-            snap['rev'] = rev
             radio = list(pending_radio)
             pending_radio.clear()
-            if radio:
-                snap['radio'] = snap.get('radio', []) + radio
-            frame = build_frame(session, rev, t_ms, cars_list, radio=radio)
-            r.set(snap_key(session), json.dumps(snap, separators=(",", ":")))
-            r.publish(frames_chan(session), json.dumps(frame, separators=(",", ":")))
+            _publish_frame(r, session, snapshot_holder[0], rev_holder[0],
+                           int(time.time() * 1000), latest_cars,
+                           running_positions, radio)
 
     # Subclass SignalRClient to intercept messages after the file write.
     # UNVERIFIED: The exact structure of `msg` inside _on_message during a live

--- a/ingest/record.py
+++ b/ingest/record.py
@@ -681,6 +681,9 @@ with open(OUTPUT_PATH, 'w', encoding='utf-8') as f:
                 "pos": pos_order,
                 "p": {"x": nx, "y": ny},
                 "status": status_str,
+                # Doubles as reconcile_positions()'s tie-break below, so it is set
+                # here rather than in the gap/interval pass that also reads it.
+                "lap": _lap_number(dnum, t_s),
             }
             # Only attach non-zero/non-empty timing fields (mirror Go omitempty).
             if t['tyre']:
@@ -706,43 +709,30 @@ with open(OUTPUT_PATH, 'w', encoding='utf-8') as f:
                     car['drs'] = True
             cars.append(car)
 
-        # 'lap' is needed as reconcile_positions()'s tie-break, so it must be
-        # assigned before reconciliation rather than in the gap/interval pass below.
-        for car in cars:
-            car['lap'] = _lap_number(car['driverNum'], t_s)
-
-        # Reconcile 'pos' once per frame across all drivers (#66): get_position()
-        # above is an independent per-driver lookup, so raw values can collide,
-        # leave gaps, or carry the UNKNOWN_POS sentinel. This sorts by each
-        # driver's raw position (tie-broken by laps completed, then driver
-        # number) and renumbers 1..N so every frame's running order is unique
-        # and contiguous.
+        # Reconcile 'pos' into a unique, contiguous 1..N running order (#66) —
+        # get_position() above is an independent per-driver lookup, so raw values
+        # can collide, gap, or carry UNKNOWN_POS. See reconcile_positions' docstring.
+        # Returns `cars` sorted into that order, so P1 is cars[0] from here on.
         reconcile_positions(cars)
 
         # --- gap / interval pass (best-effort) ---
         # Race distance in "lap units" = whole lap number + fraction round the lap.
-        lapn, frac, dist = {}, {}, {}
-        for car in cars:
-            dn = car['driverNum']
-            lapn[dn] = car['lap']
-            frac[dn] = _lap_fraction(car['p']['x'], car['p']['y'])
-            dist[dn] = lapn[dn] + frac[dn]
-        by_pos = sorted(cars, key=lambda c: c['pos'])
-        # Anchor the leader to the CLASSIFIED P1 (matches the FE pos===1 leader test),
-        # not the max-distance car (derivation noise could disagree).
-        leader_dn = by_pos[0]['driverNum'] if by_pos else None
-        leader_dist = dist.get(leader_dn, 0.0)
-        leader_lap = lapn.get(leader_dn, 0)
-        leader_car = by_pos[0] if by_pos else None
+        dist = {car['driverNum']: car['lap'] + _lap_fraction(car['p']['x'], car['p']['y'])
+                for car in cars}
+        # Anchor the leader to the CLASSIFIED P1, not the max-distance car
+        # (derivation noise could disagree).
+        leader_car = cars[0] if cars else None
+        leader_dist = dist.get(leader_car['driverNum'], 0.0) if leader_car else 0.0
+        leader_lap = leader_car['lap'] if leader_car else 0
         leader_has_lap = leader_car is not None and 'lastLapMs' in leader_car
         prev_dist = None
         prev_has_lap = False
-        for car in by_pos:
+        for car in cars:
             dn = car['driverNum']
             has_lap = 'lastLapMs' in car
             behind = max(0.0, leader_dist - dist[dn])      # lap units behind leader
             gap_ms = int(behind * LEADER_LAP_MS)
-            gap_laps = max(0, leader_lap - lapn[dn])        # whole-lap deficit (from LapNumber)
+            gap_laps = max(0, leader_lap - car['lap'])      # whole-lap deficit (from LapNumber)
             # Suppress derived times until both ends have a completed reference lap —
             # the distance derivation is meaningless (and can be ~a lap wrong) before
             # then. Same lastLapMs signal the FE's gapLabel/intLabel guards use.
@@ -848,14 +838,30 @@ for idx in check_indices:
 
 # Scan every frame line (not just the sample) for weather presence and, when a
 # lap window was requested, an actual pit stop — the whole point of the re-bake.
+# The same pass checks reconcile_positions' actual invariant (#66): every frame's
+# positions unique and contiguous 1..N, with no UNKNOWN_POS sentinel. The sampled
+# per-frame checks above only assert pos is an int, which a duplicate/gapped/99
+# frame passes — exactly the bug that shipped.
 saw_weather = False
 saw_pit = False
-for line in lines[1:]:
+bad_positions = None    # (line index, positions) of the first offending frame
+for n, line in enumerate(lines[1:], start=1):
     fr = json.loads(line)['frame']
     if 'weather' in fr:
         saw_weather = True
     if any(c.get('status') == 'Pit' for c in fr['cars']):
         saw_pit = True
+    positions = sorted(c['pos'] for c in fr['cars'])
+    if bad_positions is None and positions != list(range(1, len(fr['cars']) + 1)):
+        bad_positions = (n, positions)
+if bad_positions is None:
+    print(f"  Positions OK: all {len(lines) - 1} frames carry a unique, contiguous 1..N order")
+else:
+    bad_line, bad = bad_positions
+    print(f"  POSITION ERROR: line {bad_line}: positions must be unique and "
+          f"contiguous 1..{len(bad)}, got {bad}")
+    errors += 1
+
 try:
     assert saw_weather, "no frame carried a 'weather' field"
     print("  Weather OK: at least one frame carries weather")

--- a/ingest/resample.py
+++ b/ingest/resample.py
@@ -64,10 +64,24 @@ def reconcile_positions(cars):
     have broken it. Then renumber 1..N so every frame's running order is
     unique and contiguous, and 99 never reaches the wire.
 
+    KNOWN LIMITATIONS (accepted, not yet addressed):
+      - Cold start: the renumbering is over whoever is in `cars` right now, so a
+        partial roster (only some drivers have reported at session start) gets a
+        dense 1..N over that subset — i.e. a plausible-looking but wrong running
+        order until the whole field reports.
+      - Retired cars: a car with status 'Out' still takes a rank inline rather
+        than being sunk to the tail, so a retirement holds its last position
+        ahead of cars still racing.
+
     cars: list of dicts, each with at least 'driverNum' and 'pos' (raw,
     possibly stale/duplicate/UNKNOWN_POS), and optionally 'lap' (laps
     completed so far). Mutates each dict's 'pos' in place. Returns the same
     list, now sorted into running order (rank 1 first).
+
+    Callers must pass RAW feed positions, not a previous call's output mixed
+    with fresh values: this renumbers in place, so re-feeding a car's own rank
+    as if it were feed data lets that rank stick (see live_signalr's
+    _publish_frame, which re-stamps every car from running_positions first).
     """
     cars.sort(key=lambda c: (c.get('pos', UNKNOWN_POS), -(c.get('lap') or 0), c['driverNum']))
     for i, c in enumerate(cars):

--- a/ingest/test_capture_replay.py
+++ b/ingest/test_capture_replay.py
@@ -24,27 +24,11 @@ pytest.importorskip("fastf1", reason="needs fastf1 for LiveTimingData; not insta
 sys.path.insert(0, os.path.dirname(__file__))
 
 from live_signalr import _replay_capture, _shutdown_flush_radio  # noqa: E402
+from test_live_publish import FakeRedis  # noqa: E402  (shared fake, defined fastf1-free)
 
 CAPTURE_PATH = os.path.join(os.path.dirname(__file__), "tests", "capture_sample.txt")
 CAPTURE_PATH_RADIO_TAIL = os.path.join(
     os.path.dirname(__file__), "tests", "capture_sample_radio_tail.txt")
-
-
-class FakeRedis:
-    """Minimal in-memory stand-in for redis.Redis — get/set/publish only."""
-
-    def __init__(self):
-        self.store = {}
-        self.published = []
-
-    def get(self, key):
-        return self.store.get(key)
-
-    def set(self, key, value):
-        self.store[key] = value
-
-    def publish(self, channel, message):
-        self.published.append((channel, message))
 
 
 class FailingPublishRedis(FakeRedis):

--- a/ingest/test_live_publish.py
+++ b/ingest/test_live_publish.py
@@ -1,0 +1,146 @@
+"""Unit tests for live_signalr.py's two publish paths, without fastf1 or Redis.
+
+test_capture_replay.py drives the same code through a real capture file, which
+needs fastf1 installed (it is skipped in CI's fastf1-free contract job). These
+tests poke `_publish_frame` / `_publish_trailing_radio_frame` directly instead,
+so the position-reconciliation invariants they cover run everywhere.
+"""
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from live_signalr import _publish_frame, _publish_trailing_radio_frame  # noqa: E402
+from resample import UNKNOWN_POS  # noqa: E402
+
+
+class FakeRedis:
+    """Minimal in-memory stand-in for redis.Redis — get/set/publish only."""
+
+    def __init__(self):
+        self.store = {}
+        self.published = []
+
+    def get(self, key):
+        return self.store.get(key)
+
+    def set(self, key, value):
+        self.store[key] = value
+
+    def publish(self, channel, message):
+        self.published.append((channel, message))
+
+    def frames(self):
+        """Every published frame, parsed, oldest first."""
+        return [json.loads(msg) for _, msg in self.published]
+
+
+def _car(dnum, pos, lap=10):
+    return {
+        'driverNum': dnum, 'code': f'D{dnum}', 'team': 'Test',
+        'pos': pos, 'p': {'x': 0.5, 'y': 0.5}, 'status': 'OnTrack', 'lap': lap,
+    }
+
+
+def _assert_contiguous(cars):
+    positions = sorted(c['pos'] for c in cars)
+    assert positions == list(range(1, len(cars) + 1)), (
+        f"positions must be unique and contiguous 1..N, got {positions}")
+    assert UNKNOWN_POS not in positions, f"{UNKNOWN_POS} must never reach the wire: {positions}"
+
+
+def _snapshot():
+    return {"session": "test-session", "mode": "live", "cars": {}, "rev": 0, "timeMs": 0}
+
+
+def test_trailing_radio_frame_reconciles_positions():
+    """The trailing radio frame is a publish path like any other, so its cars must
+    carry a unique, contiguous 1..N order too.
+
+    It used to be the one path that skipped reconciliation, so a stream ending
+    before the rate limiter ever let a regular frame out shipped the raw
+    per-driver lookups: duplicates, gaps and the UNKNOWN_POS (99) sentinel. The
+    existing capture-file regression test uses a single car, where reconciliation
+    is a no-op — this one needs several to bite.
+    """
+    r = FakeRedis()
+    snapshot = _snapshot()
+    cars = [
+        _car(1, 1, lap=20),
+        _car(44, 4, lap=20),                 # duplicate raw pos with 55...
+        _car(55, 4, lap=19),                 # ...and a gap at 2/3
+        _car(63, UNKNOWN_POS, lap=18),       # never reported by the feed
+    ]
+    refs = [{"timeMs": 1500, "driverNum": 1, "clip": "https://x/a.mp3"}]
+
+    _publish_trailing_radio_frame(r, "test-session", snapshot, 5, 2000, cars, refs)
+
+    frame = r.frames()[-1]
+    _assert_contiguous(frame['cars'])
+    by_num = {c['driverNum']: c['pos'] for c in frame['cars']}
+    assert by_num == {1: 1, 44: 2, 55: 3, 63: 4}, by_num
+    assert frame['radio'] == refs, frame
+
+
+def test_quiet_car_does_not_inherit_its_own_rank_as_input():
+    """A driver with no fresh Position.z sample must not feed its previous RANK
+    back in as if it were raw feed data.
+
+    `latest_cars`' dicts persist across publishes and reconciliation renumbers
+    'pos' in place, so without re-stamping from `running_positions` every publish
+    a quiet car's rank sticks: a position change the feed *did* report can then
+    never move it. Two publishes, a position swap reported between them, no fresh
+    car dicts in between — the shape the live handler actually produces.
+    """
+    r = FakeRedis()
+    snapshot = _snapshot()
+    # Raw feed order: 1 leads, 44 second, then a gap up to 16 (P8) and 63 (P9).
+    running_positions = {'1': 1, '44': 2, '16': 8, '63': 9}
+    latest_cars = {
+        '1': _car(1, 1), '44': _car(44, 2), '16': _car(16, 8), '63': _car(63, 9),
+    }
+
+    _publish_frame(r, "test-session", snapshot, 1, 1000, latest_cars, running_positions, [])
+    first = r.frames()[-1]
+    _assert_contiguous(first['cars'])
+    assert {c['driverNum']: c['pos'] for c in first['cars']} == {1: 1, 44: 2, 16: 3, 63: 4}
+
+    # The feed now reports 63 ahead of 16. No new Position.z arrives for anyone,
+    # so latest_cars still holds the SAME dicts — whose 'pos' the publish above
+    # rewrote to 1/2/3/4.
+    running_positions['16'], running_positions['63'] = 9, 8
+
+    _publish_frame(r, "test-session", snapshot, 2, 2000, latest_cars, running_positions, [])
+    second = r.frames()[-1]
+    _assert_contiguous(second['cars'])
+    by_num = {c['driverNum']: c['pos'] for c in second['cars']}
+    assert by_num == {1: 1, 44: 2, 63: 3, 16: 4}, (
+        "the swap the feed reported must reach the wire; a stale rank fed back in "
+        f"as raw input would have kept 16 at P3, got {by_num}")
+
+    # The snapshot holds the same car dicts, so it agrees with the frame.
+    assert {int(k): v['pos'] for k, v in snapshot['cars'].items()} == by_num
+
+
+def test_publish_frame_demotes_a_car_the_feed_never_reported():
+    """A driver present in Position.z but absent from TimingData has no raw
+    position at all; UNKNOWN_POS must sort it last and never reach the wire."""
+    r = FakeRedis()
+    snapshot = _snapshot()
+    running_positions = {'1': 1, '44': 2}
+    latest_cars = {'1': _car(1, 1), '44': _car(44, 2), '63': _car(63, UNKNOWN_POS, lap=18)}
+
+    _publish_frame(r, "test-session", snapshot, 1, 1000, latest_cars, running_positions, [])
+
+    frame = r.frames()[-1]
+    _assert_contiguous(frame['cars'])
+    assert {c['driverNum']: c['pos'] for c in frame['cars']} == {1: 1, 44: 2, 63: 3}
+
+
+if __name__ == "__main__":
+    test_trailing_radio_frame_reconciles_positions()
+    test_quiet_car_does_not_inherit_its_own_rank_as_input()
+    test_publish_frame_demotes_a_car_the_feed_never_reported()
+    print("live publish-path self-check PASSED")
+    sys.exit(0)

--- a/web/src/components/Standings.render.test.tsx
+++ b/web/src/components/Standings.render.test.tsx
@@ -1,0 +1,39 @@
+import { describe, test, expect } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { Standings } from './Standings';
+import { emptyState } from '../state/race';
+import { car } from '../state/testCar';
+
+describe('Standings leader label', () => {
+  test('labels the front-runner LEADER', () => {
+    const state = {
+      ...emptyState(),
+      cars: {
+        1: car({ driverNum: 1, code: 'VER', pos: 1, lap: 12, lastLapMs: 85000 }),
+        16: car({ driverNum: 16, code: 'LEC', pos: 2, lap: 12, lastLapMs: 85500, gapMs: 1200 }),
+      },
+    };
+    const html = renderToStaticMarkup(<Standings state={state} />);
+    expect(html).toContain('LEADER');
+    expect(html).toContain('+1.200');
+  });
+
+  test('degrades honestly instead of labelling nobody when no car carries a literal pos:1 (#66)', () => {
+    // Mirrors the StatusRail/StintChart tests: the Monza-2024-shaped frame with
+    // two cars tied on a stale pos and none at pos:1. Reading the leader off
+    // orderCars' running order keeps a LEADER row; the old `c.pos === 1` test
+    // labelled nobody and showed a nonsense gap for the actual front-runner.
+    const state = {
+      ...emptyState(),
+      cars: {
+        22: car({ driverNum: 22, code: 'TSU', pos: 19, lap: 7, lastLapMs: 86000, gapMs: 90000 }),
+        27: car({ driverNum: 27, code: 'HUL', pos: 19, lap: 12, lastLapMs: 85000, gapMs: 0 }),
+      },
+    };
+    const html = renderToStaticMarkup(<Standings state={state} />);
+    expect(html).toContain('LEADER');
+    // ...and it is the front-runner's row that carries it, not the lapped car's.
+    expect(html.indexOf('HUL')).toBeLessThan(html.indexOf('LEADER'));
+    expect(html.indexOf('LEADER')).toBeLessThan(html.indexOf('TSU'));
+  });
+});

--- a/web/src/components/Standings.tsx
+++ b/web/src/components/Standings.tsx
@@ -9,7 +9,7 @@ export function Standings({ state }: { state: RaceState }) {
   const order = orderCars(state.cars);
   return (
     <ol style={{ lineHeight: 1.8, margin: 0, paddingLeft: '1.4em', fontVariantNumeric: 'tabular-nums' }}>
-      {order.map((c) => (
+      {order.map((c, idx) => (
         <li key={c.driverNum}>
           <b>{c.code}</b>{' '}
           <span style={{ color: TYRE_COLOUR[c.tyre ?? ''] ?? 'var(--slate)' }}>
@@ -17,7 +17,10 @@ export function Standings({ state }: { state: RaceState }) {
           </span>{' '}
           <span>{fmtLap(c.lastLapMs)}</span>{' '}
           <span style={{ color: 'var(--slate)' }}>
-            {gapLabel(c.gapMs, c.gapLaps, c.pos === 1, false, c.lastLapMs)}
+            {/* Leader is the front of orderCars' running order, not a literal
+                pos===1 match (#66) — same test TimingTower uses, so a frame with
+                no exact pos:1 still labels someone LEADER instead of nobody. */}
+            {gapLabel(c.gapMs, c.gapLaps, idx === 0, false, c.lastLapMs)}
           </span>
         </li>
       ))}

--- a/web/src/components/StatusRail.render.test.tsx
+++ b/web/src/components/StatusRail.render.test.tsx
@@ -2,11 +2,7 @@ import { describe, test, expect } from 'vitest';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { StatusRail } from './StatusRail';
 import { emptyState } from '../state/race';
-import type { Car } from '../state/race';
-
-const car = (over: Partial<Car>): Car => ({
-  driverNum: 1, code: 'VER', team: 'Red Bull', pos: 1, p: { x: 0, y: 0 }, status: 'OnTrack', ...over,
-});
+import { car } from '../state/testCar';
 
 describe('StatusRail leader-lap badge', () => {
   test('shows LAP n/m when a car is tagged pos:1', () => {
@@ -34,5 +30,28 @@ describe('StatusRail leader-lap badge', () => {
     };
     const html = renderToStaticMarkup(<StatusRail active="board" state={state} />);
     expect(html).toContain('LAP 12/53');
+  });
+
+  test('still shows the badge when the leader is on lap 0', () => {
+    // lap 0 is a real value on the wire (internal/model/model.go) — the opening
+    // lap, before anyone has crossed the line. A truthiness guard hid the badge
+    // for exactly the moment it is most interesting.
+    const state = {
+      ...emptyState(),
+      totalLaps: 53,
+      cars: { 1: car({ driverNum: 1, pos: 1, lap: 0 }) },
+    };
+    const html = renderToStaticMarkup(<StatusRail active="board" state={state} />);
+    expect(html).toContain('LAP 0/53');
+  });
+
+  test('omits the badge when the leader has no lap at all', () => {
+    const state = {
+      ...emptyState(),
+      totalLaps: 53,
+      cars: { 1: car({ driverNum: 1, pos: 1 }) },
+    };
+    const html = renderToStaticMarkup(<StatusRail active="board" state={state} />);
+    expect(html).not.toContain('LAP ');
   });
 });

--- a/web/src/components/StatusRail.tsx
+++ b/web/src/components/StatusRail.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from 'react';
 import type { RaceState } from '../state/race';
 import type { ConnStatus } from '../realtime/socket';
 import { StatusBadge } from './StatusBadge';
-import { fmtClock, orderCars } from './timingHelpers';
+import { fmtClock, leaderLapOf } from './timingHelpers';
 
 const TABS = [
   { key: 'board', href: '#', label: 'BOARD', sub: 'live board' },
@@ -28,12 +28,9 @@ export function StatusRail({
 }) {
   // The race leader's current lap, out of the session's total — the recorder bakes
   // both from FastF1's lap data (ingest/record.py's _lap_number / TOTAL_LAPS), so
-  // this is exact, not a derived estimate like Gap/Int. Read off orderCars' running
-  // order (front of the sorted list) rather than matching pos===1 directly: the wire
-  // now reconciles pos into a unique, contiguous 1..N per frame (#66), but orderCars'
-  // tie-break stays as belt-and-braces, so this degrades honestly instead of the
-  // whole badge vanishing if a stale/malformed frame ever lacked a literal pos:1.
-  const leaderLap = state && orderCars(state.cars)[0]?.lap;
+  // this is exact, not a derived estimate like Gap/Int. See leaderLapOf for why it
+  // reads the running order rather than matching pos===1.
+  const leaderLap = state ? leaderLapOf(state.cars) : undefined;
 
   return (
     <div className="rail">
@@ -42,7 +39,9 @@ export function StatusRail({
         <>
           {state.label && <span className="rail-session">{state.label}</span>}
           <span className="rail-clock">{fmtClock(state.timeMs)}</span>
-          {!!leaderLap && !!state.totalLaps && (
+          {/* != null, not truthiness: lap 0 (the leader is on the opening lap) is a
+              real value on the wire, and hid the whole badge under `!!leaderLap`. */}
+          {leaderLap != null && !!state.totalLaps && (
             <span className="rail-lap">LAP {leaderLap}/{state.totalLaps}</span>
           )}
           {state.weather && (

--- a/web/src/components/StintChart.render.test.tsx
+++ b/web/src/components/StintChart.render.test.tsx
@@ -2,11 +2,7 @@ import { describe, test, expect } from 'vitest';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { StintChart } from './StintChart';
 import { emptyState } from '../state/race';
-import type { Car } from '../state/race';
-
-const car = (over: Partial<Car>): Car => ({
-  driverNum: 1, code: 'VER', team: 'Red Bull', pos: 1, p: { x: 0, y: 0 }, status: 'OnTrack', ...over,
-});
+import { car } from '../state/testCar';
 
 describe('StintChart leader-lap marker', () => {
   test('draws the marker when a car is tagged pos:1', () => {
@@ -38,5 +34,18 @@ describe('StintChart leader-lap marker', () => {
     };
     const html = renderToStaticMarkup(<StintChart state={state} />);
     expect(html).toContain('Leader is on lap 12');
+  });
+
+  test('still draws the marker when the leader is on lap 0', () => {
+    // Same falsy-zero trap as StatusRail's LAP badge: lap 0 is the opening lap,
+    // not "no value", so the marker must sit at the start of the axis.
+    const state = {
+      ...emptyState(),
+      totalLaps: 53,
+      cars: { 1: car({ driverNum: 1, pos: 1, lap: 0 }) },
+      stints: { 1: [{ compound: 'SOFT', startLap: 1, endLap: 20 }] },
+    };
+    const html = renderToStaticMarkup(<StintChart state={state} />);
+    expect(html).toContain('Leader is on lap 0');
   });
 });

--- a/web/src/components/StintChart.tsx
+++ b/web/src/components/StintChart.tsx
@@ -1,15 +1,6 @@
 import { memo } from 'react';
 import type { RaceState } from '../state/race';
-import { orderCars, TYRE_COLOUR } from './timingHelpers';
-
-// Leader's current lap read off orderCars' running order (front of the sorted
-// list) rather than an exact pos===1 match: the wire now reconciles pos into a
-// unique, contiguous 1..N per frame (#66), but orderCars' tie-break stays as
-// belt-and-braces, so the marker degrades honestly instead of silently not
-// drawing if a stale/malformed frame ever lacked a literal pos:1.
-function leaderLapOf(state: RaceState): number | undefined {
-  return orderCars(state.cars)[0]?.lap;
-}
+import { leaderLapOf, orderCars, sameRunningOrder, TYRE_COLOUR } from './timingHelpers';
 
 // StintChart is the full-race strategy timeline: one row per car (running
 // order), each stint drawn as a coloured segment on a 0..totalLaps axis, with
@@ -18,16 +9,16 @@ function leaderLapOf(state: RaceState): number | undefined {
 // race so the strategy story reads at a glance (see ingest/record.py's stints).
 //
 // state.stints/state.totalLaps are baked once per session and never change
-// mid-race; only the leader-lap marker needs to move. Memoized on just those
-// three values (not `state` itself, which gets a new identity every 10Hz
-// frame) so the full sort + per-driver stint bars aren't rebuilt every tick.
+// mid-race; the row order and the leader-lap marker are what move. Memoized on
+// those (not `state` itself, which gets a new identity every 10Hz frame) so the
+// full sort + per-driver stint bars aren't rebuilt every tick.
 function StintChartInner({ state }: { state: RaceState }) {
   const order = orderCars(state.cars).filter((c) => state.stints[c.driverNum]?.length);
   if (order.length === 0) return <div className="empty">No stint data for this session.</div>;
 
   // Leader may have no stint data (rare) and so be filtered out of `order` above;
   // derive the marker from the full field, not the stint-filtered list.
-  const leaderLap = leaderLapOf(state);
+  const leaderLap = leaderLapOf(state.cars);
   const total = state.totalLaps || 1;
 
   return (
@@ -52,7 +43,9 @@ function StintChartInner({ state }: { state: RaceState }) {
                 }}
               />
             ))}
-            {!!leaderLap && (
+            {/* != null, not truthiness: lap 0 is a real value on the wire, and
+                `!!leaderLap` silently skipped the marker on the opening lap. */}
+            {leaderLap != null && (
               <div
                 role="img"
                 aria-label={`Leader is on lap ${leaderLap}`}
@@ -75,8 +68,12 @@ function StintChartInner({ state }: { state: RaceState }) {
   );
 }
 
+// Chose sameRunningOrder over comparing only the leader's lap: row order comes
+// from EVERY car's pos, so a position swap that left the leader's lap unchanged
+// used to leave the chart's order stale indefinitely — and it's cheaper besides,
+// one O(n) field walk instead of the two full sorts leaderLapOf used to do here.
 export const StintChart = memo(StintChartInner, (prev, next) => (
   prev.state.stints === next.state.stints &&
   prev.state.totalLaps === next.state.totalLaps &&
-  leaderLapOf(prev.state) === leaderLapOf(next.state)
+  sameRunningOrder(prev.state.cars, next.state.cars)
 ));

--- a/web/src/components/TimingTower.test.ts
+++ b/web/src/components/TimingTower.test.ts
@@ -2,13 +2,9 @@ import { describe, it, expect } from 'vitest';
 import {
   fmtLap, fmtGap, fmtClock, fmtElapsed, gapLabel, intLabel, bestSectors, orderCars,
   updatePersonalBests, sectorColour, sectorDelta, updateLapHistory, tyreLabel, statusLabel,
-  sectorDeltaVs, fmtSigned, updateGapHistory,
+  sectorDeltaVs, fmtSigned, updateGapHistory, leaderLapOf, sameRunningOrder,
 } from './timingHelpers';
-import type { Car } from '../state/race';
-
-const car = (over: Partial<Car>): Car => ({
-  driverNum: 1, code: 'VER', team: 'Red Bull', pos: 1, p: { x: 0, y: 0 }, status: 'OnTrack', ...over,
-});
+import { car } from '../state/testCar';
 
 describe('fmtLap', () => {
   it('formats ms as m:ss.SSS, dash when absent', () => {
@@ -109,6 +105,47 @@ describe('orderCars', () => {
       22: car({ driverNum: 22, code: 'TSU', pos: 19, lap: 12 }),
     };
     expect(orderCars(cars).map((c) => c.code)).toEqual(['TSU', 'HUL']);
+  });
+});
+
+describe('leaderLapOf', () => {
+  it('agrees with orderCars[0].lap without sorting', () => {
+    const cars = {
+      22: car({ driverNum: 22, code: 'TSU', pos: 19, lap: 7 }),
+      27: car({ driverNum: 27, code: 'HUL', pos: 19, lap: 12 }),
+      1: car({ driverNum: 1, code: 'VER', pos: 3, lap: 11 }),
+    };
+    expect(leaderLapOf(cars)).toBe(orderCars(cars)[0].lap);
+    expect(leaderLapOf(cars)).toBe(11);
+  });
+
+  it('returns 0 for a leader on the opening lap, undefined when there is no lap at all', () => {
+    // 0 is a real lap number, so callers must guard with != null. Distinguishing
+    // the two is the whole point of the undefined return.
+    expect(leaderLapOf({ 1: car({ pos: 1, lap: 0 }) })).toBe(0);
+    expect(leaderLapOf({ 1: car({ pos: 1 }) })).toBeUndefined();
+    expect(leaderLapOf({})).toBeUndefined();
+  });
+});
+
+describe('sameRunningOrder', () => {
+  const a = { 1: car({ driverNum: 1, pos: 1, lap: 10 }), 16: car({ driverNum: 16, pos: 2, lap: 10 }) };
+
+  it('is true for the same values in fresh objects (the 10 Hz no-op frame)', () => {
+    expect(sameRunningOrder(a, { ...a, 1: car({ driverNum: 1, pos: 1, lap: 10 }) })).toBe(true);
+  });
+
+  it('is false for a position swap that leaves the leader lap unchanged', () => {
+    // The staleness this guards: comparing only the leader's lap saw nothing
+    // change here, so StintChart's row order froze until the leader next
+    // completed a lap.
+    const swapped = { 1: car({ driverNum: 1, pos: 2, lap: 10 }), 16: car({ driverNum: 16, pos: 1, lap: 10 }) };
+    expect(sameRunningOrder(a, swapped)).toBe(false);
+  });
+
+  it('is false when a lap advances, or when the roster changes size', () => {
+    expect(sameRunningOrder(a, { ...a, 1: car({ driverNum: 1, pos: 1, lap: 11 }) })).toBe(false);
+    expect(sameRunningOrder(a, { ...a, 4: car({ driverNum: 4, pos: 3, lap: 10 }) })).toBe(false);
   });
 });
 

--- a/web/src/components/timingHelpers.ts
+++ b/web/src/components/timingHelpers.ts
@@ -95,15 +95,50 @@ export function statusLabel(status: string): string | undefined {
   return undefined;
 }
 
+// byRunningOrder is the running-order comparator: position, then laps completed,
+// then driver number. The feed is not guaranteed to hand out unique positions —
+// the Monza 2024 clip reports two cars at pos 19 (and no 20) in every frame — so
+// laps completed keeps the order right, and driver number makes the result stable
+// rather than dependent on object key order. ingest/resample.py's
+// reconcile_positions sorts server-side by the same three keys, so a frame that
+// still needed a tie-break agrees with how the frontend would have broken it.
+const byRunningOrder = (a: Car, b: Car) =>
+  a.pos - b.pos || (b.lap ?? 0) - (a.lap ?? 0) || a.driverNum - b.driverNum;
+
 // orderCars returns the cars sorted by running position.
-// The feed is not guaranteed to hand out unique positions — the Monza 2024 clip
-// reports two cars at pos 19 (and no 20) in every frame. Tie-break on laps
-// completed so the running order is still right, then driver number so the
-// result is stable rather than dependent on object key order.
 export function orderCars(cars: RaceState['cars']): Car[] {
-  return Object.values(cars).sort(
-    (a, b) => a.pos - b.pos || (b.lap ?? 0) - (a.lap ?? 0) || a.driverNum - b.driverNum,
-  );
+  return Object.values(cars).sort(byRunningOrder);
+}
+
+// leaderLapOf is the race leader's current lap: the front of the running order
+// without the sort, so a caller that wants only this one number (StatusRail's LAP
+// badge, StintChart's marker) is O(n) rather than O(n log n) per 10 Hz frame.
+// Read off the running order rather than matching pos===1 directly: the wire now
+// reconciles pos into a unique, contiguous 1..N per frame (#66), but the tie-break
+// stays as belt-and-braces, so callers degrade honestly instead of showing nothing
+// if a stale/malformed frame ever lacked a literal pos:1.
+// undefined means "no cars, or the leader has no lap yet" — 0 is a real lap number
+// (internal/model/model.go), so callers must guard with != null, not truthiness.
+export function leaderLapOf(cars: RaceState['cars']): number | undefined {
+  let leader: Car | undefined;
+  for (const c of Object.values(cars)) {
+    if (leader === undefined || byRunningOrder(c, leader) < 0) leader = c;
+  }
+  return leader?.lap;
+}
+
+// sameRunningOrder: do these two car maps produce the same rendered running order?
+// Compares the two fields the order (and the leader-lap marker) depend on, per car,
+// without sorting either side — cheap enough to run in a React.memo comparator that
+// exists to avoid the sort.
+export function sameRunningOrder(a: RaceState['cars'], b: RaceState['cars']): boolean {
+  if (a === b) return true;
+  const keys = Object.keys(a);
+  if (keys.length !== Object.keys(b).length) return false;
+  return keys.every((k) => {
+    const ca = a[k as unknown as number], cb = b[k as unknown as number];
+    return cb !== undefined && ca.pos === cb.pos && ca.lap === cb.lap;
+  });
 }
 
 // bestSectors finds the session-best (min across all cars) for each sector this frame.

--- a/web/src/state/testCar.ts
+++ b/web/src/state/testCar.ts
@@ -1,0 +1,10 @@
+import type { Car } from './race';
+
+// car() is the shared test fixture factory: a minimal valid Car (every required
+// field of the wire contract, no optional ones) with per-test overrides spread on
+// top. Lives here, next to the Car type it mirrors, so adding a required field to
+// the contract breaks in one place rather than in every test file that had its own
+// byte-identical copy.
+export const car = (over: Partial<Car> = {}): Car => ({
+  driverNum: 1, code: 'VER', team: 'Red Bull', pos: 1, p: { x: 0, y: 0 }, status: 'OnTrack', ...over,
+});


### PR DESCRIPTION
Fix stage for a max-effort multi-angle code review of the recent position-reconciliation work (#66, #68, #70). Ten findings verified against the code and fixed; three deferred with a comment rather than speculative code.

## Bugs

- **`ingest/live_signalr.py:298` (`_publish_trailing_radio_frame`)** — the one publish path that never called `reconcile_positions`, so a stream ending before the rate limiter let a regular frame out shipped raw duplicate/gapped/`UNKNOWN_POS=99` positions. Fixed structurally: `build_frame` (`ingest/live.py:60`) now reconciles, so no caller can forget.
- **`ingest/live_signalr.py:311` (`_publish_frame`)** — `reconcile_positions` renumbers `'pos'` in place on dicts that persist in `latest_cars` across publishes, so a driver with no fresh `Position.z` sample fed its own previous *rank* back in as if it were raw feed data and its rank stuck. Each car's raw position is now re-stamped from `running_positions` before reconciling.
- **`web/src/components/Standings.tsx:20`** — still computed the leader as a literal `c.pos === 1`, the pattern #66 removed from StatusRail/StintChart; now uses `orderCars`' running order, so a frame with no exact `pos:1` still labels a leader.
- **`web/src/components/StatusRail.tsx:45` and `StintChart.tsx:55`** — `!!leaderLap` hid the LAP badge and the leader marker when the leader's lap was legitimately `0` (a real value per `internal/model/model.go:23`); guarded with `!= null`.
- **`web/src/components/StintChart.tsx:78`** — the `React.memo` comparator watched only stints/totalLaps/leaderLap, all referentially stable across 10 Hz frames, so a position swap that didn't change the leader's lap left the row order stale indefinitely; it now compares the running order via `sameRunningOrder`.

## Cleanups

- **`web/src/components/timingHelpers.ts`** — new `leaderLapOf` (single-pass min-by-position, no sort) replaces the near-verbatim leader derivation duplicated in StatusRail and StintChart; the memo comparator's two full sorts per tick are gone.
- **`ingest/live_signalr.py`** — the copy-pasted reconcile-then-publish sequence in `_replay_capture` and `_run_live_signalr`'s handler is now one shared `_publish_frame`.
- **`ingest/record.py:730`** — dropped the redundant `sorted(cars, key=pos)` (`reconcile_positions` already returns that order) and the `lapn` dict (duplicated `car['lap']`), folded the lap assignment into the build loop, and fixed the stale "matches the FE pos===1 leader test" comment.
- **`ingest/record.py:849`** — the post-bake full-file scan now asserts the actual invariant per frame (positions unique and contiguous `1..N`), not merely that `pos` is an `int` — which a duplicate/gapped/`99` frame passed.
- **`ingest/record.py:714`, `ingest/live_signalr.py:577`** — comments that restated `reconcile_positions`' docstring shrunk to one line pointing at it.
- **`web/src/state/testCar.ts`** — the byte-identical `car()` fixture factory from three test files, exported once.

## Deferred (comment only, no speculative code)

- **Cold-start partial roster** gets a fabricated dense `1..N` until every driver reports — noted in `reconcile_positions`' docstring.
- **Retired / `'Out'` cars aren't sunk to the tail** and hold their last position ahead of cars still racing — same place.
- **Live `NumberOfLaps`** is still unverified against a real feed; the existing `UNVERIFIED` note in `_parse_timing_line` and `docs/runbooks/live-verification.md` already cover it.

## Tests

New: `ingest/test_live_publish.py` (fastf1-free) covers the multi-car trailing-frame path and a two-publish case proving a quiet car no longer inherits its own rank; `web/src/components/Standings.render.test.tsx`; lap-0 render tests for StatusRail and StintChart; `leaderLapOf` / `sameRunningOrder` unit tests. Every new test was confirmed to fail against the pre-fix code.

Verified: `go vet ./...` and `go test ./...` clean, `pytest ingest` 48 passed, `pytest bench` 3 passed, `ruff check ingest bench` clean, `npm test` 126 passed, `npm run lint` and `npm run build` clean, `FILE-MAP.md` regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
