### PR TITLE
fix(tests): make repo-root pytest invocation collect and pass

### DIFF
--- a/FILE-MAP.md
+++ b/FILE-MAP.md
@@ -20,7 +20,7 @@ docstring — an orientation gap, not an omission by the generator.
 | `internal/feed/replay` | 2 | replay reads a .jsonl clip and replays it as a frame stream. |
 | `internal/model` | 5 | model is the normalised contract shared by every layer (and, later, Python). |
 | `internal/ws` | 7 | ws is the gateway-side WebSocket fan-out hub. |
-| `ingest` | 20 | Records FastF1 sessions to JSONL replay clips and runs the true-live SignalR ingest path. |
+| `ingest` | 21 | Records FastF1 sessions to JSONL replay clips and runs the true-live SignalR ingest path. |
 | `bench` | 2 | Drive the loadtest sweeps behind BENCHMARKS.md by running cmd/loadtest at increasing concurrency and recording gateway resource usage. |
 | `web/src` | 3 | The React app shell: mounts the root component, wires the live WebSocket or static-replay data source into race state, and lays out the dashboard panels. |
 | `web/src/components` | 25 | The dashboard's presentational components — map, timing tower, standings, telemetry, comms, race control, ghost/compare overlays, and their shared layout/formatting helpers. |
@@ -28,4 +28,4 @@ docstring — an orientation gap, not an omission by the generator.
 | `web/src/realtime` | 4 | The frontend's data-source connections: a reconnecting live WebSocket and a paced static-replay reader, both feeding the same RaceState reducer. |
 | `web/src/state` | 10 | The frontend's race state: wire message types, the applyMessage reducer, and the comms/ghost sub-state it composes. |
 
-17 source directories, 103 files, 0 without a declared purpose.
+17 source directories, 104 files, 0 without a declared purpose.

--- a/ingest/conftest.py
+++ b/ingest/conftest.py
@@ -1,0 +1,13 @@
+"""Make the self-check scripts importable from any pytest invocation dir.
+
+The scripts in this directory import each other by bare name (`from live
+import ...`) so they stay runnable directly (`python ingest/test_radio.py`).
+That resolves when pytest runs with ingest/ as cwd (CI does this), but not
+from the repo root, where the package __init__.py makes pytest import them
+as `ingest.X` without ingest/ on sys.path. Pin it here so both work.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))

--- a/ingest/pytest.ini
+++ b/ingest/pytest.ini
@@ -1,5 +1,7 @@
 [pytest]
 # Collect the self-check scripts (test_*.py) and the contract check (check_*.py).
 # These stay runnable directly too (python ingest/test_radio.py) for CI's contract job.
-python_files = test_*.py check_*.py
+# *_test.py keeps bench/run_test.py collected when this ini governs a
+# repo-root `pytest ingest bench` run (pytest adopts it via the ingest arg).
+python_files = test_*.py check_*.py *_test.py
 testpaths = .


### PR DESCRIPTION
`.venv/Scripts/python.exe -m pytest ingest bench -q` from the repo root previously died at collection (`ModuleNotFoundError: No module named 'live'`) and — less visibly — never collected bench's 3 tests at all.

- `ingest/conftest.py`: pins `ingest/` onto `sys.path` so the self-check scripts' bare-name imports (`from live import ...`) resolve from any invocation directory. They stay runnable directly (`python ingest/test_radio.py`) as before.
- `ingest/pytest.ini`: `python_files` gains `*_test.py` so `bench/run_test.py` is collected when this ini governs a repo-root run.

Verified: root run 51 passed (was: collection error); per-directory runs (CI style) unchanged at 48 + 3; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)