### PR TITLE
fix(web): reconnect cap, deep-linkable selection, visible titles, design-system tidy

### DIFF
--- a/FILE-MAP.md
+++ b/FILE-MAP.md
@@ -212,6 +212,8 @@ The app shell: entry point, root component, error boundary, static-demo bootstra
 | `App.tsx` | The React app shell: mounts the root component, wires the live WebSocket or static-replay data source into race state, and lays out the dashboard panels. |
 | `ErrorBoundary.tsx` | React error boundary that keeps one component's render-time exception from blanking the whole app. |
 | `main.tsx` | Browser entry point: mounts App under an error boundary and pulls in the global fonts and stylesheets. |
+| `routing.test.ts` | Unit tests for hash parsing and serialising: route names and the deep-linked car code. |
+| `routing.ts` | The app's hash routing: which view a URL names, and which car it pre-selects. |
 | `staticDemo.ts` | Build-time identity of the public GitHub Pages demo, and the repo it came from. |
 
 ### `web/src/components`
@@ -488,4 +490,4 @@ The golden snapshot pinning the wire contract between Go, Python and the fronten
 
 ---
 
-45 directories, 169 files listed, 0 without a declared purpose.
+45 directories, 171 files listed, 0 without a declared purpose.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2,7 +2,7 @@
  * The React app shell: mounts the root component, wires the live WebSocket or static-replay data source into race state, and lays out the dashboard panels.
  * @packageDocumentation
  */
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { connectRace, type ConnStatus } from './realtime/socket';
 import { connectStaticReplay } from './realtime/staticReplay';
 import { emptyState, type RaceState } from './state/race';
@@ -24,18 +24,24 @@ import { Ghost } from './components/Ghost';
 import { Settings } from './components/Settings';
 import { StintChart } from './components/StintChart';
 import { STATIC_DEMO } from './staticDemo';
+import { buildHash, parseHash } from './routing';
 
 // How long the clip-wrapped notice stays up. Long enough to be read after the
 // clock visibly jumps, short enough not to become part of the chrome.
 const LOOP_NOTICE_MS = 8000;
 
-// Three distinct reasons the map is missing, so the copy never contradicts what
+// Four distinct reasons the map is missing, so the copy never contradicts what
 // the rest of the board is showing: an unrecoverable static-demo load failure,
-// a session streaming fine but without a track outline, or nothing yet at all.
-function SkeletonMap({ failed, trackless }: { failed?: boolean; trackless?: boolean }) {
+// a live socket that has spent its reconnect budget, a session streaming fine
+// but without a track outline, or nothing yet at all.
+function SkeletonMap({ failed, offline, trackless }: {
+  failed?: boolean; offline?: boolean; trackless?: boolean;
+}) {
   const copy = failed
     ? 'The demo replay could not be loaded. Refresh the page to retry.'
-    : trackless
+    : offline
+      ? 'Connection lost. Use Reconnect in the status rail above to try again.'
+      : trackless
       ? 'No track outline for this session — timing still works.'
       : 'Warming up the timing feed…';
   return <div className="track-skeleton">{copy}</div>;
@@ -97,12 +103,24 @@ export default function App() {
     return () => window.removeEventListener('keydown', onKey);
   }, []);
 
+  // The socket hands its retry function over with the 'offline' status (see
+  // MAX_RECONNECT_ATTEMPTS). Held in a ref and pressed through a stable callback
+  // so handing it to the rail does not re-render the board every time the status
+  // changes, and so a handle from a torn-down connection is replaced rather than
+  // captured in a stale closure.
+  const retryRef = useRef<(() => void) | null>(null);
+  const reconnect = useCallback(() => { retryRef.current?.(); }, []);
+
   useEffect(() => {
     const onState = (s: RaceState) => {
       latestRef.current = s;
       if (!frozenRef.current) setState(s);
     };
-    return (STATIC_DEMO ? connectStaticReplay : connectRace)(onState, setStatus);
+    const onStatus = (s: ConnStatus, retry?: () => void) => {
+      retryRef.current = retry ?? null;
+      setStatus(s);
+    };
+    return (STATIC_DEMO ? connectStaticReplay : connectRace)(onState, onStatus);
   }, []);
 
   useEffect(() => {
@@ -138,18 +156,64 @@ export default function App() {
   // The flag, not `selected == null`, is what makes this fire exactly once: a
   // user who clears the selection later (ui-ux M4, agent 5's) must not have the
   // leader pushed back at them on the very next frame.
+  //
+  // A `?car=` in the URL overrides the leader (accessibility M-7): someone who
+  // was sent `#board?car=VER` asked for VER, and seeding the leader first would
+  // make the board flash the wrong car before correcting itself.
+  const { route, car: carParam } = parseHash(hash);
   const [leaderSeeded, setLeaderSeeded] = useState(false);
   if (!leaderSeeded) {
     const leader = leaderOf(state.cars);
     if (leader) {
       setLeaderSeeded(true);
-      if (selected == null) setSelected(leader.driverNum);
+      const linked = carParam
+        ? Object.values(state.cars).find((c) => c.code.toUpperCase() === carParam)
+        : undefined;
+      if (linked) setSelected(linked.driverNum);
+      else if (selected == null) setSelected(leader.driverNum);
     }
   }
 
-  if (hash === '#compare') return <Compare />;
-  if (hash === '#ghost') return <Ghost initialSelected={selected} />;
-  if (hash === '#settings') return <Settings />;
+  // The URL is an input as well as an output: a hash change that names a car —
+  // pasting a shared link into the address bar of an already-open board, or Back
+  // onto one — must move the selection. The seed block above only fires on the
+  // first frame with cars, so without this a link pasted into a warm tab changed
+  // the URL and nothing else. Reads the cars off the ref rather than state so the
+  // effect is keyed on the car code alone and does not re-run at 10 Hz; a code
+  // that names nobody in this session is left alone rather than clearing the
+  // selection, since the likeliest cause is a link from a different race.
+  useEffect(() => {
+    if (!carParam) return;
+    const linked = Object.values(latestRef.current.cars)
+      .find((c) => c.code.toUpperCase() === carParam);
+    if (linked) setSelected(linked.driverNum);
+  }, [carParam]);
+
+  // Selection is deep-linkable, so it has to be written back — with
+  // replaceState, never pushState: the reference car changes on every click of a
+  // twenty-row tower, and pushing would bury the previous page under twenty Back
+  // presses. Keyed off the code rather than the state object so the effect runs
+  // when the selection changes and not at 10 Hz with every frame; and gated on
+  // the seed, so it cannot erase the `?car=` in the URL before the first frame
+  // with cars has had a chance to read it.
+  const selectedCode = selected != null ? state.cars[selected]?.code ?? null : null;
+  useEffect(() => {
+    // Board only. This effect runs on every route (the hooks above all sit
+    // before the route switch, so the socket and the selection stay alive while
+    // #ghost is on screen) and an unguarded write would quietly rewrite a
+    // #compare URL to the board's — invisibly, because replaceState fires no
+    // hashchange, so the view would stay put and only a reload would betray it.
+    if (!leaderSeeded || route !== 'board') return;
+    const next = buildHash({ route: 'board', car: selectedCode });
+    // location.hash is '' for a bare page and '#' for buildHash's empty board;
+    // compare the built forms so an unchanged URL is never rewritten.
+    if (buildHash(parseHash(location.hash)) === next) return;
+    history.replaceState(null, '', next);
+  }, [selectedCode, leaderSeeded, route, hash]);
+
+  if (route === 'compare') return <Compare />;
+  if (route === 'ghost') return <Ghost initialSelected={selected} />;
+  if (route === 'settings') return <Settings />;
 
   // A snapshot without a track outline would render an invisible map, so stand
   // in for it — but say which of the two cases it is, because "warming up" is a
@@ -169,6 +233,11 @@ export default function App() {
           // stopped" — so the staleness chip must not start claiming an outage the
           // moment a user pauses to read a row.
           staleSec={frozen ? 0 : staleSec}
+          onReconnect={reconnect}
+          // The board is the one route that carries a Replay/Live control, so
+          // the rail's healthy lane chip would only repeat it (ui-ux m8). On the
+          // static demo there is no control, and the chip stays.
+          laneNamedElsewhere={!STATIC_DEMO}
         >
           {!STATIC_DEMO && <SourceToggle state={state} />}
           {/* Label swap rather than aria-pressed, matching the overlay's existing
@@ -189,20 +258,26 @@ export default function App() {
     >
       <div className="board-top">
         <Panel label="Track">
-          {status === 'reconnecting' && !showSkeleton && (
+          {(status === 'reconnecting' || status === 'offline') && !showSkeleton && (
             <div style={{ position: 'relative', display: 'inline-block' }}>
               <Map state={state} paused={frozen} selected={selected} rival={effectiveRival} />
               <div className="chip chip-reconnect" style={{
                 position: 'absolute', top: 12, left: '50%', transform: 'translateX(-50%)',
               }}>
-                ↺ Reconnecting…
+                {status === 'offline' ? '⚠ Connection lost' : '↺ Reconnecting…'}
               </div>
             </div>
           )}
-          {!showSkeleton && status !== 'reconnecting' && (
+          {!showSkeleton && status !== 'reconnecting' && status !== 'offline' && (
             <Map state={state} paused={frozen} selected={selected} rival={effectiveRival} />
           )}
-          {showSkeleton && <SkeletonMap failed={status === 'failed'} trackless={trackless} />}
+          {showSkeleton && (
+            <SkeletonMap
+              failed={status === 'failed'}
+              offline={status === 'offline'}
+              trackless={trackless}
+            />
+          )}
         </Panel>
         <Panel label="Timing">
           <TimingTower state={state} selected={selected} onSelect={setSelected} />

--- a/web/src/components/Comms.tsx
+++ b/web/src/components/Comms.tsx
@@ -36,7 +36,7 @@ export function Comms({ state }: { state: RaceState }) {
       {enabled && nowPlaying && (
         <div style={{
           display: 'flex', alignItems: 'center', gap: 'var(--sp-2)', padding: 'var(--sp-2) var(--sp-3)',
-          background: 'var(--asphalt)', borderRadius: 4, fontSize: 'var(--fs-md)',
+          background: 'var(--asphalt)', borderRadius: 'var(--radius)', fontSize: 'var(--fs-md)',
         }}>
           <span style={{ color: colourFor(nowPlaying.driverNum), fontWeight: 700 }}>
             {codeFor(nowPlaying.driverNum)}
@@ -51,38 +51,56 @@ export function Comms({ state }: { state: RaceState }) {
         </div>
       )}
 
-      {enabled && history.length > 0 && (
+      {/* The history is tracked whether or not comms is enabled (useComms keeps
+          it either way), so the off state does not have to be an empty box —
+          see the resting branch below. */}
+      {history.length > 0 && (
         <div style={{ display: 'grid', gap: 'var(--sp-1)' }}>
           {/* The history used to be six identical "CODE ▶" rows: no time, no
               ordering stated, and no way to tell which one was playing — so there
               was no reason to press one button over another. */}
-          <div className="empty" style={{ fontSize: 'var(--fs-2xs)' }}>Newest first</div>
+          <div className="empty" style={{ fontSize: 'var(--fs-sm)' }}>
+            {enabled ? 'Newest first' : 'Recent radio — newest first'}
+          </div>
           {history.map((m, i) => {
             const playing = nowPlaying?.clip === m.clip;
             return (
-            <div key={`${m.timeMs}-${i}`} style={{
-              display: 'flex', alignItems: 'center', gap: 'var(--sp-2)',
-              fontSize: 'var(--fs-sm)', color: 'var(--slate)',
-            }}>
-              <span style={{ fontVariantNumeric: 'tabular-nums', fontSize: 'var(--fs-2xs)' }}>
-                {fmtClock(m.timeMs)}
-              </span>
+            <div
+              key={`${m.timeMs}-${i}`}
+              className={enabled ? 'comms-row' : 'comms-row comms-row-resting'}
+            >
+              <span style={{ fontVariantNumeric: 'tabular-nums' }}>{fmtClock(m.timeMs)}</span>
               <span style={{ color: colourFor(m.driverNum), fontWeight: 700 }}>{codeFor(m.driverNum)}</span>
-              <button
-                onClick={() => replay(m)}
-                className="btn btn-icon"
-                style={{ border: 'none' }}
-                aria-label={`Play ${codeFor(m.driverNum)} radio from ${fmtClock(m.timeMs)}`}
-              >▶</button>
-              {playing && <span className="chip chip-replay">PLAYING</span>}
+              {/* No play button while comms is off. The clips are real and the
+                  list is the substance of the resting state, but the one control
+                  offered there has to be the toggle above — two ways to start
+                  audio, one of which silently turns the feature on and one of
+                  which does not, is a worse resting state than none. */}
+              {enabled && (
+                <button
+                  onClick={() => replay(m)}
+                  className="btn btn-icon"
+                  style={{ border: 'none' }}
+                  aria-label={`Play ${codeFor(m.driverNum)} radio from ${fmtClock(m.timeMs)}`}
+                >▶</button>
+              )}
+              {enabled && playing && <span className="chip chip-replay">PLAYING</span>}
             </div>
             );
           })}
         </div>
       )}
 
+      {/* Comms off used to be a single line explaining a setting — one of the two
+          board panels that opened as an empty box describing a control
+          (frontend-design item 6). With clips in hand the resting state shows
+          what is being missed; with none, it still has to explain itself. */}
       {!enabled && (
-        <div className="empty">Radio clips play automatically when comms is on.</div>
+        <div className="empty">
+          {history.length > 0
+            ? 'Press Comms to hear these as they arrive.'
+            : 'Radio clips play automatically when comms is on.'}
+        </div>
       )}
       {enabled && !nowPlaying && history.length === 0 && (
         <div className="empty">No radio yet — clips play as the replay reaches them.</div>

--- a/web/src/components/Ghost.tsx
+++ b/web/src/components/Ghost.tsx
@@ -170,7 +170,7 @@ function GhostLive({ initialSelected }: { initialSelected?: number | null }) {
             value={resolvedSelected ?? ''}
             onChange={(e) => setSelected(Number(e.target.value))}
             disabled={drivers.length === 0}
-            style={{ background: 'var(--asphalt)', color: 'var(--chalk)', border: '1px solid var(--edge)', padding: 'var(--sp-1) var(--sp-2)', borderRadius: 4 }}
+            style={{ background: 'var(--asphalt)', color: 'var(--chalk)', border: '1px solid var(--edge)', padding: 'var(--sp-1) var(--sp-2)', borderRadius: 'var(--radius)' }}
           >
             {/* An empty dropdown reads as "no drivers exist"; say we are waiting instead. */}
             {drivers.length === 0 && <option value="">Waiting for driver data…</option>}

--- a/web/src/components/RaceControl.tsx
+++ b/web/src/components/RaceControl.tsx
@@ -2,7 +2,7 @@
 // they arrive.
 
 import type { RaceControlMessage, RaceState } from '../state/race';
-import { fmtClock, needsDriverTag } from './timingHelpers';
+import { fmtClock, needsDriverTag, splitWallClock } from './timingHelpers';
 
 const MAX_SHOWN = 8;
 
@@ -52,18 +52,30 @@ export function RaceControl({ state, selected }: { state: RaceState; selected?: 
     <div style={{ display: 'grid', gap: 'var(--sp-1)' }} role="log" aria-live="polite" aria-relevant="additions">
       {recent.map((m) => {
         const cat = CATEGORY[m.category] ?? { label: m.category.toUpperCase(), colour: 'var(--chalk)' };
+        // The row's leading number is the race clock; anything FastF1 appended to
+        // the message body is the circuit's time of day. Two different clocks, so
+        // they are no longer printed as two identical-looking numbers (ui-ux m14).
+        const { text, wallClock } = splitWallClock(m.message);
         return (
-        <div key={idOf(m)} className={m.driver != null && m.driver === selected ? 'rc-row rc-row-mine' : 'rc-row'} style={{
-          display: 'flex', alignItems: 'baseline', gap: 'var(--sp-2)', fontSize: 'var(--fs-sm)', color: 'var(--slate)',
-        }}>
-          <span style={{ fontVariantNumeric: 'tabular-nums', fontSize: 'var(--fs-2xs)' }}>{fmtClock(m.t)}</span>
-          <span style={{ color: cat.colour, fontWeight: 700, fontSize: 'var(--fs-2xs)', letterSpacing: '0.08em' }}>
+        <div key={idOf(m)} className={m.driver != null && m.driver === selected ? 'rc-row rc-row-mine' : 'rc-row'}>
+          <span style={{ fontVariantNumeric: 'tabular-nums', fontSize: 'var(--fs-sm)' }}>{fmtClock(m.t)}</span>
+          <span style={{ color: cat.colour, fontWeight: 700, fontSize: 'var(--fs-sm)', letterSpacing: '0.08em' }}>
             {cat.label}
           </span>
-          <span>{m.message}</span>
+          <span className="rc-text">{text}</span>
           {m.driver != null && state.cars[m.driver]
             && needsDriverTag(m.message, state.cars[m.driver].code, m.driver) && (
             <span style={{ color: 'var(--slate)' }}>({state.cars[m.driver].code})</span>
+          )}
+          {wallClock && (
+            // Labelled, not stripped: it is the only record of when race control
+            // actually issued the message, which for a deleted lap or a penalty
+            // is the operative fact. "at" plus --dim puts it a tier below both
+            // the race clock and the message, so it cannot be misread as either.
+            <span className="rc-wall">
+              at {wallClock}
+              <span className="visually-hidden"> local time at the circuit</span>
+            </span>
           )}
         </div>
         );

--- a/web/src/components/Route.tsx
+++ b/web/src/components/Route.tsx
@@ -10,10 +10,15 @@ import { useEffect, useState, type ReactNode } from 'react';
 let firstPaint = true;
 
 // Route is the shared page frame: the skip link (first focusable element on
-// every route), the route's own <h1> — visually hidden because the status rail
-// already carries the brand — and the <main> landmark the skip link targets.
-// Panel titles are <h2> beneath it, so every route has one unbroken heading
-// chain instead of a grid of untitled boxes.
+// every route), the rail, and the <main> landmark the skip link targets. The
+// route's <h1> lives inside StatusRail — visible, named after the route, and
+// part of the masthead rather than a band above it (accessibility L-2). Panel
+// titles are <h2> beneath it, so every route has one unbroken heading chain
+// instead of a grid of untitled boxes.
+//
+// `title` is the long form of the same thing and now drives document.title,
+// which is what a screen reader announces on navigation and what a browser tab,
+// a bookmark and a shared link all show — none of which a hidden <h1> ever fed.
 export function Route({ title, rail, children }: {
   title: string;
   rail: ReactNode;
@@ -24,10 +29,10 @@ export function Route({ title, rail, children }: {
   // one's effects have run, so the flag is already down by then.
   const [intro] = useState(() => firstPaint);
   useEffect(() => { firstPaint = false; }, []);
+  useEffect(() => { document.title = `${title} · F1 Race Tracker`; }, [title]);
   return (
     <div className={intro ? 'page page-intro' : 'page'}>
       <a className="skip-link" href="#main">Skip to content</a>
-      <h1 className="visually-hidden">{title}</h1>
       {rail}
       <main id="main" className="route-main">{children}</main>
     </div>

--- a/web/src/components/StatusBadge.tsx
+++ b/web/src/components/StatusBadge.tsx
@@ -7,6 +7,20 @@ interface Props {
   status: ConnStatus;
   state: RaceState;
   staleSec?: number;
+  // Handed down from the socket when it gives up (see MAX_RECONNECT_ATTEMPTS).
+  // Absent everywhere else, which is why the terminal chip renders its button
+  // conditionally rather than assuming one is always available.
+  onReconnect?: () => void;
+  // True on a route that already carries a Replay/Live control (the board's
+  // SourceToggle sits ~40px to the left of this chip). The healthy chip and that
+  // control said the same word with the same glyph, one a readout and one a
+  // button, so a reader could not tell which one to press (ui-ux m8). Where the
+  // control exists the chip stands down in the healthy case and keeps only the
+  // exceptional states — warming, stale, reconnecting, offline, failed — which
+  // is where a chip earns its slot. Routes with no toggle (Compare's two lanes,
+  // the static demo's board, Settings) leave this false and keep the readout,
+  // because there it is the only thing naming the lane.
+  laneNamedElsewhere?: boolean;
 }
 
 const STALE_THRESHOLD_SEC = 4;
@@ -14,7 +28,22 @@ const STALE_THRESHOLD_SEC = 4;
 const LIVE_CAVEAT =
   'Demo lane streaming a second replay clip — real live ingestion not yet verified';
 
-function Chip({ status, state, staleSec }: Props) {
+function Chip({ status, state, staleSec, onReconnect, laneNamedElsewhere }: Props) {
+  // Terminal, and the only chip in the set that carries an action: the socket
+  // has stopped dialling, so nothing will change on its own and the reader needs
+  // to be told that as well as given the way out.
+  if (status === 'offline') {
+    return (
+      <span className="chip chip-stall">
+        ⚠ Connection lost — not retrying any more
+        {onReconnect && (
+          <button type="button" className="btn chip-action" onClick={onReconnect}>
+            Reconnect
+          </button>
+        )}
+      </span>
+    );
+  }
   if (status === 'failed') {
     return <span className="chip chip-stall">⚠ Demo data failed to load — refresh the page to retry.</span>;
   }
@@ -40,6 +69,8 @@ function Chip({ status, state, staleSec }: Props) {
       </span>
     );
   }
+  // Everything below this line is the healthy case — see laneNamedElsewhere.
+  if (laneNamedElsewhere) return null;
   if (state.mode === 'live') {
     return (
       // "LIVE (DEMO)" put the qualifier in a parenthesis and the truth in a

--- a/web/src/components/StatusRail.tsx
+++ b/web/src/components/StatusRail.tsx
@@ -19,19 +19,35 @@ const TABS = [
   { key: 'ghost', href: '#ghost', label: 'OVERLAY', sub: 'lap delta' },
 ] as const;
 
+// The visible page title, per route (accessibility L-2). The <h1> used to be
+// visually hidden on every route because the rail already carried the brand — a
+// correct heading chain that nobody could see, so a sighted reader landing on
+// #ghost had no titled thing on the page above the panel headings. Rather than
+// add a title band above a rail that is already the page's masthead, the brand
+// IS the h1 and it names the route after itself: "F1 RACE TRACKER · LAP DELTA
+// OVERLAY". One element, no new band, and the chain below it is unchanged.
+const ROUTE_TITLES = {
+  board: 'Race board',
+  compare: 'Compare',
+  ghost: 'Lap delta overlay',
+  settings: 'F1TV link',
+} as const;
+
 // StatusRail is the persistent instrument strip on every route — the
 // signature element. On the board it carries live session identity, the
 // race clock, and lane health; on Compare/Ghost (two independent lanes,
 // no single clock to show) it's a lighter shell: brand, a static note,
 // and the same view tabs.
 export function StatusRail({
-  active, state, status, staleSec, note, children,
+  active, state, status, staleSec, note, onReconnect, laneNamedElsewhere, children,
 }: {
   active: 'board' | 'compare' | 'ghost' | 'settings';
   state?: RaceState;
   status?: ConnStatus;
   staleSec?: number;
   note?: string;
+  onReconnect?: () => void;
+  laneNamedElsewhere?: boolean;
   children?: ReactNode;
 }) {
   // The race leader's current lap, out of the session's total — the recorder bakes
@@ -42,7 +58,13 @@ export function StatusRail({
 
   return (
     <div className="rail">
-      <span className="rail-brand">F1 Race Tracker</span>
+      {/* The route's <h1>. Route no longer renders one — two would break the
+          chain this comment block exists to keep straight. */}
+      <h1 className="rail-brand">
+        F1 Race Tracker
+        <span className="rail-brand-sep" aria-hidden="true">·</span>
+        <span className="rail-route">{ROUTE_TITLES[active]}</span>
+      </h1>
       {state && (
         <>
           {state.label && <span className="rail-session">{state.label}</span>}
@@ -61,7 +83,13 @@ export function StatusRail({
           {/* No live-region wrapper here any more: StatusBadge carries its own, so
               Compare's two lanes announce their transitions too and there is no
               chance of nesting two polite regions and double-announcing. */}
-          <StatusBadge status={status ?? 'connecting'} state={state} staleSec={staleSec} />
+          <StatusBadge
+            status={status ?? 'connecting'}
+            state={state}
+            staleSec={staleSec}
+            onReconnect={onReconnect}
+            laneNamedElsewhere={laneNamedElsewhere}
+          />
         </>
       )}
       {note && <span className="rail-note">{note}</span>}

--- a/web/src/components/StintChart.tsx
+++ b/web/src/components/StintChart.tsx
@@ -101,12 +101,12 @@ function StintChartInner({ state, selected, rival }: {
       {/* The tyre key lived in the Timing panel, several hundred pixels away and
           in a different container — and on touch there is no hover to recover the
           compound from. It costs one line to repeat it where the colours are. */}
-      <div className="empty tt-legend" style={{ fontSize: 'var(--fs-2xs)' }}>
+      <div className="empty tt-legend" style={{ fontSize: 'var(--fs-sm)' }}>
         {(['SOFT', 'MEDIUM', 'HARD', 'INTERMEDIATE', 'WET'] as const).map((t) => (
           <span key={t} style={{ color: TYRE_COLOUR[t] }}>{t[0]}{t.slice(1).toLowerCase()}</span>
         ))}
       </div>
-      <div className="empty" style={{ fontSize: 'var(--fs-2xs)', marginTop: 'var(--sp-0)' }}>
+      <div className="empty" style={{ fontSize: 'var(--fs-sm)', marginTop: 'var(--sp-0)' }}>
         Full-race stint plan baked from session data — the marker is where the replay currently sits.
       </div>
     </div>

--- a/web/src/components/TelemetryPanel.tsx
+++ b/web/src/components/TelemetryPanel.tsx
@@ -12,15 +12,15 @@ const MIN_SPARK_POINTS = 4;
 // at a glance.
 function Bar({ label, value, tone }: { label: string; value: number; tone: 'good' | 'bad' }) {
   return (
-    <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--sp-2)', fontSize: 'var(--fs-sm)' }}>
-      <span style={{ width: 64, color: 'var(--slate)' }}>{label}</span>
-      <div style={{ flex: 1, height: 8, background: 'var(--edge)', borderRadius: 4 }}>
+    <div className="tele-row">
+      <span className="tele-label">{label}</span>
+      <div style={{ flex: 1, height: 8, background: 'var(--edge)', borderRadius: 'var(--radius)' }}>
         <div style={{
           width: `${Math.max(0, Math.min(100, value))}%`, height: '100%',
-          background: tone === 'good' ? 'var(--good)' : 'var(--bad)', borderRadius: 4,
+          background: tone === 'good' ? 'var(--good)' : 'var(--bad)', borderRadius: 'var(--radius)',
         }} />
       </div>
-      <span style={{ width: 36, textAlign: 'right' }}>{value}</span>
+      <span className="tele-value">{value}</span>
     </div>
   );
 }
@@ -119,15 +119,15 @@ function CarTelemetry({ car, history, gapHistory, role }: {
       <Bar label="Throttle" value={car.throttle ?? 0} tone="good" />
       <Bar label="Brake" value={car.brake ?? 0} tone="bad" />
       {trend(history) && history && (
-        <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--sp-2)', fontSize: 'var(--fs-sm)' }}>
-          <span style={{ width: 64, color: 'var(--slate)' }}>Laps</span>
+        <div className="tele-row">
+          <span className="tele-label">Laps</span>
           <Sparkline values={history} label={`${car.code} lap time trend`} />
           <span>{fmtLap(history[history.length - 1])}</span>
         </div>
       )}
       {trend(gapHistory) && gapHistory && (
-        <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--sp-2)', fontSize: 'var(--fs-sm)' }}>
-          <span style={{ width: 64, color: 'var(--slate)' }}>Gap</span>
+        <div className="tele-row">
+          <span className="tele-label">Gap</span>
           <Sparkline values={gapHistory} label={`${car.code} gap trend`} />
           {/* The derived gap, at the derived gap's resolution — same rule as the
               tower's Gap column. */}
@@ -135,7 +135,7 @@ function CarTelemetry({ car, history, gapHistory, role }: {
         </div>
       )}
       {!trend(history) && (
-        <div className="empty" style={{ fontSize: 'var(--fs-2xs)' }}>
+        <div className="empty" style={{ fontSize: 'var(--fs-sm)' }}>
           Lap and gap trends build after {MIN_SPARK_POINTS} laps.
         </div>
       )}

--- a/web/src/components/gapDisplay.test.ts
+++ b/web/src/components/gapDisplay.test.ts
@@ -3,7 +3,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   fmtGapEstimate, fmtLongGap, median, updateGapSmoothing, displayGaps, holdOrder,
-  hasNoData, needsDriverTag, axisTicks, GAP_WINDOW, GAP_HYSTERESIS_MS, settle,
+  hasNoData, needsDriverTag, splitWallClock, axisTicks, GAP_WINDOW, GAP_HYSTERESIS_MS, settle,
   type GapSmoothing,
 } from './timingHelpers';
 import { car } from '../state/testCar';
@@ -180,5 +180,34 @@ describe('axisTicks', () => {
   it('degenerates safely for a session with no lap count', () => {
     expect(axisTicks(1)).toEqual([1]);
     expect(axisTicks(0)).toEqual([1]);
+  });
+});
+
+describe('splitWallClock', () => {
+  it('lifts the trailing time of day FastF1 appends off the end of the prose', () => {
+    expect(splitWallClock('CAR 55 (SAI) TIME 1:25.423 DELETED - TRACK LIMITS AT TURN 2 LAP 13 15:20:51'))
+      .toEqual({
+        text: 'CAR 55 (SAI) TIME 1:25.423 DELETED - TRACK LIMITS AT TURN 2 LAP 13',
+        wallClock: '15:20:51',
+      });
+  });
+
+  it('leaves a message with no trailing stamp exactly as it arrived', () => {
+    const m = 'PIT LANE INCIDENT INVOLVING CAR 3 (RIC) NOTED';
+    expect(splitWallClock(m)).toEqual({ text: m });
+  });
+
+  it('does not eat a time that is part of what the message says', () => {
+    // The deleted lap time is the subject of the sentence, not a stamp — and
+    // 1:25.423 is not the h:mm:ss shape anyway.
+    const m = 'CAR 55 TIME 1:25.423 DELETED';
+    expect(splitWallClock(m)).toEqual({ text: m });
+    // A mid-string time of day stays put; only the anchored one is lifted.
+    expect(splitWallClock('INCIDENT AT 15:20:51 UNDER INVESTIGATION').wallClock).toBeUndefined();
+  });
+
+  it('rejects shapes that only look like a clock', () => {
+    expect(splitWallClock('LAP 13 25:99:00').wallClock).toBeUndefined();
+    expect(splitWallClock('LAP 13 15:20').wallClock).toBeUndefined();
   });
 });

--- a/web/src/components/timingHelpers.ts
+++ b/web/src/components/timingHelpers.ts
@@ -500,6 +500,24 @@ export function needsDriverTag(message: string, code: string, driverNum: number)
   return !words.includes(code.toUpperCase()) && !words.includes(String(driverNum));
 }
 
+// FastF1's race-control feed appends the circuit's time of day to some message
+// bodies — "…TRACK LIMITS AT TURN 2 LAP 13 15:20:51". Rendered raw that put a
+// bare 15:20:51 a few pixels from the row's own race clock (1:14:24), two
+// unlabelled clocks side by side reading as different values of the same thing
+// (ui-ux m14). splitWallClock lifts it out of the prose so the row can label it
+// as a time of day, or drop it, instead of leaving it mid-sentence.
+//
+// Anchored to the END of the string only: a time in the middle of a message is
+// part of what the message says (a deleted lap time, a penalty duration), and
+// the trailing stamp is the one FastF1 appends.
+const TRAILING_WALL_CLOCK = /\s+([0-2]?\d:[0-5]\d:[0-5]\d)\s*$/;
+
+export function splitWallClock(message: string): { text: string; wallClock?: string } {
+  const m = TRAILING_WALL_CLOCK.exec(message);
+  if (!m) return { text: message };
+  return { text: message.slice(0, m.index), wallClock: m[1] };
+}
+
 // axisTicks picks readable lap labels for a race of `total` laps: first, last,
 // and a round step between them. Ten-lap steps for a normal grand prix, five for
 // a sprint, so the strip never crowds.

--- a/web/src/realtime/socket.test.ts
+++ b/web/src/realtime/socket.test.ts
@@ -2,7 +2,7 @@
 // dispatch.
 
 import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
-import { connectRace } from './socket';
+import { connectRace, MAX_RECONNECT_ATTEMPTS } from './socket';
 import type { RaceState } from '../state/race';
 
 class MockWebSocket {
@@ -177,5 +177,126 @@ describe('connectRace reconnect/backoff', () => {
 
     vi.advanceTimersByTime(10_000); // well past the largest possible backoff
     expect(MockWebSocket.instances).toHaveLength(1); // no reconnect was scheduled
+  });
+});
+
+describe('connectRace reconnect budget', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  // Drives one failed attempt: close the newest socket and let its whole backoff
+  // elapse. 10s is past the 8s ceiling, so it covers every rung of the curve.
+  function failOnce() {
+    MockWebSocket.instances.at(-1)!.onclose?.();
+    vi.advanceTimersByTime(10_000);
+  }
+
+  const snapshot = JSON.stringify({
+    type: 'snapshot',
+    data: { session: 'x', mode: 'replay', label: 'L', cars: {}, timeMs: 0, rev: 1 },
+  });
+
+  test('the socket keeps retrying for the whole budget — a gateway restart still self-heals', () => {
+    const statuses: string[] = [];
+    connectRace(() => {}, (s) => statuses.push(s));
+
+    for (let i = 0; i < MAX_RECONNECT_ATTEMPTS; i++) failOnce();
+
+    // One socket per attempt, on top of the original.
+    expect(MockWebSocket.instances).toHaveLength(MAX_RECONNECT_ATTEMPTS + 1);
+    expect(statuses.at(-1)).toBe('reconnecting');
+    expect(statuses).not.toContain('offline');
+  });
+
+  test('one attempt past the budget it goes offline and stops dialling', () => {
+    const statuses: string[] = [];
+    connectRace(() => {}, (s) => statuses.push(s));
+
+    for (let i = 0; i <= MAX_RECONNECT_ATTEMPTS; i++) failOnce();
+
+    expect(statuses.at(-1)).toBe('offline');
+    const opened = MockWebSocket.instances.length;
+    vi.advanceTimersByTime(60_000); // a minute of nothing
+    expect(MockWebSocket.instances).toHaveLength(opened); // no timer was left running
+  });
+
+  test('offline hands over a retry that resets the budget and dials immediately', () => {
+    const statuses: string[] = [];
+    let retry: (() => void) | undefined;
+    connectRace(() => {}, (s, r) => { statuses.push(s); if (r) retry = r; });
+
+    for (let i = 0; i <= MAX_RECONNECT_ATTEMPTS; i++) failOnce();
+    expect(retry).toBeTypeOf('function');
+
+    const before = MockWebSocket.instances.length;
+    retry!();
+    expect(MockWebSocket.instances).toHaveLength(before + 1); // no wait, no backoff
+    expect(statuses.at(-1)).toBe('reconnecting');
+
+    // The budget is genuinely reset, not merely nudged: a full budget's worth of
+    // failures is survivable again, and the backoff restarts at 500ms.
+    MockWebSocket.instances.at(-1)!.onclose?.();
+    vi.advanceTimersByTime(499);
+    expect(MockWebSocket.instances).toHaveLength(before + 1);
+    vi.advanceTimersByTime(1);
+    expect(MockWebSocket.instances).toHaveLength(before + 2);
+
+    for (let i = 0; i < MAX_RECONNECT_ATTEMPTS - 1; i++) failOnce();
+    expect(statuses.at(-1)).toBe('reconnecting');
+    failOnce();
+    expect(statuses.at(-1)).toBe('offline');
+  });
+
+  test('retry is idempotent — a double press opens one socket, not two', () => {
+    let retry: (() => void) | undefined;
+    connectRace(() => {}, (_s, r) => { if (r) retry = r; });
+    for (let i = 0; i <= MAX_RECONNECT_ATTEMPTS; i++) failOnce();
+
+    const before = MockWebSocket.instances.length;
+    retry!();
+    retry!();
+    retry!();
+    expect(MockWebSocket.instances).toHaveLength(before + 1);
+  });
+
+  test('a frame refills the budget; a handshake alone does not', () => {
+    const statuses: string[] = [];
+    connectRace(() => {}, (s) => statuses.push(s));
+
+    // Nineteen failures, then a socket that opens and immediately drops without
+    // ever delivering a frame. A gateway flapping like this must still reach the
+    // terminal state rather than refilling its budget on every handshake.
+    for (let i = 0; i < MAX_RECONNECT_ATTEMPTS - 1; i++) failOnce();
+    MockWebSocket.instances.at(-1)!.onopen?.();
+    failOnce();
+    expect(statuses.at(-1)).toBe('reconnecting'); // attempt 20 — the last one in budget
+    failOnce();
+    expect(statuses.at(-1)).toBe('offline');
+  });
+
+  test('a single delivered frame resets the count, so a long outage later starts clean', () => {
+    const statuses: string[] = [];
+    connectRace(() => {}, (s) => statuses.push(s));
+
+    for (let i = 0; i < MAX_RECONNECT_ATTEMPTS; i++) failOnce();
+    MockWebSocket.instances.at(-1)!.onmessage?.({ data: snapshot });
+    expect(statuses.at(-1)).toBe('live');
+
+    // The budget is back to full: the whole span passes without going offline.
+    for (let i = 0; i < MAX_RECONNECT_ATTEMPTS; i++) failOnce();
+    expect(statuses).not.toContain('offline');
+    failOnce();
+    expect(statuses.at(-1)).toBe('offline');
+  });
+
+  test('a retry handle from a closed connection is inert', () => {
+    let retry: (() => void) | undefined;
+    const close = connectRace(() => {}, (_s, r) => { if (r) retry = r; });
+    for (let i = 0; i <= MAX_RECONNECT_ATTEMPTS; i++) failOnce();
+
+    close();
+    const before = MockWebSocket.instances.length;
+    retry!();
+    expect(MockWebSocket.instances).toHaveLength(before);
   });
 });

--- a/web/src/realtime/socket.ts
+++ b/web/src/realtime/socket.ts
@@ -6,16 +6,31 @@
  */
 import { applyMessage, emptyState, parseMsg, type RaceState } from '../state/race';
 
-// 'failed' is terminal — only the static replay emits it (a missing/empty baked
-// clip has nothing to retry against); the live socket always keeps reconnecting.
-export type ConnStatus = 'connecting' | 'live' | 'reconnecting' | 'failed';
+// Two terminal states, for two different reasons.
+//   'failed'  — only the static replay emits it: a missing or empty baked clip
+//               has nothing to retry against, so the only way out is a reload.
+//   'offline' — the live socket spent its whole reconnect budget without a
+//               single frame arriving. Recoverable, but only on a deliberate
+//               press: the retry handle is handed to onStatus alongside it.
+export type ConnStatus = 'connecting' | 'live' | 'reconnecting' | 'failed' | 'offline';
+
+// How many consecutive failed attempts the socket makes before giving up. With
+// the backoff below (500ms doubling to an 8s ceiling) twenty attempts span about
+// two and a quarter minutes — comfortably longer than a gateway restart or a
+// laptop coming back from sleep, both of which must still heal on their own, and
+// short enough that a genuinely dead backend stops pretending. Before this cap
+// the socket retried forever: on the static-demo host that meant a permanent
+// "Reconnecting…" chip over a console filling with socket errors, with no state
+// the UI could ever reach that told the reader to stop waiting (accessibility D-2).
+export const MAX_RECONNECT_ATTEMPTS = 20;
 
 // connectRace opens a reconnecting WebSocket. onState is called with the latest
 // RaceState on every message. The optional onStatus callback receives connection
-// lifecycle events. Returns a close function.
+// lifecycle events; when it receives 'offline' it is also handed a retry function
+// that resets the budget and dials immediately. Returns a close function.
 export function connectRace(
   onState: (s: RaceState) => void,
-  onStatus?: (status: ConnStatus) => void,
+  onStatus?: (status: ConnStatus, retry?: () => void) => void,
   session?: string,
 ): () => void {
   let state = emptyState();
@@ -23,6 +38,24 @@ export function connectRace(
   let closed = false;
   let backoff = 500;
   let attempted = false;
+  // Consecutive failed attempts since the last frame actually arrived, and
+  // whether the budget is currently spent. `exhausted` is what makes retry()
+  // idempotent — a double-click on the Reconnect button must not open two
+  // sockets, and a stale retry handle held by a component that has since
+  // reconnected must be inert.
+  let attempts = 0;
+  let exhausted = false;
+
+  // The manual recovery half of the budget. Only ever live while exhausted, so
+  // it cannot race the automatic retry loop.
+  const retry = () => {
+    if (closed || !exhausted) return;
+    exhausted = false;
+    attempts = 0;
+    backoff = 500;
+    onStatus?.('reconnecting');
+    open();
+  };
   // A systematically bad feed drops every frame, and at 10 Hz that used to write
   // ten console.error lines a second forever while the board showed a
   // normal-looking but frozen tower. Log enough to diagnose the shape, then say
@@ -79,12 +112,25 @@ export function connectRace(
       state = applyMessage(state, msg);
       if (!live) {
         live = true;
+        // A frame, not a handshake, is what proves the feed is healthy — so the
+        // budget resets here rather than in onopen. A gateway that accepts the
+        // socket and immediately drops it would otherwise refill the budget on
+        // every flap and never reach the terminal state at all.
+        attempts = 0;
         onStatus?.('live');
       }
       onState(state);
     };
     ws.onclose = () => {
       if (closed) return;
+      attempts++;
+      if (attempts > MAX_RECONNECT_ATTEMPTS) {
+        // Stop dialling and say so. No timer is scheduled from here, so the tab
+        // goes quiet until someone presses Reconnect.
+        exhausted = true;
+        onStatus?.('offline', retry);
+        return;
+      }
       onStatus?.('reconnecting');
       setTimeout(open, backoff);
       backoff = Math.min(backoff * 2, 8000); // exponential backoff, capped at 8s (Task 7 acceptance)

--- a/web/src/routing.test.ts
+++ b/web/src/routing.test.ts
@@ -1,0 +1,79 @@
+// Unit tests for hash parsing and serialising: route names and the deep-linked car code.
+
+import { describe, test, expect } from 'vitest';
+import { buildHash, parseHash, type RouteName } from './routing';
+
+describe('parseHash', () => {
+  test('a bare or empty hash is the board', () => {
+    expect(parseHash('')).toEqual({ route: 'board', car: null });
+    expect(parseHash('#')).toEqual({ route: 'board', car: null });
+  });
+
+  test('the three named routes parse, with or without the leading #', () => {
+    for (const r of ['compare', 'ghost', 'settings'] as RouteName[]) {
+      expect(parseHash(`#${r}`).route).toBe(r);
+      expect(parseHash(r).route).toBe(r);
+    }
+  });
+
+  test('an unknown route falls back to the board rather than rendering nothing', () => {
+    // The skip link navigates to #main, and a stale bookmark can name anything.
+    expect(parseHash('#main').route).toBe('board');
+    expect(parseHash('#nope?car=VER')).toEqual({ route: 'board', car: 'VER' });
+  });
+
+  test('?car= is read on the board and uppercased', () => {
+    expect(parseHash('#board?car=VER')).toEqual({ route: 'board', car: 'VER' });
+    expect(parseHash('#board?car=ver').car).toBe('VER');
+  });
+
+  test('a car number is a valid code — not every session publishes abbreviations', () => {
+    expect(parseHash('#board?car=44').car).toBe('44');
+  });
+
+  test('a malformed car is dropped, so no caller has to re-validate it', () => {
+    expect(parseHash('#board?car=').car).toBeNull();
+    expect(parseHash('#board?car=V').car).toBeNull();
+    expect(parseHash('#board?car=TOOLONG').car).toBeNull();
+    expect(parseHash('#board?car=V%20R').car).toBeNull();
+    expect(parseHash('#board?car=<script>').car).toBeNull();
+  });
+
+  test('other query keys are ignored and do not disturb the route', () => {
+    expect(parseHash('#compare?lane=2&car=HAM')).toEqual({ route: 'compare', car: 'HAM' });
+    expect(parseHash('#board?lane=2')).toEqual({ route: 'board', car: null });
+  });
+});
+
+describe('buildHash', () => {
+  test('the board with no selection is the bare # the BOARD tab already links to', () => {
+    expect(buildHash({ route: 'board', car: null })).toBe('#');
+  });
+
+  test('a selection names the board explicitly, so the query has something to hang off', () => {
+    expect(buildHash({ route: 'board', car: 'VER' })).toBe('#board?car=VER');
+  });
+
+  test('the other routes keep their existing hashes untouched', () => {
+    expect(buildHash({ route: 'compare', car: null })).toBe('#compare');
+    expect(buildHash({ route: 'ghost', car: null })).toBe('#ghost');
+    expect(buildHash({ route: 'settings', car: null })).toBe('#settings');
+  });
+});
+
+describe('round-tripping', () => {
+  test('parse and build are inverses over every shape the app writes', () => {
+    for (const h of ['#', '#board?car=VER', '#compare', '#ghost', '#settings']) {
+      expect(buildHash(parseHash(h))).toBe(h);
+    }
+  });
+
+  test('the two spellings of an empty board normalise to one, so no-op writes are detectable', () => {
+    // App compares built forms before calling replaceState; '' and '#' and
+    // '#board' must all collapse to the same string or every frame would rewrite
+    // the URL.
+    for (const h of ['', '#', '#board']) {
+      expect(buildHash(parseHash(h))).toBe('#');
+    }
+  });
+});

--- a/web/src/routing.ts
+++ b/web/src/routing.ts
@@ -1,0 +1,51 @@
+// The app's hash routing: which view a URL names, and which car it pre-selects.
+
+// The four views. 'board' is the default because the board's own tab links to a
+// bare '#' — the hash a browser lands on with no fragment at all is the board,
+// and so is an explicit '#board'.
+export type RouteName = 'board' | 'compare' | 'ghost' | 'settings';
+
+const ROUTES: RouteName[] = ['board', 'compare', 'ghost', 'settings'];
+
+// Driver codes on the wire are FIA three-letter abbreviations (VER, HAM), but a
+// session that has not published one yet falls back to a car number, so two to
+// four alphanumerics is the honest shape. Anything else in ?car= is somebody
+// else's URL or a typo, and is dropped rather than used to search the field —
+// the parse must never hand a caller a value it would then have to re-validate.
+const CAR_CODE = /^[A-Z0-9]{2,4}$/;
+
+export interface ParsedHash {
+  route: RouteName;
+  /** Uppercased driver code from `?car=`, or null when absent or malformed. */
+  car: string | null;
+}
+
+// parseHash reads a location.hash into a route and an optional car selection.
+// Unknown routes fall back to the board rather than rendering nothing, because
+// a stale or hand-edited URL should land somewhere real.
+export function parseHash(hash: string): ParsedHash {
+  const raw = hash.startsWith('#') ? hash.slice(1) : hash;
+  const q = raw.indexOf('?');
+  const name = (q === -1 ? raw : raw.slice(0, q)).toLowerCase();
+  const route = (ROUTES as string[]).includes(name) ? (name as RouteName) : 'board';
+
+  let car: string | null = null;
+  if (q !== -1) {
+    const value = new URLSearchParams(raw.slice(q + 1)).get('car');
+    // Uppercased before the test, so a shared `#board?car=ver` works: driver
+    // codes are conventionally upper case but a URL typed by hand rarely is.
+    const code = value?.toUpperCase() ?? '';
+    if (CAR_CODE.test(code)) car = code;
+  }
+  return { route, car };
+}
+
+// buildHash is parseHash's inverse: the shortest hash that round-trips.
+// The board with no selection is a bare '#', which is exactly what the BOARD tab
+// already links to — so the common case leaves the URL looking untouched, and
+// only a deliberate selection lengthens it.
+export function buildHash({ route, car }: ParsedHash): string {
+  const query = car ? `?car=${encodeURIComponent(car)}` : '';
+  if (route === 'board') return query ? `#board${query}` : '#';
+  return `#${route}${query}`;
+}

--- a/web/src/styles/components.css
+++ b/web/src/styles/components.css
@@ -27,7 +27,7 @@
   background: var(--chalk);
   color: var(--asphalt);
   padding: var(--sp-2) var(--sp-3);
-  border-radius: 4px;
+  border-radius: var(--radius);
   font-family: var(--display);
   font-size: var(--fs-sm);
   font-weight: 600;
@@ -69,11 +69,19 @@
   padding: var(--sp-3) var(--sp-4);
   background: var(--carbon);
   border: 1px solid var(--edge);
-  border-radius: 4px;
+  border-radius: var(--radius);
   flex-wrap: wrap;
 }
 
+/* This is the page's <h1>, so the UA's 2em/1.34em margins have to go — a heading
+   inside a flex rail would otherwise be the one item pushing the strip taller
+   than its own padding. Everything else here is the brand lockup it has always
+   been. */
 .rail-brand {
+  margin: 0;
+  display: flex;
+  align-items: baseline;
+  gap: var(--sp-2);
   font-family: var(--display);
   font-weight: 700;
   font-size: var(--fs-sm);
@@ -83,14 +91,29 @@
   white-space: nowrap;
 }
 
+/* The route name sits a tier below the brand in weight and colour, so the h1
+   reads as "product, then page" rather than as two competing titles. It is the
+   only visible page title on the route (accessibility L-2), so it keeps --chalk's
+   sibling --slate rather than the dimmer --dim. */
+.rail-route {
+  font-weight: 400;
+  letter-spacing: 0.1em;
+  color: var(--slate);
+}
+
+.rail-brand-sep {
+  color: var(--edge);
+  font-weight: 400;
+}
+
 /* The rail's supporting values read as labels: uppercase and widely tracked, so
    they sit visibly BELOW the clock in the hierarchy instead of a pixel away from
-   it. The report asked for 10px here; --fs-2xs is the token it named, and it is
-   12px now because agent 2 retired the 9/10px rungs as below the legibility
-   floor. Tracking, case and colour carry the demotion instead of size. */
+   it. The report asked for 10px here; --fs-sm is the rung that job landed on
+   after the 9/10px rungs were retired as below the legibility floor, so it is
+   12px. Tracking, case and colour carry the demotion instead of size. */
 .rail-session,
 .rail-lap {
-  font-size: var(--fs-2xs);
+  font-size: var(--fs-sm);
   letter-spacing: 0.14em;
   text-transform: uppercase;
   color: var(--slate);
@@ -146,7 +169,7 @@
   gap: var(--sp-0);
   padding: var(--sp-1) var(--sp-3);
   border: 1px solid var(--edge);
-  border-radius: 4px;
+  border-radius: var(--radius);
   text-decoration: none;
   color: var(--chalk);
   font-family: var(--display);
@@ -173,7 +196,7 @@
 .rail-tab-sub {
   white-space: nowrap;
   font-family: var(--data);
-  font-size: var(--fs-2xs);
+  font-size: var(--fs-sm);
   font-weight: 400;
   letter-spacing: 0;
   text-transform: none;
@@ -215,7 +238,7 @@
      neighbours change its width by 4px — visible on a rail that already wraps
      at phone widths. Left as a measured value rather than snapped. */
   padding: var(--sp-0) 10px;
-  border-radius: 4px;
+  border-radius: var(--radius);
   font-family: var(--data);
   font-size: var(--fs-md);
   font-weight: 600;
@@ -246,6 +269,23 @@
   color: var(--amber);
 }
 
+/* The Reconnect button inside the terminal chip. A chip is a pill of text, so a
+   full .btn (32px min-height, its own border) would have burst it — this trims
+   the control back to the chip's own height and lets the chip's amber wash carry
+   the alarm, while the underline and the 24px touch floor keep it obviously
+   pressable. The (pointer: coarse) block at the end of this file still raises it
+   on touch, so the WCAG 2.5.8 target size is not lost. */
+.chip-action {
+  min-height: 24px;
+  margin-left: var(--sp-1);
+  padding: 0 var(--sp-2);
+  border-color: currentColor;
+  color: inherit;
+  font-size: var(--fs-sm);
+  font-weight: 700;
+  text-decoration: underline;
+}
+
 /* The clip-wrap notice. Amber like the other "read this" chips — it is not a
    fault, but it is the explanation for a clock that has just run backwards, and
    it has about eight seconds to be noticed. */
@@ -259,7 +299,7 @@
 .panel {
   background: var(--carbon);
   border: 1px solid var(--edge);
-  border-radius: 4px;
+  border-radius: var(--radius);
   overflow: hidden;
 }
 
@@ -304,7 +344,7 @@
   color: var(--chalk);
   cursor: pointer;
   padding: var(--sp-1) var(--sp-3);
-  border-radius: 4px;
+  border-radius: var(--radius);
   font-family: var(--data);
   font-size: var(--fs-md);
   touch-action: manipulation;
@@ -395,7 +435,7 @@ select.btn {
   width: 100%;
   height: min(var(--track-h), 70vh);
   background: var(--carbon);
-  border-radius: 4px;
+  border-radius: var(--radius);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -550,7 +590,7 @@ select.btn {
 }
 
 .tt-mark {
-  font-size: var(--fs-3xs);
+  font-size: var(--fs-xs);
   margin-left: var(--sp-0);
 }
 
@@ -561,7 +601,7 @@ select.btn {
   display: inline-block;
   min-width: 3.4ch;
   margin-left: var(--sp-0);
-  font-size: var(--fs-3xs);
+  font-size: var(--fs-xs);
   color: var(--slate);
 }
 
@@ -570,7 +610,7 @@ select.btn {
 }
 
 .tt-note {
-  font-size: var(--fs-2xs);
+  font-size: var(--fs-sm);
   margin-top: var(--sp-1);
 }
 
@@ -684,6 +724,25 @@ select.btn {
   font-size: var(--fs-lg);
   font-weight: 400;
   letter-spacing: 0;
+}
+
+/* Comms history rows. Extracted from three inline copies of the same flex
+   triple when the off state started reusing them. */
+.comms-row {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  font-size: var(--fs-sm);
+  color: var(--slate);
+}
+
+/* The resting variant: same rows, no controls, one tier quieter. --dim is the
+   codebase's one de-emphasis colour and still measures above the 4.5:1 floor, so
+   "off" reads as recessed rather than as disabled-and-unreadable. The driver
+   code keeps its team colour — it is the thing worth scanning for. */
+.comms-row-resting {
+  color: var(--dim);
+  min-height: 20px;
 }
 
 /* Shared text utilities */
@@ -804,7 +863,7 @@ select.btn {
   padding: var(--sp-3);
   background: var(--asphalt);
   border: 1px solid var(--edge);
-  border-radius: 4px;
+  border-radius: var(--radius);
   /* Wrap the one-liner rather than scroll it: it is meant to be read and
      copied whole, and on a phone a horizontal scroller hides half of it. */
   white-space: pre-wrap;
@@ -901,11 +960,41 @@ select.btn {
   max-width: 100%;
 }
 
+/* The telemetry row primitive. Throttle, Brake, Laps and Gap are the same
+   shape — a fixed label gutter, a flexible middle (a bar or a sparkline), a
+   right-aligned value — and TelemetryPanel repeated that flex/gap/font triple
+   and the `width: 64` label cell verbatim at four sites (design-system 2.7).
+   One class each, and the gutter width is a token, so the four rows cannot
+   drift apart the next time one of them is edited. */
+.tele-row {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  font-size: var(--fs-sm);
+}
+
+/* The bar's numeric readout — the last unnamed magic width in this row
+   (`width: 36`, three digits of tabular data plus breathing room). */
+.tele-value {
+  width: 4ch;
+  text-align: right;
+  flex: 0 0 auto;
+}
+
+.tele-label {
+  width: var(--tele-label-w);
+  color: var(--slate);
+  /* The gutter is a fixed column, not a flex item that gives ground: without
+     this a long label ("Throttle" at a user-raised font size) shrank the cell
+     and un-aligned the four rows from each other. */
+  flex: 0 0 auto;
+}
+
 /* Which card is which. With two live traces side by side and no labels, the only
    thing telling them apart was the driver code — fine if you remember which one
    you picked, useless if you are being shown the board. */
 .telemetry-role {
-  font-size: var(--fs-2xs);
+  font-size: var(--fs-sm);
   letter-spacing: 0.14em;
   text-transform: uppercase;
   color: var(--slate);
@@ -1011,7 +1100,7 @@ select.btn {
 
   .tt-table td:nth-child(n)::before {
     content: attr(data-label);
-    font-size: var(--fs-3xs);
+    font-size: var(--fs-xs);
     letter-spacing: 0.1em;
     text-transform: uppercase;
     color: var(--slate);
@@ -1121,7 +1210,7 @@ select.btn {
   position: relative;
   flex: 1;
   height: 1.2em;
-  font-size: var(--fs-3xs);
+  font-size: var(--fs-xs);
   color: var(--slate);
   font-variant-numeric: tabular-nums;
 }
@@ -1137,6 +1226,34 @@ select.btn {
 }
 
 /* Race Control — the selected driver's messages */
+
+/* Was four inline spans in a non-wrapping flex row. Adding the time-of-day
+   stamp (ui-ux m14) took the widest message 47px past the panel edge at 1280,
+   because a nowrap row of fixed-width cells has nowhere to give. The message is
+   the one cell that can shrink and wrap; everything else stays on its own line
+   and drops below when it must. */
+.rc-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: var(--sp-2);
+  font-size: var(--fs-sm);
+  color: var(--slate);
+}
+
+.rc-text {
+  flex: 1 1 12ch;
+  min-width: 0;
+}
+
+/* The time of day race control issued the message — a tier below both the race
+   clock at the head of the row and the message itself, so three numbers in one
+   row cannot be mistaken for each other. */
+.rc-wall {
+  color: var(--dim);
+  font-size: var(--fs-xs);
+  white-space: nowrap;
+}
 
 .rc-row-mine {
   border-left: 2px solid var(--chalk);
@@ -1176,7 +1293,7 @@ select.btn {
   gap: var(--sp-1) var(--sp-4);
   margin-bottom: var(--sp-2);
   font-family: var(--data);
-  font-size: var(--fs-2xs);
+  font-size: var(--fs-sm);
   color: var(--slate);
 }
 
@@ -1201,7 +1318,7 @@ select.btn {
 }
 
 .cmd-copy {
-  font-size: var(--fs-2xs);
+  font-size: var(--fs-sm);
   min-height: 24px;
   padding: var(--sp-0) var(--sp-2);
   flex-shrink: 0;

--- a/web/src/styles/tokens.css
+++ b/web/src/styles/tokens.css
@@ -112,19 +112,41 @@
   --sp-4: 16px;
   --sp-6: 24px;
 
+  /* The house corner. 4px appeared as a raw literal at thirteen sites across two
+     file types (eight rules in components.css plus four inline styles), which
+     made "soften the corners" a find-and-replace rather than an edit. The value
+     is unchanged; only its name is new. The 2px and 1px corners on the strategy
+     bars and sparkline rects stay raw: they are graph geometry scaled to a 10px
+     bar, not chrome, and pinning them to the chrome radius would round a bar
+     into a lozenge the moment this token moved. */
+  --radius: 4px;
+
+  /* The telemetry row's label column. Three rows in TelemetryPanel repeated
+     `width: 64` verbatim (design-system 2.7); named here so the label gutter and
+     the value column can move together. */
+  --tele-label-w: 64px;
+
   /* rem, not px, so raising the browser's default font size actually scales the
      board — the accommodation a low-vision user reaches for before page zoom.
      :root deliberately sets no font-size, so 1rem stays the user's own default
      (16px unless they changed it) and the px values in the comments are just
      what each token resolves to at that default.
 
-     The bottom two rungs are retired: --fs-3xs was 9px and --fs-2xs 10px, and
-     they carried real meaning (sector-best S/P marks, sector delta superscripts,
-     the tyre legend, Race Control timestamps) at a size a lot of sighted readers
-     can't parse either. They now alias --fs-xs/--fs-sm; the names stay so the
-     intent at each call site is still legible. */
-  --fs-3xs: 0.6875rem;  /* 11px */
-  --fs-2xs: 0.75rem;    /* 12px */
+     --fs-3xs (9px) and --fs-2xs (10px) used to be the bottom two rungs, carrying
+     real meaning (sector-best S/P marks, sector delta superscripts, the tyre
+     legend, Race Control timestamps) at a size a lot of sighted readers cannot
+     parse. Agent 2 retired both by aliasing them to --fs-xs/--fs-sm, which left
+     four names for two sizes and no rule for picking between them — the report's
+     own complaint (design-system 2.10) was that the same job was already being
+     done at two different rungs. The aliases are now gone rather than
+     documented: every former --fs-3xs site reads --fs-xs and every former
+     --fs-2xs site reads --fs-sm, so the scale is six rungs and a size has one
+     name. The two jobs the aliases used to name are now carried by the two
+     surviving rungs:
+       --fs-xs — chrome that labels something else (tyre legend, sector marks,
+                 footnotes, the rival picker's label).
+       --fs-sm — supporting readouts that are read on their own (timestamps,
+                 category tags, rail labels, body-adjacent copy). */
   --fs-xs: 0.6875rem;   /* 11px */
   --fs-sm: 0.75rem;     /* 12px */
   --fs-md: 0.8125rem;   /* 13px */


### PR DESCRIPTION
The owner-approved leftovers from `reviews/ui-fix-log.md`'s "Remaining after all
five agents" list. `web/` only.

## A — Reconnect cap with manual recovery (accessibility D-2)

`socket.ts` retried forever, so a dead backend showed a permanent
`↺ Reconnecting…` over a console filling with socket errors, with no state the UI
could reach that told the reader to stop waiting.

- `MAX_RECONNECT_ATTEMPTS = 20`. On the existing 500ms→8s backoff that is about
  two and a quarter minutes — longer than a gateway restart or a laptop waking
  from sleep, both of which still heal on their own inside the budget.
- New terminal `'offline'` status, distinct from the static replay's `'failed'`.
  `onStatus` gains a second argument: the retry function, handed over only with
  `'offline'`.
- The budget resets on a **delivered frame**, not on `onopen` — a gateway that
  accepts the socket and immediately drops it would otherwise refill its budget
  on every flap and never reach the terminal state.
- UI: the status chip becomes `⚠ Connection lost — not retrying any more` with a
  `Reconnect` button (inside the existing polite live region, so the transition is
  announced); the map overlay and the track skeleton get matching copy. `retry()`
  is idempotent, and a handle from a torn-down connection is inert.
- The static demo never dials, so it is untouched.
- Seven new unit tests cover the budget, the reset, both refill rules, idempotence
  and the closed-connection case.

## B — Deep-linkable car selection (accessibility M-7)

New `web/src/routing.ts` owns the hash grammar; every route check now goes through
`parseHash` instead of comparing string literals.

- `#board?car=VER`. `history.replaceState`, never push — the reference car changes
  on every click of a twenty-row tower.
- On load a valid code overrides the leader auto-seed, so a shared link does not
  flash the wrong car first. A hash change on a warm tab moves the selection too.
- Clearing the selection (the tower's clear button, or Esc) drops the parameter.
- Unknown routes and malformed codes fall back rather than erroring; the parse
  never hands a caller a value it would have to re-validate.
- The route guard keeps the effect from rewriting a `#compare`/`#ghost` URL —
  `replaceState` fires no `hashchange`, so that would have been invisible until a
  reload.
- Works on the static demo (verified against a baked clip).
- 12 new tests for the parse/serialise pair, including round-tripping.

## C — ui-ux nits

- **m8** — the rail's healthy lane chip (`▶ REPLAY · LOOPING CLIP`) sat ~40px from
  a button reading `▶ Replay`. It now stands down on routes that carry the
  Replay/Live control and stays on the ones that do not: the static demo's board,
  Compare's two lanes, Settings. Exceptional states (warming, stale, reconnecting,
  offline, failed) always show.
- **m14 (the third bullet only)** — FastF1 appends the circuit's time of day to
  some message bodies, which put a bare `15:20:51` beside the row's own race
  clock. `splitWallClock` lifts it out and it renders as a labelled, dimmer
  `at 15:20:51`. The row also wraps now, which is what keeps it inside the panel.
  M13 and M14's control placement are untouched — they belong to the rail
  restructure.

## D — Design-system tidy (design-system 2.7, 2.8, 2.10)

- `.tele-row` / `.tele-label` extracted from four verbatim copies in
  `TelemetryPanel`, with `--tele-label-w` naming the gutter and `.tele-value`
  naming the old `width: 36`.
- `--radius` added and used at the thirteen `4px` sites (eight CSS rules, four
  inline styles). The 2px/1px corners on the strategy bars stay raw and the token
  comment says why.
- `--fs-3xs` / `--fs-2xs` were already aliases of `--fs-xs` / `--fs-sm`, so they
  are **retired** rather than documented — four names for two sizes was the
  report's own complaint. The two jobs they used to name are written onto the
  surviving rungs. Every call site moved.
- Measured-ratio comment discipline kept throughout.

## E — Visible page title on sub-routes (accessibility L-2)

The `<h1>` moves out of `Route`'s visually-hidden line and into the rail's brand
lockup, where it names the route after the product:
`F1 RACE TRACKER · LAP DELTA OVERLAY`. One element, no new band, heading chain
unchanged (panel `<h2>`s still sit beneath it). `Route` now drives
`document.title` from the same prop, which is what a screen reader announces on
navigation and what a tab, a bookmark and a shared link all show.

## F — Comms resting state with substance (frontend-design item 6)

`useComms` has always tracked history whether or not comms is enabled, so the off
state no longer has to be an empty box explaining a setting: it lists the recent
clips (time, driver code in team colour) in a recessed style, with the existing
Comms toggle as the one way to start audio.

## Verification

- `npm test` — 226 passed / 18 files (19 new).
- `npm run lint`, `tsc -b`, `npm run build`, and the `VITE_STATIC_DEMO=true`
  variant — all clean. `web/dist/.gitkeep` intact.
- Browser (`npm run dev`, own port, own tab), against the docker stack:
  - **Reconnect:** `docker compose stop gateway` → `↺ Reconnecting…`; budget
    exhausts → `⚠ Connection lost` chip + Reconnect button; `docker compose start
    gateway` → pressed Reconnect → recovered, clock advancing. (The terminal-state
    UI was exercised with the budget temporarily set to 2 — a hidden browser pane
    throttles timers, so the real 20-attempt span could not be waited out
    interactively; the full-budget behaviour is covered by the unit tests.)
  - **Deep link:** cold load of `#board?car=HAM` selects HAM over the leader;
    warm-tab hash change to `?car=VER` moves the selection; row clicks rewrite the
    hash without growing `history.length`; Esc clears both.
  - **Comms resting state** and the labelled Race Control stamp confirmed in the
    live DOM.
  - Zero console errors across all four routes on a clean tab; zero horizontal
    overflow at 1280 and 390 on all four routes. (Screenshots did not composite in
    the in-app browser, so geometry is from computed styles and
    `getBoundingClientRect`, as in the previous passes.)
- `python scripts/gen_file_map.py` re-run; `--check` reports current.

### Noted, not fixed

The static-demo build logs a React `Maximum update depth exceeded` warning a few
seconds after load. **This reproduces on unmodified `origin/main`** and does not
occur on the live data source — it is the static replay's much higher frame rate
tripping a pre-existing setState-in-effect somewhere. Out of scope here; raised
separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
