### PR TITLE
feat(web): rebuild the status rail as a four-zone instrument cluster

### DIFF
--- a/FILE-MAP.md
+++ b/FILE-MAP.md
@@ -229,6 +229,7 @@ Presentational components — map, timing tower, telemetry, comms, race control,
 | `Panel.tsx` | The shared panel chrome every dashboard card renders inside: title, framing and spacing. |
 | `RaceControl.tsx` | The race-control log: the most recent marshalling messages, announced politely as they arrive. |
 | `Route.tsx` | The shared page frame every route renders inside: skip link, heading, and the main landmark. |
+| `SegmentedControl.tsx` | The rail's one control grammar for a choice between persistent states: a labelled radiogroup of .btn segments with roving tabindex. |
 | `Settings.tsx` | The settings page: F1 TV link status and the operator instructions for establishing it. |
 | `SourceToggle.tsx` | The replay/live lane switch, including the caveat text that keeps the live lane honest. |
 | `StaticDemoNotice.tsx` | The placeholder gateway-backed views render on the static GitHub Pages build, where no gateway exists. |
@@ -493,4 +494,4 @@ The golden snapshot pinning the wire contract between Go, Python and the fronten
 
 ---
 
-45 directories, 174 files listed, 0 without a declared purpose.
+45 directories, 175 files listed, 0 without a declared purpose.

--- a/FILE-MAP.md
+++ b/FILE-MAP.md
@@ -234,8 +234,8 @@ Presentational components — map, timing tower, telemetry, comms, race control,
 | `StaticDemoNotice.tsx` | The placeholder gateway-backed views render on the static GitHub Pages build, where no gateway exists. |
 | `StatusBadge.render.test.tsx` | Render tests for the connection/staleness badge, including the live-lane caveat. |
 | `StatusBadge.tsx` | The connection/staleness badge: what the socket is doing and how old the data is. |
-| `StatusRail.render.test.tsx` | Render tests for the top rail: tabs, clock and status. |
-| `StatusRail.tsx` | The top rail: brand, route tabs, session clock and connection status. |
+| `StatusRail.render.test.tsx` | Render tests for the top rail: instrument clusters, empty zones, tabs and status. |
+| `StatusRail.tsx` | The top rail as an instrument cluster: identity, instruments, state, controls. |
 | `StintChart.render.test.tsx` | Render tests for the strategy timeline's stint segments and leader marker. |
 | `StintChart.tsx` | The full-race strategy timeline: one row per car, each stint a coloured segment on a lap axis. |
 | `TelemetryPanel.tsx` | The selected car's telemetry readout: speed, gear, pedal bars and lap/gap sparklines. |

--- a/web/index.html
+++ b/web/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="theme-color" content="#0B0D10" />
     <title>F1 Race Tracker — live timing tower &amp; telemetry</title>
     <meta

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -242,22 +242,33 @@ export default function App() {
           // the rail's healthy lane chip would only repeat it (ui-ux m8). On the
           // static demo there is no control, and the chip stays.
           laneNamedElsewhere={!STATIC_DEMO}
-        >
-          {!STATIC_DEMO && <SourceToggle state={state} />}
-          {/* Label swap rather than aria-pressed, matching the overlay's existing
-              Play/Pause: a transport control names the action it will take. The
-              resulting state is carried by the chip, in a region that is present
-              before it fills so the transition is actually announced. */}
-          <button type="button" className="btn" onClick={toggleFrozen}>
-            {frozen ? '▶ Resume' : '⏸ Freeze'}
-          </button>
-          <span role="status" aria-live="polite">
-            {frozen && <span className="chip chip-replay">⏸ FROZEN</span>}
-            {justLooped && (
-              <span className="chip chip-loop">↻ CLIP LOOPED — the recording restarted</span>
-            )}
-          </span>
-        </StatusRail>
+          // Zone D. The lane pick and the transport verb travel together now:
+          // at 1440 they used to land on different rows a thousand pixels apart,
+          // because the rail wrapped wherever it happened to run out of room.
+          controls={
+            <>
+              {!STATIC_DEMO && <SourceToggle state={state} />}
+              {/* Label swap rather than aria-pressed, matching the overlay's existing
+                  Play/Pause: a transport control names the action it will take. The
+                  resulting state is carried by the chip, in a region that is present
+                  before it fills so the transition is actually announced. */}
+              <button type="button" className="btn" onClick={toggleFrozen}>
+                {frozen ? '▶ Resume' : '⏸ Freeze'}
+              </button>
+            </>
+          }
+          // Zone C, beside the connection chip: these are readouts of transport
+          // state, not controls, and they belong in the reserved slot so the rail
+          // does not change shape for eight seconds every time the clip wraps.
+          stateChips={
+            <span role="status" aria-live="polite">
+              {frozen && <span className="chip chip-replay">⏸ FROZEN</span>}
+              {justLooped && (
+                <span className="chip chip-loop">↻ CLIP LOOPED — the recording restarted</span>
+              )}
+            </span>
+          }
+        />
       }
     >
       <div className="board-top">

--- a/web/src/components/SegmentedControl.tsx
+++ b/web/src/components/SegmentedControl.tsx
@@ -1,0 +1,77 @@
+// The rail's one control grammar for a choice between persistent states: a
+// labelled radiogroup of .btn segments with roving tabindex.
+
+import { useRef } from 'react';
+
+export interface Segment {
+  key: string;
+  label: string;
+  /** Honest small print. Rendered visually-hidden inside the segment and as its title. */
+  caveat?: string;
+}
+
+// Two idioms share the rail and they must never be confused for one another:
+// a segmented control is a *pick* between states that persist (LANE: REPLAY |
+// LIVE), and a plain .btn is a momentary verb that names what it will do
+// (⏸ FREEZE). Anything that is a pick comes through here, so the pick always
+// arrives with the same keyboard contract and the same visible scope label —
+// ui-ux M13/M14's finding was that a bare toggle never says what it is toggling.
+export function SegmentedControl({
+  scope, ariaLabel, options, value, pending, disabled, onPick,
+}: {
+  /** Visible scope label — the group naming what it governs, e.g. "LANE". */
+  scope: string;
+  ariaLabel: string;
+  options: readonly Segment[];
+  value: string;
+  /** Key of the option whose switch is in flight, if any. */
+  pending?: string | null;
+  disabled?: boolean;
+  onPick: (key: string) => void;
+}) {
+  const refs = useRef(new Map<string, HTMLButtonElement | null>());
+  // Falls back to the first option so the group is always reachable even when
+  // the current value is neither of them: a radiogroup every one of whose
+  // members is tabIndex -1 is a radiogroup no keyboard can enter.
+  const activeIdx = Math.max(0, options.findIndex((o) => o.key === value));
+
+  function onKeyDown(e: React.KeyboardEvent, idx: number) {
+    const step = { ArrowRight: 1, ArrowDown: 1, ArrowLeft: -1, ArrowUp: -1 } as const;
+    const d = step[e.key as keyof typeof step];
+    if (d === undefined) return;
+    e.preventDefault();
+    const next = options[(idx + d + options.length) % options.length];
+    refs.current.get(next.key)?.focus();
+    onPick(next.key);
+  }
+
+  return (
+    <div className="rail-segmented">
+      {/* aria-hidden because the group already carries the same word in its
+          accessible name — announcing "Lane, Lane, radio group" is noise. */}
+      <span className="rail-scope" aria-hidden="true">{scope}</span>
+      <div role="radiogroup" aria-label={ariaLabel} className="rail-segments">
+        {options.map((o, i) => (
+          <button
+            key={o.key}
+            type="button"
+            role="radio"
+            aria-checked={value === o.key}
+            ref={(el) => { refs.current.set(o.key, el); }}
+            tabIndex={i === activeIdx ? 0 : -1}
+            onKeyDown={(e) => onKeyDown(e, i)}
+            onClick={() => onPick(o.key)}
+            disabled={disabled}
+            className={value === o.key ? 'btn btn-active' : 'btn'}
+            title={o.caveat}
+          >
+            {pending === o.key ? 'Switching…' : o.label}
+            {/* Was title-only, so unreachable on touch and to anyone who never
+                hovers — and this particular caveat is the honest one. */}
+            {o.caveat && <span className="visually-hidden"> — {o.caveat}</span>}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/SourceToggle.tsx
+++ b/web/src/components/SourceToggle.tsx
@@ -1,13 +1,14 @@
 // The replay/live lane switch, including the caveat text that keeps the live lane
 // honest.
 
-import { useRef, useState } from 'react';
+import { useState } from 'react';
 import type { RaceState } from '../state/race';
+import { SegmentedControl } from './SegmentedControl';
 
 const SOURCES = [
   { key: 'replay', label: '▶ Replay', caveat: undefined },
   {
-    key: 'live', label: '● Live (demo)',
+    key: 'live', label: '● Live',
     caveat: 'Demo lane streaming a second replay clip — real live ingestion not yet verified',
   },
 ] as const;
@@ -16,18 +17,14 @@ const SOURCES = [
 // ("replay"|"live") — it broadcasts a fresh snapshot the instant it switches.
 // We key off session (the lane) rather than mode (the data's provenance) so the
 // highlight is correct even when both lanes happen to be replay-sourced.
+//
+// The radiogroup, roving tabindex and arrow keys now live in SegmentedControl:
+// Replay-vs-Live is a single-select choice, and it is the rail's reference
+// example of that grammar rather than a one-off.
 export function SourceToggle({ state }: { state: RaceState }) {
   const [pending, setPending] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const active = state.session;
-  const btnRefs = useRef(new Map<string, HTMLButtonElement | null>());
-  // Replay-vs-Live is a single-select choice, not two independent switches, so it
-  // is a radio group: `.btn-active` was the only "on" signal and carried nothing
-  // non-visually. Roving tabindex + arrows are what make the role honest — a
-  // radiogroup a user can only Tab through is a radiogroup in name only. Falls
-  // back to the first option so the group is always reachable even on a route
-  // whose session key is neither of these.
-  const activeIdx = Math.max(0, SOURCES.findIndex((s) => s.key === active));
 
   async function pick(source: string) {
     if (pending || source === active) return;
@@ -47,43 +44,20 @@ export function SourceToggle({ state }: { state: RaceState }) {
     }
   }
 
-  function onKeyDown(e: React.KeyboardEvent, idx: number) {
-    const step = { ArrowRight: 1, ArrowDown: 1, ArrowLeft: -1, ArrowUp: -1 } as const;
-    const d = step[e.key as keyof typeof step];
-    if (d === undefined) return;
-    e.preventDefault();
-    const next = SOURCES[(idx + d + SOURCES.length) % SOURCES.length];
-    btnRefs.current.get(next.key)?.focus();
-    pick(next.key);
-  }
-
   return (
-    <div style={{ display: 'inline-flex', alignItems: 'center', gap: 'var(--sp-2)' }}>
-      <div role="radiogroup" aria-label="Data source" style={{ display: 'inline-flex', gap: 'var(--sp-1)' }}>
-        {SOURCES.map((s, i) => (
-          <button
-            key={s.key}
-            type="button"
-            role="radio"
-            aria-checked={active === s.key}
-            ref={(el) => { btnRefs.current.set(s.key, el); }}
-            tabIndex={i === activeIdx ? 0 : -1}
-            onKeyDown={(e) => onKeyDown(e, i)}
-            onClick={() => pick(s.key)}
-            disabled={pending !== null}
-            className={active === s.key ? 'btn btn-active' : 'btn'}
-            title={s.caveat}
-          >
-            {pending === s.key ? 'Switching…' : s.label}
-            {/* Was title-only, so unreachable on touch and to anyone who never
-                hovers — and this particular caveat is the honest one. */}
-            {s.caveat && <span className="visually-hidden"> — {s.caveat}</span>}
-          </button>
-        ))}
-      </div>
+    <>
+      <SegmentedControl
+        scope="Lane"
+        ariaLabel="Data source"
+        options={SOURCES}
+        value={active}
+        pending={pending}
+        disabled={pending !== null}
+        onPick={pick}
+      />
       <span role="status" aria-live="polite">
         {error && <span className="src-error">{error}</span>}
       </span>
-    </div>
+    </>
   );
 }

--- a/web/src/components/StatusRail.render.test.tsx
+++ b/web/src/components/StatusRail.render.test.tsx
@@ -1,20 +1,23 @@
-// Render tests for the top rail: tabs, clock and status.
+// Render tests for the top rail: instrument clusters, empty zones, tabs and status.
 
 import { describe, test, expect } from 'vitest';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { StatusRail } from './StatusRail';
+import { SourceToggle } from './SourceToggle';
 import { emptyState } from '../state/race';
 import { car } from '../state/testCar';
 
-describe('StatusRail leader-lap badge', () => {
-  test('shows LAP n/m when a car is tagged pos:1', () => {
-    const state = {
-      ...emptyState(),
-      totalLaps: 53,
-      cars: { 1: car({ driverNum: 1, pos: 1, lap: 12 }) },
-    };
-    const html = renderToStaticMarkup(<StatusRail active="board" state={state} />);
-    expect(html).toContain('LAP 12/53');
+const leaderOnLap = (lap: number) => ({
+  ...emptyState(),
+  totalLaps: 53,
+  cars: { 1: car({ driverNum: 1, pos: 1, lap }) },
+});
+
+describe('StatusRail leader-lap instrument', () => {
+  test('shows the lap value under its LAP label when a car is tagged pos:1', () => {
+    const html = renderToStaticMarkup(<StatusRail active="board" state={leaderOnLap(12)} />);
+    expect(html).toContain('12/53');
+    expect(html).toContain('>Lap<');
   });
 
   test('degrades honestly instead of vanishing when no car carries a literal pos:1 (#66)', () => {
@@ -31,29 +34,148 @@ describe('StatusRail leader-lap badge', () => {
       },
     };
     const html = renderToStaticMarkup(<StatusRail active="board" state={state} />);
-    expect(html).toContain('LAP 12/53');
+    expect(html).toContain('12/53');
   });
 
-  test('still shows the badge when the leader is on lap 0', () => {
+  test('still shows the instrument when the leader is on lap 0', () => {
     // lap 0 is a real value on the wire (internal/model/model.go) — the opening
     // lap, before anyone has crossed the line. A truthiness guard hid the badge
     // for exactly the moment it is most interesting.
-    const state = {
-      ...emptyState(),
-      totalLaps: 53,
-      cars: { 1: car({ driverNum: 1, pos: 1, lap: 0 }) },
-    };
-    const html = renderToStaticMarkup(<StatusRail active="board" state={state} />);
-    expect(html).toContain('LAP 0/53');
+    const html = renderToStaticMarkup(<StatusRail active="board" state={leaderOnLap(0)} />);
+    expect(html).toContain('0/53');
+    expect(html).toContain('>Lap<');
   });
 
-  test('omits the badge when the leader has no lap at all', () => {
+  test('omits the instrument when the leader has no lap at all', () => {
+    const state = { ...emptyState(), totalLaps: 53, cars: { 1: car({ driverNum: 1, pos: 1 }) } };
+    const html = renderToStaticMarkup(<StatusRail active="board" state={state} />);
+    expect(html).not.toContain('>Lap<');
+  });
+});
+
+describe('StatusRail instrument clusters', () => {
+  test('every instrument renders a value and the label that names it', () => {
     const state = {
-      ...emptyState(),
-      totalLaps: 53,
-      cars: { 1: car({ driverNum: 1, pos: 1 }) },
+      ...leaderOnLap(16),
+      weather: { trackTempC: 48.2, airTempC: 33.4, rainfall: false },
     };
     const html = renderToStaticMarkup(<StatusRail active="board" state={state} />);
-    expect(html).not.toContain('LAP ');
+    for (const label of ['>Session<', '>Lap<', '>Track / Air<']) {
+      expect(html).toContain(label);
+    }
+    expect(html).toContain('48° / 33°');
+  });
+
+  test('renders the four zones in cluster order on the board', () => {
+    const html = renderToStaticMarkup(
+      <StatusRail active="board" state={leaderOnLap(4)} controls={<button type="button">x</button>} />,
+    );
+    for (const cluster of ['rail-identity', 'rail-instruments', 'rail-state', 'rail-controls', 'rail-tabs', 'rail-exits']) {
+      expect(html).toContain(cluster);
+    }
+  });
+
+  test('empty zones render null rather than a stray seam', () => {
+    // The overlay: no session, no lane control. An instruments cluster or a
+    // control cluster with nothing in it is a hairline with no zone behind it.
+    const html = renderToStaticMarkup(<StatusRail active="ghost" note="two laps" />);
+    expect(html).not.toContain('rail-instruments');
+    expect(html).not.toContain('rail-conditions');
+    expect(html).not.toContain('rail-state');
+    expect(html).not.toContain('rail-controls');
+    // Identity, nav and the exits are on every route.
+    expect(html).toContain('rail-identity');
+    expect(html).toContain('rail-tabs');
+    expect(html).toContain('rail-exits');
+  });
+
+  test('a session with no weather renders no conditions cluster', () => {
+    const html = renderToStaticMarkup(<StatusRail active="board" state={leaderOnLap(4)} />);
+    expect(html).toContain('rail-instruments');
+    expect(html).not.toContain('rail-conditions');
+  });
+
+  test('the state zone appears for transient chips even with no session', () => {
+    const html = renderToStaticMarkup(
+      <StatusRail active="board" stateChips={<span className="chip">FROZEN</span>} />,
+    );
+    expect(html).toContain('rail-state');
+    expect(html).toContain('FROZEN');
+  });
+
+  test('the reserved state slot is not itself a live region', () => {
+    // Two nested polite regions double-announce; the chip carries its own and
+    // the board hands one in beside it.
+    const html = renderToStaticMarkup(<StatusRail active="board" state={leaderOnLap(4)} />);
+    expect(html).not.toMatch(/class="rail-cluster rail-state"[^>]*aria-live/);
+  });
+
+  test('exactly one polite region per chip in the rail subtree', () => {
+    const html = renderToStaticMarkup(<StatusRail active="board" state={leaderOnLap(4)} />);
+    expect(html.match(/aria-live="polite"/g)).toHaveLength(1);
+  });
+});
+
+describe('StatusRail navigation', () => {
+  test('the nav is labelled and marks exactly one current page', () => {
+    const html = renderToStaticMarkup(<StatusRail active="ghost" />);
+    expect(html).toContain('aria-label="Views"');
+    expect(html.match(/aria-current="page"/g)).toHaveLength(1);
+  });
+
+  test('Settings marks the demoted F1TV link current, not a tab', () => {
+    const html = renderToStaticMarkup(<StatusRail active="settings" />);
+    expect(html.match(/aria-current="page"/g)).toHaveLength(1);
+    expect(html).toContain('rail-repo-active');
+  });
+
+  test('the h1 stays visible in the identity zone and names the route', () => {
+    const html = renderToStaticMarkup(<StatusRail active="ghost" />);
+    expect(html.match(/<h1/g)).toHaveLength(1);
+    expect(html).toContain('Lap delta overlay');
+    expect(html).not.toContain('visually-hidden">F1 Race Tracker');
+  });
+});
+
+describe('control grammar', () => {
+  test('a persistent choice is a labelled radiogroup with a visible scope', () => {
+    const state = { ...emptyState(), session: 'replay' };
+    const html = renderToStaticMarkup(
+      <StatusRail active="board" state={state} controls={<SourceToggle state={state} />} />,
+    );
+    expect(html).toContain('role="radiogroup"');
+    expect(html).toContain('aria-label="Data source"');
+    // The group names its own scope on screen (ui-ux M14): a bare pair of
+    // buttons never says what it is choosing between.
+    expect(html).toContain('class="rail-scope"');
+    expect(html).toContain('Lane');
+    expect(html.match(/role="radio"/g)).toHaveLength(2);
+    expect(html).toContain('aria-checked="true"');
+  });
+
+  test('roving tabindex leaves exactly one segment reachable by Tab', () => {
+    const state = { ...emptyState(), session: 'live' };
+    const html = renderToStaticMarkup(<SourceToggle state={state} />);
+    expect(html.match(/tabindex="0"/g)).toHaveLength(1);
+    expect(html.match(/tabindex="-1"/g)).toHaveLength(1);
+  });
+
+  test('an unknown session key still leaves the group reachable', () => {
+    const state = { ...emptyState(), session: 'something-else' };
+    const html = renderToStaticMarkup(<SourceToggle state={state} />);
+    expect(html.match(/tabindex="0"/g)).toHaveLength(1);
+    expect(html).not.toContain('aria-checked="true"');
+  });
+
+  test('a momentary verb stays a plain button, not a segment', () => {
+    const html = renderToStaticMarkup(
+      <StatusRail
+        active="board"
+        state={leaderOnLap(4)}
+        controls={<button type="button" className="btn">⏸ Freeze</button>}
+      />,
+    );
+    expect(html).toContain('⏸ Freeze');
+    expect(html).not.toContain('role="radiogroup"');
   });
 });

--- a/web/src/components/StatusRail.tsx
+++ b/web/src/components/StatusRail.tsx
@@ -1,4 +1,4 @@
-// The top rail: brand, route tabs, session clock and connection status.
+// The top rail as an instrument cluster: identity, instruments, state, controls.
 
 import type { ReactNode } from 'react';
 import type { RaceState } from '../state/race';
@@ -33,13 +33,33 @@ const ROUTE_TITLES = {
   settings: 'F1TV link',
 } as const;
 
-// StatusRail is the persistent instrument strip on every route — the
-// signature element. On the board it carries live session identity, the
-// race clock, and lane health; on the overlay (two reference laps on their
-// own scrubbable clock, no session clock to show) it's a lighter shell:
-// brand, a static note, and the same view tabs.
+// One instrument: a value over the 11px uppercase label that says what it is.
+// A row of bare numbers is a readout; a row of labelled numbers is a cluster,
+// and the labels are the only thing that turns one into the other.
+function Metric({ label, title, children }: {
+  label: string; title?: string; children: ReactNode;
+}) {
+  return (
+    <div className="rail-metric" title={title}>
+      <span className="rail-metric-value">{children}</span>
+      <span className="rail-metric-label">{label}</span>
+    </div>
+  );
+}
+
+// StatusRail is the persistent instrument cluster on every route — the signature
+// element. Four zones, each a `.rail-cluster` closed by a hairline: IDENTITY
+// (brand/h1, session, route note), INSTRUMENTS (clock, lap, conditions), STATE
+// (the connection chip plus the board's transient FROZEN / CLIP-LOOPED chips, in
+// one reserved slot so a chip appearing never reflows the rail) and CONTROLS
+// (segmented lane pick and transport verbs, then nav, then the exits).
+//
+// Zones wrap at the zone seam, never mid-instrument, and a zone with nothing in
+// it renders null — the overlay and Settings have no session and no lane
+// control, and an empty cluster there would show as a stray hairline.
 export function StatusRail({
-  active, state, status, staleSec, note, onReconnect, laneNamedElsewhere, children,
+  active, state, status, staleSec, note, onReconnect, laneNamedElsewhere,
+  controls, stateChips,
 }: {
   active: 'board' | 'ghost' | 'settings';
   state?: RaceState;
@@ -48,85 +68,137 @@ export function StatusRail({
   note?: string;
   onReconnect?: () => void;
   laneNamedElsewhere?: boolean;
-  children?: ReactNode;
+  /** Zone D: the route's own controls — lane pick, transport verbs. */
+  controls?: ReactNode;
+  /** Zone C: transient state the route owns, e.g. the board's FROZEN/loop region. */
+  stateChips?: ReactNode;
 }) {
   // The race leader's current lap, out of the session's total — the recorder bakes
   // both from FastF1's lap data (ingest/record.py's _lap_number / TOTAL_LAPS), so
   // this is exact, not a derived estimate like Gap/Int. See leaderLapOf for why it
   // reads the running order rather than matching pos===1.
   const leaderLap = state ? leaderLapOf(state.cars) : undefined;
+  // != null, not truthiness: lap 0 (the leader is on the opening lap) is a real
+  // value on the wire, and hid the whole badge under `!!leaderLap`.
+  const showLap = !!state && leaderLap != null && !!state.totalLaps;
+  const weather = state?.weather;
+  const hasInstruments = !!state;
+  const hasState = !!state || !!stateChips;
 
   return (
-    <div className="rail">
-      {/* The route's <h1>. Route no longer renders one — two would break the
-          chain this comment block exists to keep straight. */}
-      <h1 className="rail-brand">
-        F1 Race Tracker
-        <span className="rail-brand-sep" aria-hidden="true">·</span>
-        <span className="rail-route">{ROUTE_TITLES[active]}</span>
-      </h1>
-      {state && (
-        <>
-          {state.label && <span className="rail-session">{state.label}</span>}
-          <span className="rail-clock">{fmtClock(state.timeMs)}</span>
-          {/* != null, not truthiness: lap 0 (the leader is on the opening lap) is a
-              real value on the wire, and hid the whole badge under `!!leaderLap`. */}
-          {leaderLap != null && !!state.totalLaps && (
-            <span className="rail-lap">LAP {leaderLap}/{state.totalLaps}</span>
-          )}
-          {state.weather && (
-            <span className="rail-lap" title="Baked from session weather data">
-              TRK {state.weather.trackTempC.toFixed(0)}° · AIR {state.weather.airTempC.toFixed(0)}°
-              {state.weather.rainfall && <span style={{ color: 'var(--rain)' }}> · RAIN</span>}
-            </span>
-          )}
-          {/* No live-region wrapper here any more: StatusBadge carries its own, so
-              every lane announces its transitions too and there is no
-              chance of nesting two polite regions and double-announcing. */}
-          <StatusBadge
-            status={status ?? 'connecting'}
-            state={state}
-            staleSec={staleSec}
-            onReconnect={onReconnect}
-            laneNamedElsewhere={laneNamedElsewhere}
-          />
-        </>
-      )}
-      {note && <span className="rail-note">{note}</span>}
-      {children}
-      <span className="rail-spacer" />
-      <nav className="rail-tabs">
-        {TABS.map((t) => (
+    // <header>, not a bare div: the rail is the page masthead and carries the h1.
+    // The two wrappers below are `display: contents` on desktop — they exist only
+    // so the phone breakpoint can lift the strip clusters into one sticky bar
+    // without duplicating a single node (a second <nav> would give two
+    // aria-current targets and two tab stops for the same link).
+    <header className="rail">
+      <div className="rail-block">
+        <div className="rail-cluster rail-identity">
+          {/* The route's <h1>. Route no longer renders one — two would break the
+              chain this comment block exists to keep straight. */}
+          <h1 className="rail-brand">
+            F1 Race Tracker
+            <span className="rail-brand-sep" aria-hidden="true">·</span>
+            <span className="rail-route">{ROUTE_TITLES[active]}</span>
+          </h1>
+          {state?.label && <span className="rail-session">{state.label}</span>}
+          {note && <span className="rail-note">{note}</span>}
+        </div>
+
+        {/* Conditions live in the block rather than beside the clock so the phone
+            breakpoint can leave them behind: the sticky 48px strip carries only
+            what is watched continuously (clock, lap, an exception, the tabs),
+            and track temperature is read once. On desktop `order` puts this
+            cell back where it belongs — the last instrument in the cluster. */}
+        {weather && (
+          <div className="rail-cluster rail-conditions">
+            <Metric label="Track / Air" title="Baked from session weather data">
+              <span className="rail-lap">
+                {weather.trackTempC.toFixed(0)}° / {weather.airTempC.toFixed(0)}°
+                {weather.rainfall && <span style={{ color: 'var(--rain)' }}> · RAIN</span>}
+              </span>
+            </Metric>
+          </div>
+        )}
+
+        {controls && <div className="rail-cluster rail-controls">{controls}</div>}
+
+        <div className="rail-cluster rail-exits">
           <a
-            key={t.key}
-            href={t.href}
-            className={active === t.key ? 'rail-tab rail-tab-active' : 'rail-tab'}
+            className={active === 'settings' ? 'rail-repo rail-repo-active' : 'rail-repo'}
+            href="#settings"
+            aria-current={active === 'settings' ? 'page' : undefined}
           >
-            <span>{t.label}</span>
-            <span className="rail-tab-sub">{t.sub}</span>
+            <span className="rail-repo-glyph" aria-hidden="true">⚙</span>
+            <span className="rail-repo-text">F1TV<span className="rail-repo-long"> Link</span></span>
           </a>
-        ))}
-      </nav>
-      <a
-        className={active === 'settings' ? 'rail-repo rail-repo-active' : 'rail-repo'}
-        href="#settings"
-        aria-current={active === 'settings' ? 'page' : undefined}
-      >
-        F1TV Link
-      </a>
-      {/* Deliberately outside <nav>: this is a way out of the app, not a fifth
-          view. It is the only path from any route back to the project, which
-          for a portfolio piece is the whole point of the artefact. */}
-      <a
-        className="rail-repo"
-        href={REPO_URL}
-        target="_blank"
-        rel="noreferrer"
-        title="Project source on GitHub"
-      >
-        GitHub<span aria-hidden="true"> ↗</span>
-        <span className="visually-hidden"> (opens in a new tab)</span>
-      </a>
-    </div>
+          {/* Deliberately outside <nav>: this is a way out of the app, not a fifth
+              view. It is the only path from any route back to the project, which
+              for a portfolio piece is the whole point of the artefact. */}
+          <a
+            className="rail-repo"
+            href={REPO_URL}
+            target="_blank"
+            rel="noreferrer"
+            title="Project source on GitHub"
+          >
+            <span className="rail-repo-glyph" aria-hidden="true">↗</span>
+            <span className="rail-repo-text">GitHub<span aria-hidden="true"> ↗</span></span>
+            <span className="visually-hidden"> (opens in a new tab)</span>
+          </a>
+        </div>
+      </div>
+
+      <div className="rail-strip">
+        {hasInstruments && (
+          <div className="rail-cluster rail-instruments">
+            <Metric label="Session">
+              <span className="rail-clock">{fmtClock(state.timeMs)}</span>
+            </Metric>
+            {showLap && (
+              <Metric label="Lap">
+                <span className="rail-lap">{leaderLap}/{state.totalLaps}</span>
+              </Metric>
+            )}
+          </div>
+        )}
+
+        {/* The reserved state slot. Deliberately NOT a live region itself: the
+            chip carries its own polite region (StatusBadge) and the board hands
+            in another for FROZEN/CLIP-LOOPED, and nesting two would
+            double-announce. min-width, not a fixed width, so an arriving chip
+            does not reflow the rail but a long one is never clipped. */}
+        {hasState && (
+          <div className="rail-cluster rail-state">
+            {state && (
+              <StatusBadge
+                status={status ?? 'connecting'}
+                state={state}
+                staleSec={staleSec}
+                onReconnect={onReconnect}
+                laneNamedElsewhere={laneNamedElsewhere}
+              />
+            )}
+            {stateChips}
+          </div>
+        )}
+
+        <span className="rail-cluster rail-spacer" aria-hidden="true" />
+
+        <nav className="rail-cluster rail-tabs" aria-label="Views">
+          {TABS.map((t) => (
+            <a
+              key={t.key}
+              href={t.href}
+              className={active === t.key ? 'rail-tab rail-tab-active' : 'rail-tab'}
+              aria-current={active === t.key ? 'page' : undefined}
+            >
+              <span>{t.label}</span>
+              <span className="rail-tab-sub">{t.sub}</span>
+            </a>
+          ))}
+        </nav>
+      </div>
+    </header>
   );
 }

--- a/web/src/styles/components.css
+++ b/web/src/styles/components.css
@@ -54,23 +54,191 @@
 }
 
 /* The <main> landmark inherits the page grid so wrapping the panels in it
-   does not change any spacing. */
+   does not change any spacing. scroll-margin-top keeps the skip link honest on
+   a phone, where a 48px sticky strip would otherwise sit on top of the first
+   thing focus lands on. */
 .route-main {
+  scroll-margin-top: 64px;
   display: grid;
   gap: var(--sp-6);
 }
 
 /* Status rail — the signature element */
 
+/* The rail is an instrument cluster of four zones — IDENTITY, INSTRUMENTS,
+   STATE, CONTROLS — and it wraps at the seams BETWEEN zones, never inside one.
+   That is the whole trick: flex-wrap on a flat list of fourteen elements is why
+   the 1440px rail used to be two rows with the lane switch on one and Freeze on
+   the other, a thousand pixels apart. Wrapping a list of four clusters can only
+   ever produce whole clusters on a line.
+
+   container-type so the collapse can be expressed against the rail's own width
+   rather than the viewport's — the rail sits inside the page's padding and, on
+   the overlay, beside narrower content. */
 .rail {
   display: flex;
-  align-items: center;
-  gap: var(--sp-4);
-  padding: var(--sp-3) var(--sp-4);
+  align-items: stretch;
+  flex-wrap: wrap;
+  gap: 0;
+  padding: var(--sp-2) var(--sp-4);
   background: var(--carbon);
   border: 1px solid var(--edge);
   border-radius: var(--radius);
+}
+
+/* Two grouping wrappers that are invisible on desktop (display: contents, so
+   their children are the rail's own flex items and `order` below places them)
+   and become real boxes at the phone breakpoint, where .rail-strip is lifted
+   into a 48px sticky bar. They exist so the phone layout re-flows the SAME
+   nodes: duplicating the <nav> would give two aria-current targets and two tab
+   stops for one link. */
+.rail-block,
+.rail-strip {
+  display: contents;
+}
+
+/* A zone. The hairline is on the cluster itself rather than on an adjacent
+   sibling selector, because a zone that renders null (no session on the
+   overlay, no lane control on Settings) must not leave its seam behind — and
+   with `order` in play, DOM adjacency is not visual adjacency. IDENTITY is
+   always first and always suppresses its own edge. */
+.rail-cluster {
+  display: flex;
+  align-items: center;
+  flex-wrap: nowrap;
+  gap: var(--sp-2);
+  padding-inline: var(--sp-2);
+  border-left: 1px solid var(--edge);
+}
+
+.rail-identity {
+  order: 0;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+  gap: var(--sp-0);
+  padding-left: 0;
+  border-left: none;
+}
+
+.rail-instruments { order: 1; gap: 0; }
+.rail-conditions { order: 2; }
+.rail-controls { order: 4; }
+.rail-tabs { order: 5; }
+.rail-exits { order: 6; gap: var(--sp-0); }
+
+/* STATE. A reserved slot: min-width rather than a fixed width, so the stall,
+   FROZEN and CLIP-LOOPED chips arriving and leaving never reflow the rail, but
+   the eight-second loop notice — the one chip that MUST be readable in the
+   moment it appears — is never clipped either. 15ch is the measured width of
+   the widest resting chip. */
+.rail-state {
+  order: 3;
   flex-wrap: wrap;
+  gap: var(--sp-2);
+  min-width: 22ch;
+}
+
+/* Chips shrink before the rail gains a row. The transient chips are the widest
+   things that can arrive in the cluster — the eight-second loop notice is ~340px
+   — and reserving that permanently would cost more than the row it saves, while
+   reserving nothing lets a chip reflow the whole rail for eight seconds. Letting
+   the slot shrink and the chip ellipsise resolves it: the chip is whole wherever
+   there is room, clipped where there is not, and its text — and so the polite
+   announcement — is unchanged either way. Not the terminal chip: it carries the
+   Reconnect button, and a truncated way out is no way out. */
+.rail-state > *,
+.rail-state .chip {
+  min-width: 0;
+}
+
+.rail-state .chip:not(:has(.chip-action)) {
+  display: block;
+  max-width: 22ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* The slot is reserved, so it keeps its width even when the board is healthy
+   and every chip has stood down (ui-ux m8) — but a hairline with nothing
+   behind it is the stray seam this whole structure exists to avoid. The border
+   belongs to the chip, not to the reservation. */
+.rail-state:not(:has(.chip)) {
+  border-left: none;
+}
+
+/* An instrument: the value over the label that says what it is. Hairline-split
+   sub-cells, so the cluster reads as one gauge face rather than three numbers. */
+.rail-metric {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: var(--sp-0);
+  padding-inline: var(--sp-2);
+}
+
+.rail-metric:first-child { padding-left: 0; }
+
+.rail-metric + .rail-metric {
+  border-left: 1px solid var(--edge);
+}
+
+.rail-metric-value {
+  display: flex;
+  align-items: baseline;
+  line-height: 1;
+}
+
+/* No new rung: --fs-xs (11px) uppercase --slate is exactly the idiom
+   .rail-tab-sub already established for "chrome that labels something else". */
+.rail-metric-label {
+  font-family: var(--display);
+  font-size: var(--fs-xs);
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--slate);
+  white-space: nowrap;
+}
+
+/* The segmented control and the word that says what it governs. */
+.rail-segmented {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-2);
+}
+
+.rail-scope {
+  font-family: var(--display);
+  font-size: var(--fs-xs);
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--slate);
+  white-space: nowrap;
+}
+
+/* Segments abut into one control rather than floating as two buttons: the pick
+   is one object with two states, and a gap between them says "two buttons". */
+.rail-segments {
+  display: inline-flex;
+}
+
+.rail-segments .btn:first-child {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.rail-segments .btn:last-child {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  margin-left: -1px;
+}
+
+.rail-segments .btn-active {
+  position: relative;
+  z-index: 1;
 }
 
 /* This is the page's <h1>, so the UA's 2em/1.34em margins have to go — a heading
@@ -145,18 +313,22 @@
   font-size: var(--fs-sm);
 }
 
+/* The gap between the readout zones and the control zones. An element rather
+   than margin-left:auto on the first control zone, because which zone that is
+   depends on the route: the overlay has no lane control and Settings has no
+   instruments, and an auto margin on two candidates splits the space between
+   them instead of collecting it in one place. order:2 with the STATE zone puts
+   it after state and before controls on every route. */
 .rail-spacer {
-  flex: 1;
+  order: 3;
+  flex: 1 1 0;
+  min-width: 0;
+  border-left: none;
+  padding: 0;
 }
 
-/* margin-left: auto as well as the spacer, because .rail-spacer collapses when
-   the rail wraps: the nav then dropped to a LEFT-aligned second row and the
-   chrome visibly changed shape. The auto margin re-anchors it on either line. */
 .rail-tabs {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--sp-2);
-  margin-left: auto;
+  gap: var(--sp-1);
   /* justify-content matters only once it wraps: a wrapped nav that centred its
      orphan row would read as a different component on the second line. */
   justify-content: flex-end;
@@ -167,7 +339,7 @@
   flex-direction: column;
   align-items: center;
   gap: var(--sp-0);
-  padding: var(--sp-1) var(--sp-3);
+  padding: var(--sp-1) var(--sp-2);
   border: 1px solid var(--edge);
   border-radius: var(--radius);
   text-decoration: none;
@@ -196,7 +368,7 @@
 .rail-tab-sub {
   white-space: nowrap;
   font-family: var(--data);
-  font-size: var(--fs-sm);
+  font-size: var(--fs-xs);
   font-weight: 400;
   letter-spacing: 0;
   text-transform: none;
@@ -212,15 +384,27 @@
 .rail-repo {
   display: inline-flex;
   align-items: center;
-  padding: var(--sp-2) var(--sp-2);
+  padding: var(--sp-2) var(--sp-1);
   font-family: var(--display);
   font-size: var(--fs-xs);
   font-weight: 600;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
   color: var(--slate);
   text-decoration: none;
   white-space: nowrap;
+}
+
+/* Scoped to the rail so nothing below it changes: the cluster is a dense strip
+   of controls and the desktop board's density depends on it staying that way.
+   The coarse-pointer block still raises every one of these to 44px. */
+.rail .btn {
+  padding-inline: var(--sp-2);
+}
+
+/* Hidden until the rail runs out of room; see the 1220px block. */
+.rail-repo-glyph {
+  display: none;
 }
 
 .rail-repo:hover {
@@ -969,6 +1153,12 @@ select.btn {
     min-height: 44px;
     justify-content: center;
   }
+
+  /* The two exits were 32px tall — below the 44px floor even on touch, and the
+     only leftover from the H-4 sweep. They stay link-weight; only the box grows. */
+  .rail-repo {
+    min-height: 44px;
+  }
 }
 
 /* ---------------------------------------------------------------------------
@@ -1355,11 +1545,209 @@ select.btn {
 
 /* Phone chrome */
 
+/* Between a full-width desktop and the phone the rail sheds decoration before
+   it sheds a row: the tab captions and the tracking on the instrument labels
+   are the two things worth less than a single 64px line. Below this the rail is
+   still one row of six zones; only under ~1050px does it start wrapping, and
+   then only at a cluster seam. */
+@media (max-width: 1360px) {
+  .rail-tab-sub {
+    display: none;
+  }
+
+  /* Out of the flow, not out of the accessibility tree: the link is still
+     called "F1TV Link" when it is read aloud, it just stops paying for the
+     second word in pixels. */
+  .rail-repo-long {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip-path: inset(50%);
+    white-space: nowrap;
+  }
+
+  .rail-metric-label,
+  .rail-scope {
+    letter-spacing: 0.08em;
+  }
+
+  .rail {
+    padding-inline: var(--sp-2);
+  }
+
+  .rail-controls,
+  .rail-segmented {
+    gap: var(--sp-1);
+  }
+
+  /* The exits go to their glyphs — they are the quietest thing in the rail and
+     the last thing worth a row of their own. Their names stay in the
+     accessibility tree, out of the flow. */
+  .rail-repo-glyph {
+    display: inline;
+  }
+
+  .rail-repo-text {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip-path: inset(50%);
+    white-space: nowrap;
+  }
+
+  .rail-repo {
+    padding-inline: var(--sp-2);
+    font-size: var(--fs-lg);
+  }
+
+  .rail-state {
+    min-width: 6ch;
+  }
+
+  .rail-state .chip:not(:has(.chip-action)) {
+    max-width: 12ch;
+  }
+
+  .rail-metric {
+    padding-inline: var(--sp-1);
+  }
+}
+
+/* The last thing to go before the rail wraps. 22px is an existing rung
+   (--fs-2xl), the one the phone strip uses, and the clock is still by a wide
+   margin the largest number in the chrome at it. */
+@media (max-width: 1220px) {
+  .rail-clock {
+    font-size: var(--fs-2xl);
+  }
+
+  /* The value keeps a degree sign and a slash; at this width that is enough to
+     say what it is without spending 90px on the caption. */
+  .rail-conditions .rail-metric-label {
+    display: none;
+  }
+
+  .rail-state {
+    min-width: 4ch;
+  }
+
+  .rail-state .chip:not(:has(.chip-action)) {
+    max-width: 10ch;
+  }
+
+}
+
+/* The phone rail: one 48px sticky strip plus a scroll-away block.
+
+   At 390px the flat rail was 379px tall — 7.8% of the document and ~44% of the
+   first screen — and once you scrolled past it there was no navigation on the
+   page at all (ui-ux m22). `display: contents` dissolves the rail box so its two
+   wrappers become children of the .page grid; .rail-strip can then be sticky
+   against the page scroll (a sticky element inside a 160px-tall rail would have
+   160px of travel and be useless), while the block scrolls away. Same nodes, no
+   duplication — the <nav>, its aria-current and its tab stops are the ones the
+   desktop rail uses. */
+@media (max-width: 700px) {
+  .rail {
+    display: contents;
+  }
+
+  .rail-strip {
+    display: flex;
+    align-items: center;
+    gap: var(--sp-3);
+    order: -1;
+    position: sticky;
+    /* Above the panels, below the skip link (z-index 10) — the skip link is
+       pinned over this exact corner and must never end up behind it. */
+    top: 0;
+    z-index: 5;
+    min-height: 48px;
+    /* env() resolves to 0 without viewport-fit=cover in index.html's viewport
+       meta, which is why that attribute is not optional here. */
+    padding: env(safe-area-inset-top) max(var(--sp-3), env(safe-area-inset-right))
+             0 max(var(--sp-3), env(safe-area-inset-left));
+    background: var(--carbon);
+    border: 1px solid var(--edge);
+    border-radius: var(--radius);
+  }
+
+  .rail-block {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: var(--sp-3);
+    order: 0;
+    padding: var(--sp-2) var(--sp-3);
+    background: var(--carbon);
+    border: 1px solid var(--edge);
+    border-radius: var(--radius);
+  }
+
+  /* No seams on the phone: the two boxes already separate readouts from the
+     rest, and a hairline between every wrapped pair reads as a table. */
+  .rail-cluster,
+  .rail-metric,
+  .rail-metric:first-child {
+    padding-inline: 0;
+    border-left: none;
+  }
+
+  .rail-instruments {
+    gap: var(--sp-3);
+  }
+
+  /* Both wrappers are grid items of .page now, and a grid item's automatic
+     minimum size is its min-content width — which for a nowrap control cluster
+     is the whole cluster. Left at auto it widens the page's single column and
+     every panel below it with it, which is a document-wide horizontal scrollbar
+     caused by the rail. */
+  .rail-strip,
+  .rail-block,
+  .rail-cluster {
+    min-width: 0;
+  }
+
+  .rail-controls,
+  .rail-exits {
+    flex-wrap: wrap;
+  }
+
+  /* The strip is 48px and the clock is the tallest thing in it. --fs-2xl is an
+     existing rung, not a new one. */
+  .rail-strip .rail-clock {
+    font-size: var(--fs-2xl);
+  }
+
+  /* The strip has room for the tabs but not for the tabs and their captions. */
+  .rail-strip .rail-metric-label {
+    display: none;
+  }
+}
+
 @media (max-width: 500px) {
   /* Four sub-labels are ~34% of the first screen on a 390px phone, and the four
      primary words say the same thing. */
   .rail-tab-sub {
     display: none;
+  }
+
+  /* The strip is clock + lap + tabs and there is no room left for a sentence,
+     so an exception chip truncates to its glyph and first word rather than
+     pushing the tabs off the strip. The text is unchanged in the DOM, so the
+     polite announcement is byte-for-byte what it always was. */
+  .rail-strip .rail-state {
+    min-width: 0;
+  }
+
+  .rail-strip .chip {
+    display: inline-block;
+    max-width: 8ch;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 }
 


### PR DESCRIPTION
## What changed

The rail was a flat flex list of fourteen elements with `flex-wrap` on, so it broke wherever it ran out of room. It is now four zones, each a `.rail-cluster` closed by a hairline, wrapping only at the seams between them (plan option A).

| Zone | Holds | Renders null when |
|---|---|---|
| **IDENTITY** | the page `<h1>` brand lockup ("F1 RACE TRACKER · RACE BOARD"), the session label, the route note | never — it is on every route |
| **INSTRUMENTS** | session clock and leader lap, each a value over an 11px uppercase label, hairline-split | no `state` (overlay, Settings) |
| **CONDITIONS** | track/air temperature and rain | the session carries no weather |
| **STATE** | the connection chip and the board's transient FROZEN / CLIP-LOOPED region, in one reserved slot | no session and no transient chips |
| **CONTROLS** | the `LANE` segmented control and the Freeze transport verb | the route passes no controls (overlay, Settings, and the static demo keeps only Freeze) |
| **NAV / EXITS** | BOARD · OVERLAY, then F1TV Link and GitHub | never |

Conditions sits in the scroll-away half of the DOM so the phone strip can leave it behind; `order` puts it back beside the clock on desktop.

## Rail height, board route

| Width | Before | After |
|---|---|---|
| 1440 | 119px, 2 rows | **64px, 1 row** |
| 1280 | 119px, 2 rows | **64px, 1 row** |
| 1100 | 115px, 2 rows | 94px, 2 rows (wraps at the nav seam) |
| 1024 | 115px, 2 rows | 94px, 2 rows |
| 768 | 163px, 3 rows | 96px, 2 rows |
| 390 | 346px, 7 rows, no nav after you scroll | **48px sticky strip** (clock · lap · exception chip · tabs) + a ~110px block that scrolls away |

Overlay 62px, Settings 62px, both one row at 1440 with no stray seams.

## Control grammar (ui-ux M13 / M14 / m8)

One idiom per kind of control. A **persistent choice** is a segmented control — a `role="radiogroup"` of `.btn` segments with a visible uppercase scope word naming what it governs, extracted into `SegmentedControl.tsx` and adopted by `SourceToggle`. A **momentary verb** stays a plain button; Freeze now travels inside the control cluster with the lane pick instead of wrapping a thousand pixels away from it. The healthy-lane chip already stood down on the board (m8) and still renders on routes with no lane control.

M13 (Comms) and M14 (tower gap units) are *not* folded in here — the brief says nothing below the rail changes, and the plan phases them as a separate PR. The grammar they need is now a shared component ready to adopt.

## Accessibility properties preserved

- Skip link is still the first focusable element; `scroll-margin-top` added to `<main>` so the phone strip never covers what focus lands on.
- Exactly **one** polite live region per chip, inside `StatusBadge`; the reserved state slot is deliberately not a live region, so the board's FROZEN/loop region does not nest inside one. Asserted in tests.
- Roving tabindex and arrow keys on the segmented control, including the fallback that keeps the group reachable when the session key matches neither option.
- 44px coarse-pointer targets — and the two rail exits, at 32px, are finally raised with them (the last accessibility H-4 leftover).
- One visible `<h1>` per route, in the identity zone, still naming the route (L-2). One `aria-current` at a time; the nav gained `aria-label="Views"`.
- The exits' names stay in the accessibility tree when they collapse to glyphs at narrow widths (out of flow, not `display: none`).
- No motion added; the mobile strip is plain `position: sticky` with no hide-on-scroll.

## Verification

`npm test` 256 passed / 19 files (new tests for cluster order, the empty-zone null rendering, the radiogroup grammar, the roving tabindex, and the single-live-region contract) · `npm run lint` clean · `npx tsc -b --force` clean · `npm run build` and the `VITE_STATIC_DEMO=true` build both clean · `FILE-MAP.md` regenerated, `--check` passes.

Browser-verified headless against `npm run dev` on `/`, `/#ghost`, `/#settings` at 1440 / 1280 / 1100 / 1024 / 768 / 390 / 320: `scrollWidth - clientWidth === 0` everywhere, zero console errors, the strip stays pinned at `top: 0` after a 2000px scroll, and the lane control keyboard-walks correctly.

## Deviations from the plan

1. **One row down to 1280, not 1100.** The plan's ~64px target predated the labelled instruments and the `#82` brand-lockup h1; six zones with captions measure ~1200px at their tightest, so 1100 and 1024 take a second row — but only at a cluster seam, and the whole rail is still ~20px shorter than it was.
2. **The reserved state slot shrinks rather than reserving the widest chip.** The 8-second loop notice is ~340px; reserving that permanently costs more than the row it saves. The slot reserves 22ch and chips ellipsise past it, so the text — and therefore the announcement — is unchanged.
3. **DOM order puts the exits before the nav** (they share the scroll-away wrapper so the phone strip can re-flow the nav without duplicating it). Both are chrome navigation, so the meaning survives the order; everything else focuses in the plan's sequence.
4. **`viewport-fit=cover`** added to the viewport meta, without which the strip's safe-area insets resolve to 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
