### PR TITLE
fix(web): unify persistent toggles onto SegmentedControl grammar (M13/M14)

### DIFF
--- a/FILE-MAP.md
+++ b/FILE-MAP.md
@@ -222,6 +222,7 @@ Presentational components — map, timing tower, telemetry, comms, race control,
 
 | File | Purpose |
 | --- | --- |
+| `Comms.render.test.tsx` | Render tests for the Comms panel's radio on/off control. |
 | `Comms.tsx` | The team-radio layer: a now-playing banner over a short replayable history. |
 | `Ghost.render.test.tsx` | Render tests for the overlay: both comparison scenarios, per-side team colours, and the states where there is nothing to compare. |
 | `Ghost.tsx` | The overlay route: two reference laps animated against each other on one track map, across two seasons or two drivers in the same race. |
@@ -494,4 +495,4 @@ The golden snapshot pinning the wire contract between Go, Python and the fronten
 
 ---
 
-45 directories, 175 files listed, 0 without a declared purpose.
+45 directories, 176 files listed, 0 without a declared purpose.

--- a/web/src/components/Comms.render.test.tsx
+++ b/web/src/components/Comms.render.test.tsx
@@ -1,0 +1,26 @@
+// Render tests for the Comms panel's radio on/off control.
+
+import { describe, test, expect } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { Comms } from './Comms';
+import { emptyState } from '../state/race';
+
+describe('Comms radio control', () => {
+  test('the on/off toggle is a labelled radiogroup, not a self-swapping button (M13)', () => {
+    const html = renderToStaticMarkup(<Comms state={emptyState()} />);
+    expect(html).toContain('role="radiogroup"');
+    expect(html).toContain('aria-label="Team radio"');
+    expect(html).toContain('class="rail-scope"');
+    expect(html).toContain('Radio');
+    expect(html.match(/role="radio"/g)).toHaveLength(2);
+    expect(html).not.toContain('>Comms<');
+  });
+
+  test('defaults to the Off segment checked', () => {
+    const html = renderToStaticMarkup(<Comms state={emptyState()} />);
+    const offButton = html.slice(html.lastIndexOf('<button', html.indexOf('>Off<')));
+    const onButton = html.slice(html.lastIndexOf('<button', html.indexOf('>On<')));
+    expect(offButton.split('>')[0]).toContain('aria-checked="true"');
+    expect(onButton.split('>')[0]).toContain('aria-checked="false"');
+  });
+});

--- a/web/src/components/Comms.tsx
+++ b/web/src/components/Comms.tsx
@@ -4,6 +4,12 @@ import type { RaceState } from '../state/race';
 import { useComms } from '../hooks/useComms';
 import { teamColour } from './teamColours';
 import { fmtClock } from './timingHelpers';
+import { SegmentedControl } from './SegmentedControl';
+
+const RADIO_OPTIONS = [
+  { key: 'off', label: 'Off' },
+  { key: 'on', label: 'On' },
+] as const;
 
 // Comms is the toggleable team-radio layer: a now-playing banner + a short
 // replayable history. Audio streams from F1's public URL (ADR-0003).
@@ -19,19 +25,19 @@ export function Comms({ state }: { state: RaceState }) {
 
   return (
     <div style={{ display: 'grid', gap: 'var(--sp-2)' }}>
-      {/* "Comms ON"/"Comms OFF" was ambiguous about whether it described the
-          current state or the action the press would take. A stable noun plus
-          aria-pressed puts the state where assistive tech reads it, and leaves
-          .btn-active to carry it visually. */}
-      <button
-        type="button"
-        onClick={toggle}
-        aria-pressed={enabled}
-        className={enabled ? 'btn btn-active' : 'btn'}
-        style={{ justifySelf: 'start' }}
-      >
-        Comms
-      </button>
+      {/* "Comms ON"/"Comms OFF" was an ad-hoc toggle with no scope word — M13
+          found three different toggle idioms on one screen. This is a pick
+          between two persistent states, so it goes through the rail's one
+          control grammar: a labelled radiogroup, same as the lane switch. */}
+      <div style={{ justifySelf: 'start' }}>
+        <SegmentedControl
+          scope="Radio"
+          ariaLabel="Team radio"
+          options={RADIO_OPTIONS}
+          value={enabled ? 'on' : 'off'}
+          onPick={(key) => { if ((key === 'on') !== enabled) toggle(); }}
+        />
+      </div>
 
       {enabled && nowPlaying && (
         <div style={{

--- a/web/src/components/TimingTower.render.test.tsx
+++ b/web/src/components/TimingTower.render.test.tsx
@@ -194,6 +194,30 @@ describe('TimingTower phone card layout', () => {
   });
 });
 
+describe('TimingTower gap-units control', () => {
+  test('the gap toggle is a labelled radiogroup, not a self-swapping button (M13/M14)', () => {
+    const html = renderToStaticMarkup(
+      <TimingTower state={field()} selected={null} onSelect={() => {}} />,
+    );
+    expect(html).toContain('role="radiogroup"');
+    expect(html).toContain('aria-label="Gap units for lapped cars"');
+    expect(html).toContain('class="rail-scope"');
+    expect(html).toContain('Gaps');
+    expect(html.match(/role="radio"/g)).toHaveLength(2);
+    expect(html).not.toContain('Gaps in seconds');
+  });
+
+  test('defaults to the Laps segment checked, not Seconds', () => {
+    const html = renderToStaticMarkup(
+      <TimingTower state={field()} selected={null} onSelect={() => {}} />,
+    );
+    const lapsButton = html.slice(html.lastIndexOf('<button', html.indexOf('>Laps<')));
+    const secondsButton = html.slice(html.lastIndexOf('<button', html.indexOf('>Seconds<')));
+    expect(lapsButton.split('>')[0]).toContain('aria-checked="true"');
+    expect(secondsButton.split('>')[0]).toContain('aria-checked="false"');
+  });
+});
+
 describe('TimingTower absent data', () => {
   test('a car the feed says nothing about reads NO DATA, not six em-dashes', () => {
     const state = field([{ driverNum: 10, code: 'GAS', pos: 4 }]);

--- a/web/src/components/TimingTower.tsx
+++ b/web/src/components/TimingTower.tsx
@@ -11,6 +11,12 @@ import {
 } from './timingHelpers';
 import type { Bests, GapSmoothing } from './timingHelpers';
 import { teamColour } from './teamColours';
+import { SegmentedControl } from './SegmentedControl';
+
+const GAP_UNIT_OPTIONS = [
+  { key: 'laps', label: 'Laps' },
+  { key: 'seconds', label: 'Seconds' },
+] as const;
 
 // The header row, in order. A list rather than ten literals because the phone
 // layout reads the same names back out of each cell's data-label.
@@ -177,19 +183,20 @@ export function TimingTower({
 
   return (
     <div>
-    <button
-      type="button"
-      onClick={() => setSecondsMode((m) => !m)}
-      // A stable label plus aria-pressed, rather than a label that swaps between
-      // "Show seconds" and "Show laps": with a swapping label there is no state to
-      // report non-visually, and the button reads as an action whose current
-      // setting is invisible.
-      aria-pressed={secondsMode}
-      className={secondsMode ? 'btn btn-active' : 'btn'}
-      style={{ marginBottom: 'var(--sp-2)' }}
-    >
-      Gaps in seconds
-    </button>
+    {/* "Gaps in seconds" swapped its own label between "Show seconds" and "Show
+        laps" — M13 found this was one of three different toggle idioms on one
+        screen, and M14 found the label gave no scope: nineteen of twenty rows
+        don't change, so pressing it looked like it did nothing. A labelled
+        radiogroup names what it governs up front. */}
+    <div style={{ marginBottom: 'var(--sp-2)' }}>
+      <SegmentedControl
+        scope="Gaps"
+        ariaLabel="Gap units for lapped cars"
+        options={GAP_UNIT_OPTIONS}
+        value={secondsMode ? 'seconds' : 'laps'}
+        onPick={(key) => setSecondsMode(key === 'seconds')}
+      />
+    </div>
     <div
       className="tt-scroll"
       ref={scrollRef}


### PR DESCRIPTION
## Summary
- Replaces the Comms panel's self-swapping "Comms ON/OFF" button with a `SegmentedControl` (scope "Radio", Off/On), matching the labelled-radiogroup grammar `SourceToggle` established (reviews/ui-ux.md M13).
- Replaces the timing tower's "Gaps in seconds" button (which swapped its own label) with a `SegmentedControl` (scope "Gaps", Laps/Seconds) in the same position above the tower (M13/M14).
- Both controls now carry a visible scope word, roving tabindex, arrow-key navigation, and 44px coarse-pointer targets — all inherited for free from `SegmentedControl`.
- Adds `Comms.render.test.tsx` and extends `TimingTower.render.test.tsx` to assert the new markup (labelled radiogroup, correct `aria-checked` defaults) rather than the old button.

Note: M14's fuller recommendation (moving the control into a `Gap ⇅` column header, reformatting lapped gaps as `+10:43.6`, flashing affected cells) is a larger table-header redesign and out of scope here — this PR addresses the labelling/idiom problem (the toggle no longer looks like an action with no visible state) while keeping the control's existing placement above the tower.

## Test plan
- [x] `npm test` — 260 tests passed (20 files)
- [x] `npm run lint` — clean
- [x] `npx tsc -b --force` — clean
- [x] `npm run build` — succeeds, `dist/.gitkeep` restored by postbuild
- [x] `VITE_STATIC_DEMO=true npm run build` — succeeds, static demo build unaffected
- [x] `python scripts/gen_file_map.py --check` — FILE-MAP.md already current
- [x] Manual grep for hex colors / raw px spacing in changed files — none introduced (existing comment-only hex mentions unrelated to this diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)