### PR TITLE
fix(web): apply the validated UI/UX audit fixes (WCAG, status/feedback, discoverability)

### DIFF
--- a/FILE-MAP.md
+++ b/FILE-MAP.md
@@ -226,6 +226,7 @@ Presentational components — map, timing tower, telemetry, comms, race control,
 | --- | --- |
 | `Comms.render.test.tsx` | Render tests for the Comms panel's radio on/off control. |
 | `Comms.tsx` | The team-radio layer: a now-playing banner over a short replayable history. |
+| `CopyButton.tsx` | Shared "copy to clipboard" control: the success/failure live-region feedback pattern that used to live only in Settings.tsx's Cmd (ui-ux item 9b), now reused by the board's and overlay's "Copy link" buttons (ui-ux item 6) instead of a second copy of the same catch/live-region logic. |
 | `Ghost.render.test.tsx` | Render tests for the overlay: both comparison scenarios, per-side team colours, and the states where there is nothing to compare. |
 | `Ghost.tsx` | The overlay route: two reference laps animated against each other on one track map, across two seasons or two drivers in the same race. |
 | `Map.interaction.test.tsx` | Interaction coverage for the track map: the animation loop and the marker updates that static rendering never exercises. |
@@ -510,4 +511,4 @@ The golden snapshot pinning the wire contract between Go, Python and the fronten
 
 ---
 
-46 directories, 184 files listed, 0 without a declared purpose.
+46 directories, 185 files listed, 0 without a declared purpose.

--- a/reviews/fix-section-a.md
+++ b/reviews/fix-section-a.md
@@ -1,0 +1,48 @@
+# Section A (WCAG conformance) fixes
+
+Implements items 1, 5a, 5b, 13b from `reviews/uiux-validation.md`.
+
+## 1. Comms driver codes in raw team hex (1.4.3 AA)
+
+`web/src/components/Comms.tsx` — `colourFor` result is no longer used as the
+driver-code text colour (AlphaTauri measured 1.97:1 on `--asphalt`, 1.82:1 on
+`--carbon`, both under 4.5:1). Codes now render in `--chalk` with the team
+colour moved to a 3px `border-left` accent, matching the constructor-rule
+pattern already used in `TimingTower.tsx` / `components.css:724-728`. Applied
+to both the now-playing banner (`:47`) and the history rows (`:79`).
+`Comms.render.test.tsx` made no colour assertions, so it needed no changes.
+
+## 2. Sparkline aria-label omits the trend (1.1.1 A)
+
+`web/src/components/TelemetryPanel.tsx` — added a `trendSummary` helper that
+reduces the known series to a direction (rising/falling/flat), lap count, and
+min-max range, appended to the existing `"CODE lap/gap trend"` label. A
+screen-reader user now gets the same shape of information the bars convey
+visually, not just the final value that was already in adjacent text.
+
+## 3. Throttle/Brake bars lack `role="meter"` (WIG best practice)
+
+`TelemetryPanel.tsx` `Bar` component — the track div now carries
+`role="meter"`, `aria-valuenow`/`aria-valuemin={0}`/`aria-valuemax={100}`, and
+an `aria-label` combining the label and value (e.g. "Throttle 73%"), so
+label + bar + value read as one unit. No WCAG SC applies here (label/value are
+already real text), per the validation's correction — this is a best-practice
+improvement only.
+
+## 4. `.tt-select` under 24x24 at pointer:fine (2.5.8 AA)
+
+`web/src/styles/components.css` — `.tt-select` gains `min-width`/`min-height:
+24px` plus `margin-block: -3px` and `display: inline-flex` so the enlarged hit
+area is absorbed inward (same idea as the existing inward focus-ring
+technique) instead of growing the row height or column width. Comment cites
+2.5.8 Target Size (Minimum), AA, and that the row itself is not an accessible
+fallback target.
+
+## Verification
+
+- `npm test -- --run`: 23 files / 269 tests passed (pre-existing jsdom
+  `HTMLMediaElement.pause` "not implemented" warnings in `useComms` teardown
+  are unrelated console noise, not failures).
+- `npm run lint`: clean, no errors.
+
+No commits made per instructions.

--- a/reviews/fix-section-b.md
+++ b/reviews/fix-section-b.md
@@ -1,0 +1,64 @@
+# Section B (status & feedback) — implementation notes
+
+Branch: `uiux-audit-fixes`, built on top of Section A. Not committed.
+
+## 1. Item 3 — "● Live" overpromises
+`web/src/components/SourceToggle.tsx`: visible segment label changed to
+`● Live (demo)`. The fuller caveat string (rendered via `SegmentedControl`'s
+`title` + visually-hidden span) is unchanged. No test referenced the old
+`'● Live'` string, so no test updates were needed.
+
+## 2. Item 7 — Reconnect far from the failure
+`web/src/App.tsx`:
+- The map-overlay "⚠ Connection lost" chip (offline branch, ~line 295) now
+  includes a `Reconnect` button wired to the same `reconnect` callback already
+  passed to `StatusRail`.
+- `SkeletonMap` gained an `onReconnect` prop and its own `Reconnect` button for
+  the offline case (previously text-only: "Connection lost. Use Reconnect in
+  the status rail above to try again."). The rail-pointing copy is gone —
+  the fix is on the panel itself now (Nielsen #6 / Gestalt proximity).
+
+## 3. Item 8 — Race Control conflates "no incidents" with "not connected"
+`web/src/components/RaceControl.tsx`: added a `state.rev === 0` branch
+("⏳ Warming up the timing feed…", matching `StatusBadge`'s existing wording)
+ahead of the `messages.length === 0` check, so "No incidents." is only shown
+once a snapshot has actually arrived.
+
+## 4. Item 9b — Cmd copy button: silent failure, unannounced success
+`web/src/components/Settings.tsx` `Cmd`: added an `error` state set in the
+`catch` branch ("Copy failed — select the text and copy it manually."),
+rendered via the existing `.src-error` class (matching `SourceToggle`'s error
+styling) inside a `role="status" aria-live="polite"` region that also carries
+a visually-hidden "Copied" announcement for the success case. Added the
+item-9c comment on `children: string` explaining why that typing is
+load-bearing for the aria-label.
+
+## 5. Item 9a — Settings wall of prose for a linked operator
+`web/src/components/Settings.tsx`: factored the four-step `<ol>` + the
+check/forget-commands `<p>` into a `SigningInSteps` component. When
+`auth.state === 'linked'` it renders inside a native
+`<details><summary>Signing in (already linked)</summary>…</details>`;
+otherwise it renders inline under the existing `<h3>Signing in</h3>`, unchanged
+from before. The subscription warning, `NextStep`, and privacy/beta paragraphs
+were left exactly as they were (out of this fix's scope).
+
+## 6. Item 14a — CLIP LOOPED chip not dismissable
+`web/src/App.tsx`: added a small `✕` `.btn-icon` button
+(`aria-label="Dismiss clip looped notice"`) inside the loop chip that calls
+`setJustLooped(false)`, alongside the existing 8s `LOOP_NOTICE_MS` auto-clear.
+
+## 7. Item 14b — rival `<select>` disagrees with the collapsed rival card
+`web/src/components/TelemetryPanel.tsx`: the `<select>`'s `value` was already
+bound to the `rival` prop, and `App.tsx` already passes `effectiveRival` (not
+raw `rival` state) into that prop — so the select and the rival card were
+already reading the same collapsed value. Added a comment at the call site
+documenting that this is intentional (the select must reflect the *effective*
+rival, while `onRivalChange` still writes the raw, un-collapsed `rival` state
+in `App.tsx`), so a future edit doesn't accidentally wire the raw state back
+in believing it's more "correct".
+
+## Verification
+- `npm test -- --run`: 23 files, 269 tests, all passing. (Unrelated
+  `HTMLMediaElement.prototype.pause` "not implemented" jsdom warnings appear
+  during teardown of pre-existing Comms tests — cosmetic, not failures.)
+- `npm run lint`: clean, no errors or warnings.

--- a/reviews/fix-section-c.md
+++ b/reviews/fix-section-c.md
@@ -1,0 +1,80 @@
+# Section C (discoverability & consistency) — fixes applied
+
+Branch: `uiux-audit-fixes`. Builds on Sections A and B. Not committed.
+
+## 1. Ghost overlay undiscoverable from the board (item 2, Nielsen #6)
+
+Added a one-line link, `Compare laps in the overlay →`, to `TimingTower.tsx` as a
+new `tt-note` row after the tyre legend, using the existing `.demo-notice-link`
+text-link idiom and pointing at `#ghost` (the overlay's real route name).
+No coach marks, always visible, costs one row.
+
+- `web/src/components/TimingTower.tsx`
+
+## 2. Deep links have no UI (item 6, Nielsen #7)
+
+Extracted the copy-button + success/failure live-region pattern that used to be
+private to `Settings.tsx`'s `Cmd` into a new shared component, `CopyButton`
+(`web/src/components/CopyButton.tsx`). `Settings.tsx` now uses it internally
+(behaviour unchanged). Added:
+
+- **Board**: a "Copy link" button next to "Clear reference car" in
+  `TimingTower.tsx`'s reference-car hint — visible only when a car is selected,
+  copying `location.href` (already kept in sync with `?car=` by `App.tsx`'s
+  existing `replaceState` effect).
+- **Overlay**: a "Copy link" button in `Ghost.tsx`'s Controls panel, copying
+  `location.href` (kept in sync with `?a=`/`?b=` by the existing effect there).
+
+Both reuse the same catch/live-region feedback path, so failure is reported the
+same way everywhere instead of failing silently.
+
+- `web/src/components/CopyButton.tsx` (new)
+- `web/src/components/Settings.tsx`
+- `web/src/components/TimingTower.tsx`
+- `web/src/components/Ghost.tsx`
+
+## 3. Zone D separation between Lane and Freeze/Resume (item 10, Gestalt common region)
+
+CSS-only. Added a hairline + extra left padding on the bare `.btn` that follows
+the segmented-control wrapper inside `.rail-controls`, so the transport verb
+reads as a separate object from the abutted Lane segments instead of one
+five-part control. No JSX changes.
+
+- `web/src/styles/components.css` (`.rail-controls > .rail-segmented ~ .btn`)
+
+## 4. Rival `<select>` used `.btn` (transparent background) (item 11, Nielsen #4)
+
+Switched `TelemetryPanel.tsx`'s rival `<select>` from `className="btn"` to
+`className="overlay-select"` — the same idiom the overlay's pickers already use,
+with an explicit `background`/`color` instead of inheriting through
+transparency.
+
+- `web/src/components/TelemetryPanel.tsx`
+
+## 5. Tyre legend formatted differently in Tower vs StintChart (item 12, Nielsen #4 / 1.4.1 risk)
+
+Extracted the glyph-prefixed compound list (`S Soft`, `M Medium`, …) into one
+shared constant, `TYRE_LEGEND`, in `timingHelpers.ts`. Both `TimingTower.tsx`
+and `StintChart.tsx` now render their legend from it, so `StintChart`'s legend
+gained the leading glyph it previously lacked (the non-colour signal 1.4.1
+needs). Did not add the S/P session/personal-best note to `StintChart` — that
+mark comes from sector-best data the stint chart doesn't have, so it isn't a
+drift case, just a different signal that doesn't apply there.
+
+- `web/src/components/timingHelpers.ts`
+- `web/src/components/TimingTower.tsx`
+- `web/src/components/StintChart.tsx`
+
+## 6. `timingHelpers.ts` and `Intl` (item 14d)
+
+Added a one-line file-header comment noting broadcast timing is a fixed,
+locale-invariant wire format, so `Intl.*` is intentionally not used.
+
+- `web/src/components/timingHelpers.ts`
+
+## Verification
+
+- `npm test -- --run`: 269/269 passed (23 files). Pre-existing jsdom
+  `HTMLMediaElement.prototype.pause` warnings in `useComms` tests are unrelated
+  and unchanged by this work.
+- `npm run lint`: clean, no errors or warnings.

--- a/reviews/uiux-heuristics.md
+++ b/reviews/uiux-heuristics.md
@@ -1,0 +1,199 @@
+# UI/UX Heuristics Audit — F1 Race Tracker Frontend
+
+Scope: `web/src/` (App shell, components, hooks, state, routing, styles). Evaluated
+against Nielsen's 10 heuristics, Fitts's law, Hick's law, Jakob's law, Miller's law,
+the Doherty threshold, and progressive disclosure, with attention to mid-race
+glanceability, connection loss, stale/empty states, first run, overlay discoverability,
+and small viewports.
+
+**Context.** This codebase carries an unusually dense inline record of prior UX
+review passes (tagged `ui-ux M8/M13/M14`, `frontend-design item 6`, `agent 5`,
+`#22`, accessibility passes) that have already fixed a long list of textbook
+issues: ambiguous toggle labels, colour-only signalling, live-region spam,
+roving-tabindex tables, row order jumping under the pointer, empty panels that
+describe a setting instead of showing data, reduced-motion handling, and more.
+Findings below are what is left, not a first pass.
+
+---
+
+## High impact
+
+### H1 — Overlay/compare feature is undiscoverable from first load (Jakob's law / discoverability)
+`web/src/components/StatusRail.tsx:18-21` labels the second tab "OVERLAY / lap
+delta" — accurate but not the mental model most visitors arrive with ("compare
+two years", "ghost car"). ADR-0009 folded the old COMPARE tab into OVERLAY, but
+nothing on the **board** route hints that the overlay exists or what it shows;
+a first-time visitor who never scans the top-right tabs has no prompt to try
+it. There is no onboarding tooltip, coach-mark, or first-visit affordance
+anywhere in `App.tsx` or `StatusRail.tsx`. For a feature the product scope
+calls out as a headline (Phase 4, "ghost overlay") and a portfolio
+differentiator, its only entry point is a plain nav tab competing with BOARD,
+F1TV Link, and GitHub — four peers, no hierarchy (Hick's law: nothing biases
+the choice toward the thing worth trying).
+**Impact:** a recruiter/reviewer skimming the live board for 10 seconds may
+never see the feature the product doc treats as the star.
+
+### H2 — Live-lane semantics require reading fine print (Match between system and the real world / Recognition over recall)
+`web/src/components/StatusBadge.tsx:79-88` and `SourceToggle.tsx:9-14`: the
+"Live" lane is actually a second recorded clip, not live data. This is now
+disclosed honestly (Phase 5 fix, "Live (demo)" language), which is good —
+but the label users click is still `● Live` (`SourceToggle.tsx:11`) with the
+honest caveat living in `visually-hidden` text and a `title` attribute. A
+first-time user who clicks "Live" expecting the real broadcast gets no
+same-screen correction until the badge's parenthetical/tooltip is read. This
+is a match-to-real-world tension baked into the product's constraints (ADR
+around F1TV auth), but the control label itself (`● Live`) is the one place
+that still overpromises before the caveat is visible.
+**Impact:** sets an incorrect expectation at the exact moment of the highest-
+attention interaction (choosing the data source).
+
+### H3 — No visible way to discover deep-link / URL-driven features (Help & documentation, Discoverability)
+`web/src/routing.ts` supports rich deep-linking (`?car=VER`, `?a=slug:CODE`,
+`?b=slug:CODE` for the overlay) and `App.tsx:210-230` / `Ghost.tsx:152-163`
+keep the URL in sync via `replaceState`. This is a well-built capability with
+zero UI surface: there's no "copy link to this view" or "share this
+comparison" button anywhere in `TimingTower.tsx`, `Ghost.tsx`, or
+`StatusRail.tsx`. A shareable/bookmarkable state that can only be discovered
+by manually editing the URL bar violates recognition-over-recall for the
+overlay's most natural social use case (sharing a specific driver comparison).
+**Impact:** medium-high — the feature exists and works, but nobody will find it.
+
+---
+
+## Medium impact
+
+### M1 — Settings/F1TV link page is a wall of prose with no visual hierarchy for its one critical warning (Minimalist design / progressive disclosure)
+`web/src/components/Settings.tsx:196-271`: the `.prose` block runs a
+subscription-tier warning, a live status readout, a 4-step signup flow, three
+copy-able shell commands, a privacy note, and a beta-status disclaimer as one
+undifferentiated column. The single most important fact — "you need a paid F1
+TV subscription for this to do anything" — is bolded inline (`Settings.tsx:198`)
+but sits at the same visual weight as everything else below it once scrolled
+past. No collapsing/progressive disclosure of the "already linked" vs
+"not yet linked" paths (both render, differentiated only by which `NextStep`
+branch fires) means a returning, already-linked operator still scrolls past
+the full onboarding instructions.
+
+### M2 — Hick's law: SourceToggle and Freeze board controls are visually adjacent but semantically different classes of control
+`App.tsx:267-277`: the rail's Zone D packs `SourceToggle` (a persistent-state
+radiogroup: Replay | Live) directly beside a `Freeze/Resume` momentary-verb
+button. `SegmentedControl.tsx`'s own header comment explicitly calls out this
+exact distinction as something the codebase has previously gotten wrong and
+fixed ("a segmented control is a pick between states that persist... a plain
+.btn is a momentary verb"). The fix correctly gives them different visual
+treatments, but they still occupy one continuous row with no grouping
+divider — at a glance during a fast-moving race, the two controls read as one
+five-option choice (Replay / Live / Freeze) rather than two independent
+binary decisions, which is exactly the kind of grouping ambiguity Hick's law
+penalizes under time pressure.
+
+### M3 — Reconnect flow surfaces only in the rail's status chip, not near the frozen map (Visibility of system status / user control)
+`App.tsx:295-314` and `StatusBadge.tsx:35-45`: when the socket goes fully
+`offline`, the map itself shows a `⚠ Connection lost` overlay chip
+(`App.tsx:298-303`) but the actual **Reconnect button** lives only in the
+`StatusBadge` inside the rail (`StatusBadge.tsx:39-44`), which can be a
+different visual region of the screen (top of page) from where the user's
+attention is (the frozen map, mid-page) — especially once the layout wraps on
+narrower viewports. Fitts's law favors putting the recovery action where the
+failure is noticed; right now there are two separate visual signals for one
+failure state (map overlay text, rail button) with no link between them.
+
+### M4 — Mid-race glanceability: gap/interval "estimated, not official" caveat repeats as text on every render (minimalist design tension, but deliberate)
+`TimingTower.tsx:28` (`GAP_TITLE`) plus the persistent `tt-note` footer
+(`TimingTower.tsx:348-352`) both explain the same estimation caveat via a
+`title` tooltip AND a permanently-visible footnote. This is a reasonable
+trust/accuracy tradeoff, but for the primary glanceable view (Gap/Int columns
+read many times a second during a race) it adds a permanent block of
+secondary text under the tower that competes for space with the reference-car
+hint (`TimingTower.tsx:359-370`) and the tyre legend (`TimingTower.tsx:372-380`)
+— three stacked footnote rows below the primary data on every load, which for
+a screen whose value proposition is glanceability is a lot of always-on
+chrome relative to the standings.
+
+### M5 — StintChart color legend abbreviates compound names inconsistently with TimingTower's legend (Consistency and standards)
+`TimingTower.tsx:373-374` legend renders `'S Soft'`, `'M Medium'`, etc.
+(letter + word), while `StintChart.tsx:105-107` renders the compound's first
+letter capitalized plus the rest lowercased as a full word only (`Soft`,
+`Medium`, no leading single-letter glyph pairing). Two panels on the same
+board, both keying color to tyre compound, present the legend in two
+different formats — a small but real consistency break for a feature (tyre
+strategy) users are expected to correlate across panels.
+
+### M6 — No empty/loading state differentiation for "genuinely no incidents yet" vs "race-control feed hasn't connected" (Visibility of system status)
+`RaceControl.tsx:43`: `if (state.messages.length === 0) return <div
+className="empty">No incidents.</div>;` — this renders identically whether
+the session has produced zero flags/safety cars (a true, good-news empty
+state) or whether the snapshot simply hasn't arrived yet (`state.rev === 0`,
+same as the board's "warming up" case elsewhere). Every other panel on the
+board (Map, tower, telemetry) distinguishes "no data yet" from "confirmed
+nothing here," but RaceControl collapses both into one string.
+
+---
+
+## Low impact
+
+### L1 — GitHub link and Settings gear are both styled as "rail-repo" exits with the same visual weight as primary nav (Match to real world / Fitts's law)
+`StatusRail.tsx:126-149`: the F1TV Settings link and the external GitHub link
+share a class (`rail-repo`) and sit directly adjacent to the `rail-tabs` nav.
+Visually there are effectively four equally-weighted top-level destinations
+(Board, Overlay, Settings, GitHub) even though GitHub is "a way out of the
+app" per the code's own comment (`StatusRail.tsx:135-137`) — the comment
+acknowledges the intent but the visual treatment doesn't fully separate exit
+affordances from in-app navigation.
+
+### L2 — TelemetryPanel's "Compare with" rival picker has no persistence across selection changes (Consistency, minor)
+`TelemetryPanel.tsx:174-184`: switching the primary reference car
+(`selected`) in the timing tower does not carry the previously chosen rival
+forward or explain that it was cleared — `App.tsx:159` derives
+`effectiveRival` as `null` whenever `rival === selected`, silently dropping a
+chosen comparison the moment the primary changes to match it, with no
+transient confirmation of why the "Compare with" dropdown reset.
+
+### L3 — Loop-restart notice duration is fixed and non-dismissable (User control and freedom, minor)
+`App.tsx:29,82-86`: the `↻ CLIP LOOPED` chip is shown for a hardcoded 8
+seconds (`LOOP_NOTICE_MS`) with no way to dismiss it early; for a user who
+already understands the demo loops (a returning visitor), this is a small,
+repeated, un-skippable interruption in the state-chip zone every clip cycle.
+
+### L4 — Copy-command affordance on Settings has no visible focus/keyboard-only success signal beyond text swap (Accessibility/consistency, minor)
+`Settings.tsx:20-38`: `Cmd`'s copy button swaps its own label to "✓ copied"
+for 2 seconds but doesn't announce via a live region, unlike almost every
+other transient-state change in this codebase (Comms errors, F1TV chip
+changes, RaceControl messages all use `aria-live`). This is inconsistent with
+the app's otherwise very deliberate live-region discipline seen elsewhere
+(e.g. `Comms.tsx:116-118`, `Settings.tsx:180-189`).
+
+---
+
+## Notable strengths (brief)
+
+- **Doherty threshold / perceived performance:** `useSmoothedCars` interpolates
+  10 Hz frames to animation-frame rate so the map never looks laggy; snapshot-
+  on-connect (`App.tsx` + gateway docs) means new/reconnecting viewers see
+  state instantly rather than a blank board.
+- **Error prevention / recovery:** four distinct, worded skeleton/failure
+  states (`App.tsx:35-46`) instead of one generic spinner; decision matrix in
+  the product scope is faithfully implemented in code (`SkeletonMap`,
+  `StatusBadge`).
+- **Recognition over recall:** SegmentedControl's scope label pattern
+  (`SegmentedControl.tsx`) fixed a documented earlier failure (ambiguous
+  toggle labels) and is now consistently reused for Lane, Radio, and Gap
+  units — genuine cross-component consistency.
+- **Accessibility as a first-class heuristic driver:** roving tabindex,
+  colour-blind-safe hatching on sparklines (`TelemetryPanel.tsx:56-66`),
+  live-region discipline tuned to avoid over-announcing a 10 Hz feed
+  (`RaceControl.tsx`, `StatusBadge.tsx`), and reduced-motion handling in the
+  overlay (`Ghost.tsx:169-172`) are all handled with more care than is typical.
+- **Honesty over polish:** the "Live (demo)" caveat, the estimated-gap
+  disclosure, and the cross-season "approximate positions" note in the overlay
+  (`Ghost.tsx:314-320`) all choose to tell the user the truth about data
+  quality rather than hide it — a real trust-building pattern, even though H2
+  above notes the initial control label still slightly overpromises.
+
+---
+
+## Summary counts
+
+- High impact: 3
+- Medium impact: 6
+- Low impact: 4

--- a/reviews/uiux-ranked.md
+++ b/reviews/uiux-ranked.md
@@ -1,0 +1,111 @@
+<!-- Merged, ranked UI/UX fix list from the 2026-08-31 three-standard audit (WCAG 2.2 / Nielsen+laws-of-UX / Vercel Web Interface Guidelines). Source reports: uiux-wcag.md, uiux-heuristics.md, uiux-wig.md. -->
+# UI/UX fix list — ranked, most important first
+
+Merged from `uiux-wcag.md` (WCAG 2.2 AA), `uiux-heuristics.md` (Nielsen + laws of UX),
+and `uiux-wig.md` (Vercel Web Interface Guidelines). Duplicates across reports collapsed.
+
+> **Validated 2026-08-31** — every claim adversarially re-checked in `uiux-validation.md`,
+> which is authoritative where they disagree. Key outcomes:
+> - **Item 4 (map per-car alternatives) is REFUTED** — `Map.tsx` already has
+>   `role="img"` + `aria-label`, which is the proposed fix. Drop it.
+> - **Item 13's `.tt-select` bullet is a real WCAG 2.5.8 AA failure** (rows measured
+>   23px; the row fallback isn't an accessible control) — promote to ~rank 5.
+>   Its `.rail-repo-active`/24px-floor bullet is NOT a finding (24px conforms).
+> - **9c ([object Object] aria-label) is refuted** — the prop is typed `string`.
+> - Only items 1 (1.4.3), 5a (1.1.1), 13b (2.5.8) and 14e (1.4.10, pending live
+>   check) are genuine WCAG failures; items 2, 5b, 7, 9a, 10, 11 stand but under
+>   corrected principles (Nielsen/Gestalt/WIG, not the laws originally cited).
+> - Item 1 is worse than stated: Comms history rows sit on `--carbon` → 1.82:1.
+
+## 1. Comms panel paints driver codes in raw team hex — fails WCAG 1.4.3 contrast (BLOCKER)
+`web/src/components/Comms.tsx:22-24,47,79`. AlphaTauri `#2B4562` on `--asphalt` is
+1.98:1; Red Bull 4.02:1 — both under the 4.5:1 text floor. The Timing Tower already
+solved this exact problem (team colour as a border accent, text in `--chalk`); Comms
+regressed against the codebase's own standard. Fix: reuse the tower's pattern.
+
+## 2. The ghost overlay — the headline feature — is undiscoverable
+`StatusRail.tsx:18-21`. Its only entry point is a plain "OVERLAY" nav tab with no
+hierarchy, hint, or affordance on the board route. A 10-second visitor never finds
+the product's star feature (Jakob's law / Hick's law). Fix: a one-time hint or a
+visually weighted entry point from the board.
+
+## 3. The "● Live" toggle label overpromises
+`SourceToggle.tsx:9-14`, `StatusBadge.tsx:79-88`. The lane is a second recorded
+clip; the honest caveat lives only in visually-hidden text and a tooltip. The
+visible label at the moment of choice should say "Live (demo)" itself.
+
+## 4. Track map's 20 car markers have no per-car text alternative (WCAG 1.1.1, serious)
+`Map.tsx:24,60-66`. One static sentence names the whole SVG; a screen-reader user
+can never learn who is where. Pragmatic fix: `aria-hidden="true"` on the SVG, since
+the Timing Tower already conveys the same information as text.
+
+## 5. Telemetry readouts are visually rich but semantically empty (serious)
+- Sparklines expose only "VER lap time trend", not the trend itself —
+  `TelemetryPanel.tsx:46-49` (WCAG 1.1.1). Append values or a trend word to the label.
+- Throttle/Brake bars have no `role="meter"`/`aria-valuenow`; label, bar, and number
+  are three disconnected text pieces — `TelemetryPanel.tsx:13-26`.
+
+## 6. Deep links exist with zero UI surface
+`routing.ts`, `App.tsx:210-230`, `Ghost.tsx:152-163`. Rich shareable URLs
+(`?car=`, `?a=`, `?b=`) discoverable only by editing the URL bar. Add a
+"copy link to this view / comparison" button on the board and overlay.
+
+## 7. Reconnect action is far from where the failure is noticed
+`App.tsx:295-314`, `StatusBadge.tsx:35-45`. Offline shows a warning chip over the
+frozen map, but the Reconnect button lives only in the top rail (Fitts's law).
+Put a reconnect action in (or link from) the map overlay itself.
+
+## 8. Race Control can't tell "no incidents" from "not connected yet"
+`RaceControl.tsx:43`. `state.messages.length === 0` renders "No incidents." both
+before the snapshot arrives and when the session truly has none. Every other panel
+distinguishes these; gate on `state.rev === 0` like the board does.
+
+## 9. Settings page is a wall of prose with no progressive disclosure
+`Settings.tsx:196-271`. Subscription warning, status, 4-step flow, three commands,
+privacy and beta notes in one undifferentiated column; an already-linked operator
+still scrolls the full onboarding. Branch the layout on link status and elevate the
+paid-subscription warning. Related: the copy button gives no failure feedback and no
+live-region success announcement (`Settings.tsx:20-39`), and its
+`aria-label={`Copy: ${children}`}` breaks to "[object Object]" if a JSX child is
+ever passed (`Settings.tsx:34`).
+
+## 10. Zone D reads as one five-option control under time pressure
+`App.tsx:267-277`. SourceToggle (persistent choice) and Freeze/Resume (momentary
+verb) share one continuous row with no divider — Replay/Live/Freeze reads as one
+choice. Add a visual group separator.
+
+## 11. Rival-picker `<select>` has a transparent background
+`TelemetryPanel.tsx:177` uses `.btn` (`background: transparent`); the overlay's
+`.overlay-select` already does this right with explicit colours. One theme/browser
+change from a light popup on a dark row. Reuse `.overlay-select`.
+
+## 12. Tyre legend is formatted differently in Tower vs StintChart
+`TimingTower.tsx:373-374` ("S Soft") vs `StintChart.tsx:105-107` ("Soft"), each
+hand-rolled separately — consistency break plus drift risk for the colour-blindness
+mitigations. Extract one shared legend.
+
+## 13. Target-size and disabled-focus checks to verify live (WCAG 2.5.8 / focus loss)
+- `.tt-clear` / `.rail-repo-active` sit exactly at the 24px floor — verify computed
+  box (`components.css:1256,1536`).
+- `.tt-select` likely under 24px at pointer:fine; defensible via the row-level hit
+  target but worth an explicit code note (`components.css:760-778`).
+- Ghost scrubber: toggling `disabled` on a focused range input can silently drop
+  focus to `<body>` (`Ghost.tsx:353-372`).
+
+## 14. Minor polish
+- `↻ CLIP LOOPED` chip: fixed 8s, non-dismissable (`App.tsx:29,82-86`).
+- Rival selection silently cleared when primary changes to match, no feedback
+  (`App.tsx:159`).
+- Three stacked footnote rows under the tower compete with the standings on the
+  glanceability-first view (`TimingTower.tsx:348-380`).
+- `timingHelpers.ts` hand-formats times — deliberate (broadcast format), add a
+  one-line comment saying so to preempt Intl churn.
+- Live 400%-zoom / 320px reflow check never run (content-based `min-width` chains
+  could overflow) — WCAG 1.4.10.
+
+## What's already strong (all three auditors agreed)
+Measured-and-documented contrast tokens, reduced-motion wired into both JS animation
+loops, roving-tabindex radiogroups that survive 10 Hz re-sorting, colour never the
+sole signal (hatching, S/P glyphs, solid-vs-dashed rings), disciplined live regions
+tuned against announcement storms, tabular-nums globally, honest data-quality
+caveats, and `replaceState` URL-as-state that doesn't pollute history.

--- a/reviews/uiux-validation.md
+++ b/reviews/uiux-validation.md
@@ -1,0 +1,363 @@
+<!-- Adversarial validation of reviews/uiux-ranked.md. Every claim was checked against the cited source; contrast ratios recomputed from hex via WCAG relative-luminance math. -->
+# UI/UX fix list — adversarial validation
+
+Method: each claim's file:line evidence was reopened, the factual assertion re-derived
+from the code (contrast recomputed from the actual hex tokens, aria/role/CSS facts read
+directly), and the cited principle checked against the actual normative text of
+WCAG 2.2, Nielsen's ten heuristics, the named UX laws, and the Web Interface Guidelines.
+
+Summary: **6 CONFIRMED · 6 CONFIRMED-WITH-CORRECTION · 2 UNVERIFIABLE-STATICALLY · 1 REFUTED**
+(counted at ranked-item level; per-bullet verdicts inside items 5, 9, 13, 14 are given below).
+
+---
+
+## 1. Comms driver codes in raw team hex — **CONFIRMED**
+
+**Evidence** — exact. `Comms.tsx:22-24` (`colourFor` → `teamColour[...]`), `:45`
+(`background: 'var(--asphalt)'`), `:47` (now-playing code in `colourFor`), `:79`
+(history row code in `colourFor`). `teamColours.ts:4,7` give `Red Bull #3671C6`,
+`AlphaTauri #2B4562`. `tokens.css:6` `--asphalt: #0B0D10`.
+
+**Recomputed contrast** (sRGB relative luminance, WCAG 2.x formula):
+
+| pair | L(fg) | L(bg) | ratio | audit said |
+|---|---|---|---|---|
+| `#2B4562` on `#0B0D10` | 0.05648 | 0.003963 | **1.97:1** | 1.98 ✓ |
+| `#3671C6` on `#0B0D10` | 0.16671 | 0.003963 | **4.02:1** | 4.02 ✓ |
+
+Not large text: the banner is `--fs-md` = 13px (`tokens.css:150`) and the history row is
+`--fs-sm` = 12px (`components.css:967`), both far below the 18.66px-bold large-text
+threshold, so the 4.5:1 floor is the right one even at `fontWeight: 700`.
+
+**Worse than stated:** the *history* rows (`:79`) sit on the panel, `--carbon #14171C`
+(L = 0.008453), not on `--asphalt` — AlphaTauri there is **1.82:1** and Red Bull **3.71:1**.
+
+**Principle** — correct as cited: **WCAG 2.2 SC 1.4.3 Contrast (Minimum), Level AA**.
+Also **Nielsen #4 Consistency and standards** for the regression against
+`TimingTower`'s own colour-as-border-accent pattern (`components.css:724-728`).
+
+---
+
+## 2. Ghost overlay is undiscoverable — **CONFIRMED-WITH-CORRECTION**
+
+**Evidence** — `StatusRail.tsx:18-21` exists as cited. **Correction:** the tab is not
+"a plain OVERLAY nav tab with no hierarchy, hint, or affordance" — it carries a
+sub-label, `sub: 'lap delta'`, rendered at `StatusRail.tsx:197` as `.rail-tab-sub`. So it
+has information scent; what it lacks is *weight* relative to BOARD and any pointer from
+the board body. The claim survives in weakened form.
+
+**Principle — both cited laws are misapplied.**
+- **Jakob's law** (users expect your site to work like the ones they already know) is
+  *satisfied*, not broken: a labelled top-rail tab is exactly the convention.
+- **Hick's law** (decision time grows with the number of choices) does not apply to a
+  two-item nav; the problem is the opposite of too many choices.
+
+**Correct framing: no standard is broken.** The closest legitimate hook is
+**Nielsen #6 Recognition rather than recall** — the feature must be recognisable from
+the board rather than recalled from a tab name. Treat as a product/discoverability
+judgement call, not a violation.
+
+---
+
+## 3. "● Live" toggle label overpromises — **CONFIRMED**
+
+**Evidence** — `SourceToggle.tsx:9-14` exact: visible `label: '● Live'`, with the honest
+`caveat` string carried separately. `SegmentedControl.tsx:66` puts it in `title=`, `:71`
+puts it in a `.visually-hidden` span — so on the board the caveat reaches only hover and
+assistive tech, as claimed.
+
+**Stronger than stated:** `StatusBadge.tsx:79-88` renders the visible
+`● LIVE LANE · RECORDED CLIP` chip, but `StatusRail`/`App.tsx:263` pass
+`laneNamedElsewhere={!STATIC_DEMO}`, and `StatusBadge.tsx:73` returns `null` in the
+healthy case when that is true. **On the non-static board the visible honest chip is not
+rendered at all** — so the caveat is *only* in the tooltip and hidden text there.
+
+**Principle** — **no WCAG SC is broken**. Note 2.5.3 Label in Name (A) explicitly
+*passes*: the accessible name begins with the visible label. The correct citation is
+**Nielsen #1 Visibility of system status** (and #2 Match between the system and the real
+world — the label must not claim more than the system does).
+
+---
+
+## 4. Track map's 20 markers have no per-car text alternative — **REFUTED**
+
+**Evidence** — `Map.tsx:24` is exact, and it is what kills the claim:
+
+```
+<svg viewBox={...} className="track-svg" role="img" aria-label={anySelection ? '…' : 'Track map with live car positions'}>
+```
+
+`role="img"` makes the element a leaf in the accessibility tree — descendants are pruned
+— and `aria-label` supplies its text alternative. **This is already the "pragmatic fix"
+the audit proposes**: `aria-hidden="true"` and `role="img"` + label are near-identical in
+effect, except the existing code is *better* (it names the graphic instead of erasing it).
+
+WCAG 2.2 SC 1.1.1 Non-text Content (A) requires "a text alternative that serves the
+equivalent purpose", not one alternative per datum; for a complex graphic whose data is
+also available as text, a short label plus the equivalent text elsewhere satisfies it.
+That equivalent text exists — `TimingTower` renders every car's position, code and gap
+as a real table, and the audit's own item 4 concedes this.
+
+**Verdict: REFUTED. No standard broken.** The map's `aria-label` even conveys the
+selection state (`:19,24`), which is more than the proposed fix would.
+
+---
+
+## 5. Telemetry readouts semantically empty — **split**
+
+**5a. Sparklines expose only the label — CONFIRMED.**
+`TelemetryPanel.tsx:46-49` exact: `role="img" aria-label={label}`, label built at `:124`
+as `` `${car.code} lap time trend` `` / `:131` `` `${car.code} gap trend` ``. The trend
+itself (direction, spread, which laps were slower) reaches no assistive tech; the only
+adjacent text is the *latest* value (`:126`, `:134`), not the trend.
+**Principle correct: WCAG 2.2 SC 1.1.1 Non-text Content, Level A.** (Unlike item 4 there
+is no equivalent text elsewhere — the per-lap series exists nowhere else on the page.)
+
+**5b. Throttle/Brake bars lack `role="meter"` — CONFIRMED-WITH-CORRECTION.**
+`TelemetryPanel.tsx:13-26` exact: `.tele-label` span, an unlabelled div-in-div bar, and a
+`.tele-value` span, with no `role`, `aria-valuenow`, or programmatic association.
+**Correction to the principle: no WCAG SC is broken.** Label and value are both real
+visible text in a sensible DOM order, so 1.3.1 Info and Relationships (A) passes and
+4.1.2 Name, Role, Value (A) does not apply — the bar is a non-interactive graphic, and
+the value is not conveyed by the graphic alone. The correct citation is the
+**Web Interface Guidelines rule that a value indicator should expose `role="meter"`
+with `aria-valuenow`/`aria-valuemin`/`aria-valuemax`** — a best-practice improvement,
+not a conformance failure.
+
+---
+
+## 6. Deep links with zero UI surface — **CONFIRMED**
+
+**Evidence** — all three sites exact. `routing.ts` implements `?car=`, `?a=`, `?b=`
+(`:78-87`, `:98-107`); `App.tsx:210-230` writes the board's `?car=` back via
+`history.replaceState` (`:229`); `Ghost.tsx:152-163` does the same for `?a=`/`?b=`
+(`:162`). A repo-wide grep for `clipboard` / "copy link" / share affordances across
+`web/src/components/` and `App.tsx` returns **only** `Settings.tsx:24`
+(`navigator.clipboard.writeText` for shell commands) — there is no share control on the
+board or the overlay.
+
+**Principle** — **no standard broken; correctly framed as a missed opportunity.** The
+nearest legitimate heuristic is **Nielsen #7 Flexibility and efficiency of use**
+(accelerators for expert users, hidden from novices — here the accelerator is hidden from
+*everyone*). Not a WCAG issue.
+
+---
+
+## 7. Reconnect is far from where the failure is noticed — **CONFIRMED**
+
+**Evidence** — exact. `App.tsx:295-304` overlays `⚠ Connection lost` on the map with no
+action; `StatusBadge.tsx:35-45` is the only place the `Reconnect` button renders, in the
+rail. `App.tsx:41` even makes the separation explicit in the skeleton copy:
+`'Connection lost. Use Reconnect in the status rail above to try again.'` — a
+recall-the-other-control instruction. Confirmed.
+
+**Principle — Fitts's law is a stretch.** Fitts's law predicts *pointing time* as a
+function of distance and target size; it says the trip is slower, not that the user
+cannot find the control. The real defects are **Nielsen #6 Recognition rather than
+recall** (the fix is literally written as an instruction to go look elsewhere) and the
+**Gestalt law of proximity** (the notice and its remedy are not grouped). Cite those;
+keep Fitts's as a secondary, quantitative note. **No WCAG SC broken.**
+
+---
+
+## 8. Race Control can't tell "no incidents" from "not connected" — **CONFIRMED**
+
+**Evidence** — `RaceControl.tsx:43` exact, character for character:
+`if (state.messages.length === 0) return <div className="empty">No incidents.</div>;`
+The `state.rev === 0` discriminator the audit points to is real and used elsewhere:
+`App.tsx:244-245` (`showSkeleton = state.rev === 0 || trackless`) and
+`StatusBadge.tsx:53` (`⏳ Warming up the timing feed…`). So this panel genuinely asserts
+a fact about the session before any snapshot has arrived.
+
+**Principle** — **Nielsen #1 Visibility of system status**, correctly. No WCAG SC broken
+(the `role="log"` region at `:52` is well-formed).
+
+---
+
+## 9. Settings is a wall of prose — **CONFIRMED-WITH-CORRECTION** (one sub-claim REFUTED)
+
+**9a. Wall of prose / no progressive disclosure — CONFIRMED-WITH-CORRECTION.**
+`Settings.tsx:196-271` exact. **Correction:** the page is not wholly undifferentiated —
+`:205-207` renders a `NextStep` in a polite live region, and `:209-216` / `:218-224`
+already branch on `auth.state === 'linked'` and `noSubscription`. What is unconditional
+is the four-step `<h3>Signing in</h3><ol>` (`:226-249`), the three commands (`:239-253`),
+and the privacy/beta paragraphs (`:256-270`) — so a linked operator does still scroll the
+full onboarding. The audit's second recommendation is already satisfied: the paid-
+subscription warning is *already* the first paragraph and *already* in `<strong>` (`:198`).
+**Principle: no standard broken.** **Nielsen #8 Aesthetic and minimalist design** is the
+right heuristic. (Progressive disclosure is a technique, not a heuristic — do not cite it
+as one.)
+
+**9b. Copy button gives no failure feedback and no live-region success — CONFIRMED.**
+`Settings.tsx:22-30` exact: `catch { setCopied(false); }` swallows the failure silently,
+and the `✓ copied` label change at `:35` sits in no live region. **Principle:
+Nielsen #1 Visibility of system status** and **#9 Help users recognise, diagnose and
+recover from errors**. Note WCAG 4.1.3 Status Messages (AA) is *arguably* engaged for the
+success case, since the change is a status message not tied to a focus change — but the
+label change is on the button the user just activated, so this is weak; do not lead with it.
+
+**9c. `aria-label={`Copy: ${children}`}` breaks to "[object Object]" — REFUTED.**
+`Settings.tsx:20` types the prop as `{ children: string }`. TypeScript rejects a JSX
+child that is not a string at every call site (`:239`, `:241`, `:244` all pass string
+literals). The failure mode described cannot occur without first breaking the build.
+Latent only if someone widens the type to `ReactNode` — worth a comment, not a fix.
+
+---
+
+## 10. Zone D reads as one five-option control — **CONFIRMED-WITH-CORRECTION**
+
+**Evidence** — `App.tsx:267-277` exact. **Two corrections:**
+
+1. **The count is wrong.** Zone D holds three controls, not five: `▶ Replay`, `● Live`
+   (`SourceToggle.tsx:8-14`) and one `⏸ Freeze`/`▶ Resume` button (`App.tsx:274-276`).
+   Comms' `Off`/`On` pair lives in a board *panel* (`Comms.tsx:33-39`), not the rail.
+2. **"No divider" is wrong.** `SegmentedControl.tsx:52` renders a visible
+   `.rail-scope` label — the word **LANE** — before the segments, styled as an uppercase
+   letterspaced display-font tag (`components.css:212-220`), and the two segments *abut*
+   into one unit (`.rail-segments`, `components.css:224-237`: shared radii killed,
+   `margin-left: -1px`) while Freeze is a detached standalone `.btn` separated by
+   `.rail-controls`' gap. The grouping signal exists; it is subtle, not absent.
+
+**Principle** — the audit cites nothing explicit. The correct one is the
+**Gestalt law of common region / proximity** (the segmented pair is one region, the verb
+is another). Given the scope label and the abutted segments already encode this,
+**verdict: real but minor — a strengthening of an existing separator, not a missing one.**
+No WCAG SC broken; keep it below item 12 in priority.
+
+---
+
+## 11. Rival-picker `<select>` has a transparent background — **CONFIRMED-WITH-CORRECTION**
+
+**Evidence** — exact. `TelemetryPanel.tsx:177` is `className="btn"` on the `<select>`
+(element spans `:174-184`); `.btn` sets `background: transparent` (`components.css:527`).
+`.overlay-select` (`components.css:903-912`) does set `background: var(--asphalt)` and
+`color: var(--chalk)` explicitly. Two idioms for one job — confirmed.
+
+**Correction to the stated failure mode:** "one theme/browser change from a light popup
+on a dark row" overstates the risk. `tokens.css:4` sets `color-scheme: dark` at `:root`
+with the comment "Native form controls, scrollbars and select popups follow this. Without
+it Windows renders light chrome inside a dark page." The UA-rendered popup is already
+pinned dark; the transparent background inherits the dark page. The live defect is the
+**inconsistency**, not an imminent light-on-dark break.
+
+**Principle** — **Nielsen #4 Consistency and standards**. **No WCAG SC broken**
+(1.4.3 cannot be evaluated on a transparent background, and the effective rendering is
+the dark page). Priority should drop accordingly.
+
+---
+
+## 12. Tyre legend formatted differently in Tower vs StintChart — **CONFIRMED**
+
+**Evidence** — exact, both sites.
+`TimingTower.tsx:373-374` hard-codes glyph-prefixed labels:
+`[['SOFT', 'S Soft'], ['MEDIUM', 'M Medium'], …]`.
+`StintChart.tsx:105-107` derives them differently: `{t[0]}{t.slice(1).toLowerCase()}`
+→ `Soft`, `Medium`, `Hard`, `Intermediate`, `Wet` — **no compound glyph**.
+Same five compounds, same `TYRE_COLOUR` table, two independent renderings.
+
+**Additional finding the audit missed:** the tower's legend also carries
+`S = session best · P = personal best` (`TimingTower.tsx:380`) — the colour-blindness
+mitigation — and `StintChart` carries no equivalent. The drift risk is already realised,
+not merely prospective.
+
+**Principle** — **Nielsen #4 Consistency and standards**, correctly. No WCAG SC broken
+directly, but the diverging legends put **1.4.1 Use of Colour (A)** compliance at risk
+in `StintChart`, since the glyph is the non-colour signal.
+
+---
+
+## 13. Target size and disabled-focus — **split**
+
+**13a. `.tt-clear` / `.rail-repo-active` at the 24px floor — CONFIRMED-WITH-CORRECTION,
+and it is a PASS, not a finding.**
+- `.tt-clear` — cited line correct: `components.css:1248` opens the rule,
+  `min-height: 24px` is at **:1256** exactly as stated, and it is `display: inline-flex`
+  with the label "Clear reference car", so width is far over 24px.
+- **`.rail-repo-active` is wrong.** That rule is at `components.css:1544` and sets only
+  `color` / `text-decoration` / `text-underline-offset` — **it has no `min-height` at
+  all**. The 24px rule near the cited `:1536` is **`.cmd-copy`** (`:1534-1538`).
+- **Principle correction:** WCAG 2.2 SC 2.5.8 Target Size (Minimum), Level AA requires
+  targets to be **at least** 24×24 CSS px. Sitting *exactly* at 24px **conforms**. There
+  is nothing to verify and nothing to fix. `@media (pointer: coarse)` already lifts
+  `.btn`, `.btn-icon`, `.overlay-select`, `.tt-clear` to 44px (`:1122-1128`).
+  **Reclassify: not a finding.**
+
+**13b. `.tt-select` under 24px at `pointer: fine` — CONFIRMED, and the audit
+UNDER-states it.**
+`components.css:760-778` exact: `.tt-select` sets `padding: 0`, `border: 0`,
+`font: inherit` and no `min-height`, so its box is the 13px text's line box (~16–19px).
+The row-level fallback is real (`TimingTower.tsx:266-267` handles the click on `.tt-row`)
+but is **not an accessible control** — the `<tr>` has no `role`, no `tabIndex`, and is not
+in the accessibility tree as a target, so 2.5.8's *equivalent-control* exception does not
+apply to it. Nor does the *inline* exception (this is a table cell, not a target inside a
+sentence). The *spacing* exception fails too: the codebase's own comment at
+`components.css:1130` records "**Rows measured 23px** — one pixel under the floor", and
+adjacent rows' 24px spacing circles necessarily overlap in a stacked table.
+**Principle: WCAG 2.2 SC 2.5.8 Target Size (Minimum), Level AA — a live AA failure at
+`pointer: fine`, not "defensible … worth a code note".** Promote this bullet.
+
+**13c. Ghost scrubber loses focus when `disabled` is toggled — UNVERIFIABLE-STATICALLY.**
+`Ghost.tsx:353-372` exact: `disabled={!ready}` on the `<input type="range">` at `:364`
+and on the Play button at `:353`. The dangerous direction is `ready` going **true → false**
+while the scrubber holds focus, which requires a lane/driver change mid-session (the
+render-time reset at `:177-179`). Whether the browser then drops focus to `<body>`
+genuinely needs a live render to confirm.
+**Principle: no WCAG SC is cleanly broken** — 2.4.3 Focus Order (A) is a stretch, and
+3.2.1 On Focus does not cover focus *loss*. Cite the **Web Interface Guidelines rule that
+a focused element must not be disabled out from under the user** (the standard remedy is
+to move focus deliberately before disabling). Keep as a live-check item.
+
+---
+
+## 14. Minor polish — **mostly CONFIRMED, one correction**
+
+**14a. `↻ CLIP LOOPED` chip: fixed 8s, non-dismissable — CONFIRMED.**
+`App.tsx:29` `LOOP_NOTICE_MS = 8000`, `:82-86` the `setTimeout` that clears it, `:286`
+the chip itself. No dismiss control. **Principle: Nielsen #3 User control and freedom.**
+Note **WCAG 2.2.1 Timing Adjustable (A)** has an explicit exception for a *non-essential*
+transient notice under 20 seconds — this does **not** fail 2.2.1.
+
+**14b. Rival silently cleared when primary changes to match — CONFIRMED-WITH-CORRECTION.**
+`App.tsx:159` exact:
+`const effectiveRival = selected != null && rival !== selected ? rival : null;`
+**Correction: nothing is cleared.** The `rival` state is untouched; only the *derived*
+`effectiveRival` collapses to `null`, and it reappears the moment the primary moves off
+that car. The user-visible symptom (the rival card vanishes with no explanation, and the
+`<select>` at `TelemetryPanel.tsx:175` still shows the rival as chosen — a control
+disagreeing with the view) is real and arguably worse than "cleared".
+**Principle: Nielsen #1 Visibility of system status.**
+
+**14c. Three stacked footnote rows under the tower — CONFIRMED.**
+Exactly three consecutive `div.empty.tt-note` blocks at `TimingTower.tsx:348`, `:359`,
+`:372`. **Principle: Nielsen #8 Aesthetic and minimalist design.** No SC broken.
+
+**14d. `timingHelpers.ts` hand-formats times — CONFIRMED.**
+`fmtLap:7-12`, `fmtElapsed:18-25`, `fmtSec:29-31`, `fmtGap:35-37`,
+`fmtGapEstimate:49-53`, `fmtLongGap:59-64`, `fmtClock:68-73`, `fmtSigned:310-312` all use
+`padStart`/`toFixed`; no `Intl` anywhere in the file. **No standard broken — this is a
+documentation nicety.** Broadcast timing format is genuinely locale-invariant, so `Intl`
+would be the wrong tool; a one-line comment is the right fix.
+
+**14e. 400% zoom / 320px reflow never checked — UNVERIFIABLE-STATICALLY, correctly flagged.**
+**WCAG 2.2 SC 1.4.10 Reflow, Level AA** is the right citation. Static reading is
+reassuring but not conclusive: `Sparkline` sets `minWidth: MAX_SPARK_BARS * BAR_W` = 120px
+(`TelemetryPanel.tsx:48`), the Ghost scrubber sets `minWidth: 160` (`Ghost.tsx:370`), and
+`.tt-table` uses `white-space: nowrap` on every cell (`components.css:664`) — three
+content-based floors that could chain. Against that, the tower drops columns via
+`@container tt` queries at 771/700/635px (`components.css:686-700`). Needs a live check.
+
+---
+
+## Cross-cutting note on principle citation
+
+Six of the fourteen items cite a principle that does not survive inspection: items 2
+(Jakob's/Hick's), 5b (1.1.1 → WIG best practice), 7 (Fitts's), 9a ("progressive
+disclosure" is not a heuristic), 11 (implied 1.4.3), and 13a (2.5.8 read as a ceiling
+rather than a floor). Only items **1 (1.4.3 AA)**, **5a (1.1.1 A)**, **13b (2.5.8 AA)**
+and **14e (1.4.10 AA, pending)** are genuine WCAG conformance failures. The rest are
+Nielsen/Gestalt/WIG improvements or style preferences, and the ranked list should say so
+rather than borrowing WCAG's authority for them.
+
+The "what's already strong" section checks out: the contrast comments in `tokens.css`
+were spot-checked against recomputed ratios (`--slate` on `--carbon`, `--dim`, the tyre
+compounds) and the documented figures are accurate.

--- a/reviews/uiux-wcag.md
+++ b/reviews/uiux-wcag.md
@@ -1,0 +1,204 @@
+# WCAG 2.2 AA accessibility audit — F1 Race Tracker web frontend
+
+Scope: `web/src/**/*.tsx`, `web/src/**/*.ts`, `web/src/styles/*.css`. Method: static
+read-through of every dashboard component, hook, and the global stylesheet;
+contrast ratios computed by hand from token hex values using WCAG relative-
+luminance math (not measured in a live browser — flagged where that matters).
+
+Counts: **1 blocker, 3 serious, 6 moderate, 5 minor.**
+
+---
+
+## Blocker (fails AA)
+
+### B1 — Team-colour driver code text fails 1.4.3 Contrast (Minimum) in Comms
+`web/src/components/Comms.tsx:22-24,47,79` (`colourFor`) paints the driver code
+directly in the raw constructor hex (`teamColour[...]`) on `var(--asphalt)` /
+`var(--carbon)`. This is the exact anti-pattern `tokens.css:254-262` (team-key
+comment) and `TimingTower.tsx:254-262` explicitly avoid — the tower deliberately
+moved the team colour to a 3px border rule on the Pos cell *because* several
+constructor hexes miss the text-contrast floor, and Comms re-adopts the failing
+pattern for its "CODE radio" line and history rows.
+
+Computed contrast against `--asphalt` (#0B0D10):
+- AlphaTauri `#2B4562` → **1.98:1** (fails both 4.5:1 and 3:1)
+- Red Bull `#3671C6` → **4.02:1** (fails 4.5:1, the applicable floor for text)
+- Aston Martin `#229971`, Alfa Romeo `#C92D4B` are also worth re-checking; several
+  sit close to the 4.5:1 line the same way Haas/AlphaTauri did on the tower.
+
+Fix: reuse the tower's pattern — keep the code in `--chalk`, carry the team
+colour as a border/dot accent instead of the text fill.
+
+---
+
+## Serious
+
+### S1 — Sparkline SVGs have no accessible data, only a label (1.1.1 / 4.1.2, borderline)
+`TelemetryPanel.tsx:46-49` gives the `<svg role="img" aria-label="...lap time
+trend">` a name, but the actual per-lap values (the substance of the chart) are
+never exposed to assistive tech — a screen-reader user gets "VER lap time
+trend" and nothing else, whereas a sighted user reads relative bar heights.
+Same for `StintChart.tsx:54-55` (per-stint `role="img"` bars do carry compound
++ lap range text, which is good) but `TelemetryPanel`'s sparkline gives no
+equivalent for the shape of the trend (getting faster/slower over the window).
+Minimum fix: append the underlying values or an explicit trend word ("improving
+over last 4 laps") to the `aria-label`, matching what `StintChart` already does
+right.
+
+### S2 — Track map SVGs have no per-car text alternative (1.1.1)
+`Map.tsx:24` labels the whole map `"Track map with live car positions"` (or
+"...; the reference car is ringed") but the 20 car markers inside carry no
+accessible names of their own — a screen-reader user gets one static sentence
+for a moving field of 20 cars and can never learn who is where. The `<text>`
+driver-code labels (`Map.tsx:60-66`) are real SVG text nodes, which is better
+than nothing, but they're unlabelled/unstructured (no `role="img"`/group name
+per car, and hidden entirely under ~330px per the CSS comment at line 56-58) so
+they don't reliably substitute for the missing structure. Given the map is
+decorative-plus-informational (position is also fully available from the
+Timing Tower), the pragmatic fix is `aria-hidden="true"` on the `<svg>` (make it
+purely decorative, since the Tower already gives the same info as text) rather
+than trying to build a live per-car text table inside SVG.
+
+### S3 — Ghost overlay's `<input type="range">` has an unlabelled default value announcement gap combined with autoplay motion (2.2.2 / 2.3.3 partially mitigated, but see detail)
+`Ghost.tsx:171-172,353-372`: reduced-motion is handled well — `paused` seeds to
+`true` when `useReducedMotion()` is true, and the scrubber remains usable
+(genuinely good coverage, better than most audits find). However `OverlayLive`
+computes `loopMs` and the animation drives `tMs` via `requestAnimationFrame`
+with no user-facing global "stop" once the user has pressed Play again after
+a reduced-motion default — there is a Play/Pause button, so 2.2.2 (Pause, Stop,
+Hide) is technically satisfied, but note it as fragile: confirm in a live
+render that focus/labelling of the range persists correctly when `disabled`
+toggles (`!ready`), since disabling a focused native `<input>` can silently
+drop focus to `<body>` with no announcement.
+
+---
+
+## Moderate
+
+### M1 — `useReducedMotion` covers both JS-driven loops but CSS entrance-stagger scope not fully verified
+`hooks/useReducedMotion.ts` is correctly wired into `useSmoothedCars.ts:48,64`
+(map interpolation) and `Ghost.tsx:171-172` (overlay playback) — this is the
+"two places motion is driven from JS" the file's own comment promises, and both
+are in fact covered. `styles/components.css:994` gates the page-intro stagger
+under `@media (prefers-reduced-motion: no-preference)`, which is the correct
+polarity. No violation found here, but flagging for a manual check: the
+`.chip-loop`/`.chip-stall` chips and any `transition`/`animation` rules outside
+that guarded block (there may be hover-transition rules elsewhere in the
+1766-line stylesheet not fully enumerated by this pass) should be spot-checked
+for un-gated `transition` on repeatedly-updating elements (the tower re-renders
+~10 Hz).
+
+### M2 — Timing Tower row/segment control target size at pointer:fine (2.5.8, AA)
+`components.css:760-778` (`.tt-select`) has no explicit min-height/width at the
+default (mouse) breakpoint — it inherits from `<b>{code}</b>` content plus the
+`<td>` padding (`--sp-1` = 4px, `components.css:663`), likely rendering well
+under the 24×24 CSS px target-size minimum for a fine pointer. The `@media
+(pointer: coarse)` block (`components.css:1122-1163`) correctly raises touch
+targets to 44px, but 2.5.8's 24px floor also nominally applies at mouse
+resolution. Likely defensible under the 2.5.8 "essential"/spacing exception
+(the whole `<tr>` is also clickable, `TimingTower.tsx:266-269`, so the
+functional hit target is larger than the visible button) — worth an explicit
+note in code rather than leaving it implicit.
+
+### M3 — `.tt-clear` and `.rail-repo-active` sit exactly at the 24px floor
+`components.css:1256` (`.tt-clear`, `min-height: 24px`) and `:1536`
+(`.rail-repo-active`, `min-height: 24px`) meet 2.5.8's minimum only if their
+CSS box, not just line-height, is actually 24px including padding — verify
+computed box size in a live render; a few px of border/margin subtracted from
+a nominal 24px value is a common way this silently fails.
+
+### M4 — Race Control `role="log"` politeness is right, but `aria-relevant="additions"` combined with a sliding 8-item window could re-announce removed/reordered content unpredictably
+`RaceControl.tsx:52`: `MAX_SHOWN = 8` means old messages silently drop off the
+rendered list every time a 9th arrives. `aria-relevant="additions"` is the
+correct choice to avoid announcing removals, and the WeakMap-keyed stable
+identity (`idOf`, lines 16-25) is a genuinely good fix for the "re-announces
+the whole backlog" bug it documents having fixed. No violation, but note this
+list is unbounded upstream (`state.messages`) and only windowed in the render —
+confirm `state.messages` itself doesn't grow forever in a very long session
+(perf, not a11y, but noting since it's adjacent).
+
+### M5 — StatusBadge's live region wraps *only* the badge, not sibling FROZEN/CLIP-LOOPED chips consistently
+`StatusBadge.tsx:97-108` documents (correctly) that the region must live with
+the chip because "the region has to be in the DOM before the text changes for
+the change to be announced." `StatusRail.tsx:166-184` then separately notes the
+reserved `.rail-state` slot is "deliberately NOT a live region itself" to avoid
+double-announcing, and `App.tsx:282-289` supplies its own `role="status"
+aria-live="polite"` wrapper around FROZEN/CLIP-LOOPED. This is *correct*, but
+fragile: any future call site that renders `stateChips` without its own live
+region (StatusRail's prop is optional, untyped as requiring one) will silently
+lose the announcement with no compile-time or lint signal. Worth a comment or
+a runtime dev-mode warning.
+
+### M6 — Settings/link-copy `<button>` announces "Copy: {children}" where `children` may include markup-derived text that reads oddly
+`Settings.tsx:34`: `aria-label={\`Copy: ${children}\`}` — if `children` is not
+a plain string (e.g. contains a `<code>` wrapped command with nested spans),
+`${children}` string-interpolates a React element into `"[object Object]"`
+rather than its text content. Verify the call sites only ever pass a string
+child; if any pass JSX, the accessible name silently breaks.
+
+---
+
+## Minor
+
+### m1 — `--dim` (#7C8590) is documented as retuned to 4.8:1/5.2:1 but only checked against `--carbon`/`--asphalt`; DRS-inactive readout in TelemetryPanel also sits on those, consistent — no issue found, noting as verified-good rather than a defect (positive finding, listed here for completeness of the pass).
+
+### m2 — Zoom-to-400%/reflow (1.4.10) not verified live
+The grid layouts (`board-top`, `board-bottom` in `components.css:827-838`) and
+the cascade of `@media` breakpoints (1360/1220/1100/700/500px) strongly suggest
+reflow was designed for, but this was a static read — a live check at 400%
+zoom / 320px CSS width (per 1.4.10) is recommended before signing off, since
+several `min-width` values (`22ch`, `9ch`, `4ch`, etc.) are content-based rather
+than viewport-based and could combine to exceed 320px on certain locales/longer
+driver codes or category labels.
+
+### m3 — Sector-best superscript legend duplicated across two panels with copy drift risk
+`TimingTower.tsx:372-381` and `StintChart.tsx:101-108` each hand-roll the tyre
+legend independently (not shared via `teamColours.ts`-style single source).
+Not a WCAG violation, but a consistency risk: if compound colours are retuned
+in one place and not the other, the AAA-adjacent "don't rely on colour alone"
+mitigations (hatch pattern, S/P legend text) could drift out of sync between
+panels.
+
+### m4 — `RaceControl.tsx:68` driver-tag `<span style={{ color: 'var(--slate)' }}>` — `--slate` (5.8:1 documented) is fine for text, no issue; flagged only because it's supplementary parenthetical text and not load-bearing — included for completeness, not a defect.
+
+### m5 — `Comms.tsx:116-118`'s error region is `role="status" aria-live="polite"` but always rendered as an empty wrapper (`{error && ...}`) — correct pattern (matches `StatusBadge`'s own always-mounted-region rule) but note the *inner* conditional means an error that fires twice in a row with identical text may not re-announce in some screen readers (a known live-region quirk with identical successive text nodes). Low likelihood given errors here are rare and distinct causes.
+
+---
+
+## What's already done well
+
+- **Sector-mark colour-blindness mitigation**: `TimingTower.tsx:315-338` and
+  `TelemetryPanel.tsx`'s sparkline hatch (`SparkHatch`, lines 55-66, 74-86) both
+  pair colour with a shape/pattern or text glyph (S/P superscript, diagonal
+  hatch) — genuinely satisfies 1.4.1 Use of Color, and the code comments show
+  this was a deliberate, tracked fix.
+- **`SegmentedControl.tsx`** is a well-built roving-tabindex radiogroup:
+  correct `role="radiogroup"`/`role="radio"`/`aria-checked`, arrow-key
+  navigation, visible scope label plus `aria-label`, and honest caveat text
+  exposed via `visually-hidden` rather than title-only.
+- **Focus visibility**: global `:focus-visible { outline: 2px solid
+  var(--chalk); outline-offset: 2px }` (`tokens.css:175-178`) plus a tower-
+  specific inward ring (`TimingTower`/`components.css:774-778`) that accounts
+  for `overflow: hidden` clipping outward rings — shows real attention to 2.4.7.
+- **Contrast engineering discipline**: `tokens.css`'s inline comments show
+  measured ratios for nearly every semantic colour (`--dim` 4.8:1, `--good`
+  6.7:1, `--bad` 5.2:1, tyre compounds all re-verified against the 4.5:1 text
+  floor rather than the weaker 3:1 non-text floor) — this is unusually rigorous
+  for a project this size, and is exactly why the one miss (Comms' raw team
+  colour, B1) stands out as a regression against the codebase's own standard.
+- **Reduced motion**: both JS-driven animation loops (map interpolation, ghost
+  overlay playback) correctly subscribe to `useReducedMotion` and degrade to a
+  fully-usable, still-interactive state rather than just turning motion off.
+- **Live region hygiene**: `RaceControl`'s WeakMap-keyed stable identity to
+  avoid re-announcing history, and the explicit `aria-hidden` on the ticking
+  "Xs ago" stall counter (`StatusBadge.tsx:56-70`) to avoid live-region spam,
+  both show a correct, non-naive understanding of `aria-live="polite"`
+  behaviour that a lot of teams get wrong.
+- **Keyboard operability**: Timing Tower rows use one shared roving tab stop
+  keyed by driver number (survives re-sorts at 10 Hz), Esc clears the reference
+  car globally (`App.tsx:92-102`, correctly skipped while focus is in a form
+  control), and the horizontally-scrollable tower region is made focusable
+  only when actually overflowing (avoids a dead, empty tab stop).
+- **Audio control (1.4.2)**: team radio never autoplays until a user gesture
+  toggles Comms on, and the same toggle immediately pauses/clears any playing
+  clip — a real, always-available stop mechanism independent of system volume.

--- a/reviews/uiux-wig.md
+++ b/reviews/uiux-wig.md
@@ -1,0 +1,50 @@
+# Web Interface Guidelines Audit — F1 Race Tracker frontend
+
+Scope: every `web/src/**/*.tsx` component (excluding `*.test.tsx`), every `web/src/styles/**/*.css` file, and `web/index.html`. Read in full: `App.tsx`, `ErrorBoundary.tsx`, `main.tsx`, and all of `components/*.tsx` (Map, TimingTower, TelemetryPanel, StintChart, Comms, RaceControl, Ghost, StatusRail, StatusBadge, SegmentedControl, SourceToggle, Settings, Panel, Route, StaticDemoNotice, TrackPath), plus `components/timingHelpers.ts`, `hooks/useReducedMotion.ts`, and `hooks/useSmoothedCars.ts` for the animation/formatting logic they back. `web/index.html`, `styles/tokens.css` and `styles/components.css` (1766 lines) were read in full/by targeted section.
+
+**Overall**: this is an unusually accessibility- and interface-guideline-conscious codebase — most items on the checklist are already handled, and many inline comments show the team explicitly reasoning through WCAG/interface-guideline tradeoffs (roving tabindex, `prefers-reduced-motion`, contrast ratios computed by relative luminance, etc.). Findings below are the residual gaps, not a wholesale critique.
+
+---
+
+## High severity
+
+None found. No icon-only buttons lack `aria-label`, no `<div onClick>` standing in for a button/link, no unlabelled form controls, no `outline: none` without a focus-visible replacement, no `transition: all`, no blocked paste, no zoom-disabling viewport meta, and no unvirtualized large lists (the ~20-row driver field is explicitly exempted, see Notes below).
+
+---
+
+## Medium severity
+
+1. **Native `<select>` in the rival picker has no explicit `background-color`** — `web/src/components/TelemetryPanel.tsx:177` (`className="btn"`) resolves to `.btn` in `web/src/styles/components.css:521-536`, which sets `background: transparent`. The Ghost overlay's own pickers use `.overlay-select` (`components.css:903-912`), which sets an explicit `background: var(--asphalt); color: var(--chalk);` — the pattern the Windows-dark-mode guideline calls for. The rival `<select>` relies on `:root`'s `color-scheme: dark` (tokens.css:4) plus a transparent background, so on Windows/Chromium the closed control paints correctly, but this is inconsistent with the other `<select>` in the app and is one theme/browser change away from a light popup on a dark row. Reuse `.overlay-select` (or give `.btn` an explicit background) for `TelemetryPanel`'s select.
+
+2. **Progress-style `<Bar>` readouts (Throttle/Brake) carry no ARIA role or value** — `web/src/components/TelemetryPanel.tsx:13-26`. The numeric value is exposed as adjacent text (`<span className="tele-value">{value}</span>`), so it is not undiscoverable, but a screen-reader user gets three disconnected pieces of text (`Throttle`, a decorative div, `73`) instead of one readable "Throttle 73%" unit. Adding `role="meter"`/`aria-valuenow`/`aria-valuemin`/`aria-valuemax` (or grouping label+bar+value under one `aria-label`) would make this an actual accessible readout rather than an incidental one.
+
+3. **Hardcoded time/number formatting instead of `Intl.*`** — `web/src/components/timingHelpers.ts` (`fmtLap`, `fmtSec`, `fmtGap`, `fmtGapEstimate`, `fmtClock`, `fmtSigned`, `fmtLongGap`, all ~lines 7-105) hand-format every time value with manual `padStart`/division rather than `Intl.NumberFormat`/`Intl.DurationFormat`. This is very likely deliberate — motorsport timing has one universal broadcast format (`m:ss.SSS`) that is not meant to localize — but it is a literal violation of the "use `Intl.*`, not hardcoded formats" rule as written, and worth a one-line note in the file if the maintainers want to preempt future churn. Not flagging the tyre/gap labels (`+N LAPS`, `LEADER`) since those are domain vocabulary, not locale-sensitive numbers.
+
+---
+
+## Low severity
+
+4. **`StintChart` stint segments rely on `title` for the compound/lap-range detail, duplicated into `aria-label`** — `web/src/components/StintChart.tsx:51-56`. This is already correctly mirrored into `aria-label` for assistive tech, so it's compliant; flagging only that the `title` half is still mouse/hover-only for sighted users (no on-screen text equivalent for a sighted keyboard/touch user who can't hover a 10px-tall bar). Given the segment's color plus the shared legend below it, this is a minor/optional enhancement, not a defect.
+
+5. **`RaceControl`'s "(CODE)" driver tag and wall-clock suffix are inline `<span>` with only color for the category label** — `web/src/components/RaceControl.tsx:62-64`. `cat.colour` (amber/good/chalk/slate) is the only visual distinguisher between category kinds (FLAG vs DRS vs CAR vs NOTE) since the `cat.label` text itself already differs, so this is not a color-only-conveys-meaning violation — noting it only because it sits close to the line and is worth a glance if a future category label collision is introduced (e.g. two categories both rendering "NOTE").
+
+6. **`Settings.tsx`'s `Cmd` copy-to-clipboard control gives no `aria-live` failure feedback** — `web/src/components/Settings.tsx:20-39`. Success is announced by the button's own label changing to "✓ copied" (readable on focus/re-query, fine), but a `catch` block that fails (e.g. clipboard permission denied in an insecure context) silently resets `copied` to `false` with no error surfaced to the user at all, sighted or otherwise. A one-line inline error (mirroring the `Comms`/`SourceToggle` `role="status"` pattern already used elsewhere in this codebase, e.g. `Comms.tsx:116-118`) would close the gap.
+
+7. **`Ghost.tsx`'s scrub `<input type="range">` has no visible tick marks or step labels beyond the numeric `aria-valuetext`** — `web/src/components/Ghost.tsx:358-371`. Functionally fine (labelled, keyboard-operable, `aria-valuetext` correctly overrides the raw ms value), just noting there's no way to jump to a specific sector/point without dragging — a nice-to-have, not a defect.
+
+8. **No `<link rel="preconnect">` for the WebSocket/gateway origin** — `web/index.html`. The socket connection (`realtime/socket.ts`) and static-replay clip fetch are same-origin/relative in the deployed setups reviewed, so this is unlikely to matter in practice, but if the gateway ever moves to a distinct origin, a `preconnect` hint would shave connection setup time off the first frame.
+
+---
+
+## Compliant / notable good patterns
+
+- **`prefers-reduced-motion` is genuinely wired through, not just declared.** `hooks/useReducedMotion.ts` uses `useSyncExternalStore` against a live media-query subscription (not a one-time read), and both places motion is driven from JS — `useSmoothedCars.ts` (map marker interpolation) and `Ghost.tsx`'s rAF playback loop — check it and fall back to static/scrub-only rendering. CSS-driven entrance animation is separately gated behind `@media (prefers-reduced-motion: no-preference)` (`components.css:994`).
+- **Roving-tabindex radiogroups done correctly** in `SegmentedControl.tsx` and the 20-row `TimingTower` (`components/TimingTower.tsx:154-182`): one tab stop, Arrow/Home/End move focus, and the focused driver is tracked by driver number (not row index) so it survives the table's live re-sorting at 10 Hz — a subtlety most timing UIs get wrong.
+- **Every icon-only button carries `aria-label`** (`Comms.tsx:55,90`, `Settings.tsx:34`), decorative glyphs are `aria-hidden="true"` throughout (e.g. `StatusRail.tsx:101,132,145`), and live regions are scoped deliberately — `RaceControl` is `aria-live="polite"` because it's genuinely low-frequency, while the 10 Hz timing tower is explicitly kept out of any live region (commented rationale at `TimingTower.tsx` and `StatusRail.tsx:166-170`) to avoid a screen-reader announcement storm.
+- **Color is never the sole signal.** Sector bests get an `S`/`P` glyph in addition to purple/green (`TimingTower.tsx:322-326`), sparkline "slower" bars get a hatch pattern in addition to red (`TelemetryPanel.tsx:58-66`), and the Ghost overlay tells its two cars apart by solid-vs-dashed ring rather than opacity alone (`Ghost.tsx:390-402`, with an explicit comment about the contrast-ratio failure of the old opacity-only approach).
+- **`font-variant-numeric: tabular-nums`** is set globally on `body` (`tokens.css:172`), so every timing/lap-time column in `TimingTower`, `TelemetryPanel`, `RaceControl`, and `StintChart` gets it for free without per-component overrides.
+- **Contrast ratios are computed and documented, not eyeballed** — nearly every color token in `tokens.css` carries a measured WCAG ratio in its comment (e.g. `--dim` raised from 2.40:1 to 4.8:1, `--tyre-soft` at 5.45:1), and several components document a specific prior failure that was fixed (Map.tsx's pit-lane opacity, TelemetryPanel's DRS-off color).
+- **URL-as-state is deep and correct**, not just present: `App.tsx` syncs the selected car via `replaceState` (never `pushState`, so clicking through 20 tower rows doesn't pollute history), `Ghost.tsx` syncs both overlay sides the same way, and both guard against clobbering the other route's hash.
+- **`React.memo` used with a real, narrow comparator** in `StintChart.tsx:122-128` (`sameRunningOrder`, not a shallow `state` compare) so the full per-driver stint layout isn't recomputed on every 10 Hz frame — an actual perf-motivated memoization rather than a reflexive one.
+- **Touch targets are handled via a scoped `@media (pointer: coarse)` block** (`components.css:1122-1160+`) that raises buttons/rows/range-input hit areas to 44px only on coarse pointers, explicitly to avoid bloating the dense desktop table — a correct reading of the guideline's intent rather than a blanket `min-height: 44px` everywhere.
+- **`<title>`/`document.title` and social-preview meta are all present and correct** in `index.html` and set per-route via `Route.tsx:32`.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -32,14 +32,28 @@ const LOOP_NOTICE_MS = 8000;
 // the rest of the board is showing: an unrecoverable static-demo load failure,
 // a live socket that has spent its reconnect budget, a session streaming fine
 // but without a track outline, or nothing yet at all.
-function SkeletonMap({ failed, offline, trackless }: {
-  failed?: boolean; offline?: boolean; trackless?: boolean;
+function SkeletonMap({ failed, offline, trackless, onReconnect }: {
+  failed?: boolean; offline?: boolean; trackless?: boolean; onReconnect?: () => void;
 }) {
+  // Reconnect used to live only in the status rail, so the copy pointed the
+  // reader away from the panel that is actually reporting the failure (ui-ux
+  // item 7 — Nielsen #6 / Gestalt proximity). The action now sits right beside
+  // the notice that names it.
+  if (offline) {
+    return (
+      <div className="track-skeleton">
+        Connection lost.
+        {onReconnect && (
+          <button type="button" className="btn chip-action" onClick={onReconnect}>
+            Reconnect
+          </button>
+        )}
+      </div>
+    );
+  }
   const copy = failed
     ? 'The demo replay could not be loaded. Refresh the page to retry.'
-    : offline
-      ? 'Connection lost. Use Reconnect in the status rail above to try again.'
-      : trackless
+    : trackless
       ? 'No track outline for this session — timing still works.'
       : 'Warming up the timing feed…';
   return <div className="track-skeleton">{copy}</div>;
@@ -283,7 +297,19 @@ export default function App() {
             <span role="status" aria-live="polite">
               {frozen && <span className="chip chip-replay">⏸ FROZEN</span>}
               {justLooped && (
-                <span className="chip chip-loop">↻ CLIP LOOPED — the recording restarted</span>
+                <span className="chip chip-loop">
+                  ↻ CLIP LOOPED — the recording restarted
+                  {/* Auto-clears after LOOP_NOTICE_MS, but a fixed-duration
+                      notice with no way to dismiss it early is still stuck on
+                      screen for the full 8s (ui-ux item 14a, Nielsen #3). */}
+                  <button
+                    type="button"
+                    className="btn btn-icon"
+                    style={{ border: 'none' }}
+                    onClick={() => setJustLooped(false)}
+                    aria-label="Dismiss clip looped notice"
+                  >✕</button>
+                </span>
               )}
             </span>
           }
@@ -298,7 +324,14 @@ export default function App() {
               <div className="chip chip-reconnect" style={{
                 position: 'absolute', top: 12, left: '50%', transform: 'translateX(-50%)',
               }}>
-                {status === 'offline' ? '⚠ Connection lost' : '↺ Reconnecting…'}
+                {status === 'offline' ? (
+                  <>
+                    ⚠ Connection lost
+                    <button type="button" className="btn chip-action" onClick={reconnect}>
+                      Reconnect
+                    </button>
+                  </>
+                ) : '↺ Reconnecting…'}
               </div>
             </div>
           )}
@@ -310,6 +343,7 @@ export default function App() {
               failed={status === 'failed'}
               offline={status === 'offline'}
               trackless={trackless}
+              onReconnect={reconnect}
             />
           )}
         </Panel>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5,7 +5,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { connectRace, type ConnStatus } from './realtime/socket';
 import { connectStaticReplay } from './realtime/staticReplay';
-import { emptyState, type RaceState } from './state/race';
+import { emptyState, isWarmingUp, type RaceState } from './state/race';
 import { Map } from './components/Map';
 import { TimingTower } from './components/TimingTower';
 import { TelemetryPanel } from './components/TelemetryPanel';
@@ -32,31 +32,39 @@ const LOOP_NOTICE_MS = 8000;
 // the rest of the board is showing: an unrecoverable static-demo load failure,
 // a live socket that has spent its reconnect budget, a session streaming fine
 // but without a track outline, or nothing yet at all.
+// The "Connection lost" + Reconnect unit, shared between the skeleton and the
+// rail's own reconnect chip — same button, wording free to differ per site.
+function OfflineReconnect({ message, onReconnect }: { message: string; onReconnect: () => void }) {
+  return (
+    <>
+      {message}
+      <button type="button" className="btn chip-action" onClick={onReconnect}>
+        Reconnect
+      </button>
+    </>
+  );
+}
+
 function SkeletonMap({ failed, offline, trackless, onReconnect }: {
-  failed?: boolean; offline?: boolean; trackless?: boolean; onReconnect?: () => void;
+  failed?: boolean; offline?: boolean; trackless?: boolean; onReconnect: () => void;
 }) {
   // Reconnect used to live only in the status rail, so the copy pointed the
   // reader away from the panel that is actually reporting the failure (ui-ux
   // item 7 — Nielsen #6 / Gestalt proximity). The action now sits right beside
   // the notice that names it.
-  if (offline) {
-    return (
-      <div className="track-skeleton">
-        Connection lost.
-        {onReconnect && (
-          <button type="button" className="btn chip-action" onClick={onReconnect}>
-            Reconnect
-          </button>
-        )}
-      </div>
-    );
-  }
-  const copy = failed
-    ? 'The demo replay could not be loaded. Refresh the page to retry.'
-    : trackless
-      ? 'No track outline for this session — timing still works.'
-      : 'Warming up the timing feed…';
-  return <div className="track-skeleton">{copy}</div>;
+  return (
+    <div className="track-skeleton">
+      {offline ? (
+        <OfflineReconnect message="Connection lost." onReconnect={onReconnect} />
+      ) : failed ? (
+        'The demo replay could not be loaded. Refresh the page to retry.'
+      ) : trackless ? (
+        'No track outline for this session — timing still works.'
+      ) : (
+        'Warming up the timing feed…'
+      )}
+    </div>
+  );
 }
 
 export default function App() {
@@ -255,8 +263,8 @@ export default function App() {
   // A snapshot without a track outline would render an invisible map, so stand
   // in for it — but say which of the two cases it is, because "warming up" is a
   // lie once frames are arriving and the timing tower is already populated.
-  const trackless = state.rev > 0 && state.track.length === 0;
-  const showSkeleton = state.rev === 0 || trackless;
+  const trackless = !isWarmingUp(state) && state.track.length === 0;
+  const showSkeleton = isWarmingUp(state) || trackless;
 
   return (
     <Route
@@ -285,7 +293,7 @@ export default function App() {
                   Play/Pause: a transport control names the action it will take. The
                   resulting state is carried by the chip, in a region that is present
                   before it fills so the transition is actually announced. */}
-              <button type="button" className="btn" onClick={toggleFrozen}>
+              <button type="button" className="btn rail-divided" onClick={toggleFrozen}>
                 {frozen ? '▶ Resume' : '⏸ Freeze'}
               </button>
             </>
@@ -294,24 +302,32 @@ export default function App() {
           // state, not controls, and they belong in the reserved slot so the rail
           // does not change shape for eight seconds every time the clip wraps.
           stateChips={
-            <span role="status" aria-live="polite">
-              {frozen && <span className="chip chip-replay">⏸ FROZEN</span>}
+            <>
+              {/* The live region announces the text only — its dismiss button lives
+                  outside it as a sibling, so the button unmounting (on dismiss or
+                  the auto-clear timeout) is never itself announced as a change to
+                  the region's content. */}
+              <span role="status" aria-live="polite">
+                {frozen && <span className="chip chip-replay">⏸ FROZEN</span>}
+                {justLooped && (
+                  <span className="chip chip-loop">
+                    ↻ CLIP LOOPED — the recording restarted
+                  </span>
+                )}
+              </span>
+              {/* Auto-clears after LOOP_NOTICE_MS, but a fixed-duration notice with
+                  no way to dismiss it early is still stuck on screen for the full
+                  8s (ui-ux item 14a, Nielsen #3). */}
               {justLooped && (
-                <span className="chip chip-loop">
-                  ↻ CLIP LOOPED — the recording restarted
-                  {/* Auto-clears after LOOP_NOTICE_MS, but a fixed-duration
-                      notice with no way to dismiss it early is still stuck on
-                      screen for the full 8s (ui-ux item 14a, Nielsen #3). */}
-                  <button
-                    type="button"
-                    className="btn btn-icon"
-                    style={{ border: 'none' }}
-                    onClick={() => setJustLooped(false)}
-                    aria-label="Dismiss clip looped notice"
-                  >✕</button>
-                </span>
+                <button
+                  type="button"
+                  className="btn btn-icon"
+                  style={{ border: 'none' }}
+                  onClick={() => setJustLooped(false)}
+                  aria-label="Dismiss clip looped notice"
+                >✕</button>
               )}
-            </span>
+            </>
           }
         />
       }
@@ -325,12 +341,7 @@ export default function App() {
                 position: 'absolute', top: 12, left: '50%', transform: 'translateX(-50%)',
               }}>
                 {status === 'offline' ? (
-                  <>
-                    ⚠ Connection lost
-                    <button type="button" className="btn chip-action" onClick={reconnect}>
-                      Reconnect
-                    </button>
-                  </>
+                  <OfflineReconnect message="⚠ Connection lost" onReconnect={reconnect} />
                 ) : '↺ Reconnecting…'}
               </div>
             </div>

--- a/web/src/components/Comms.tsx
+++ b/web/src/components/Comms.tsx
@@ -1,5 +1,6 @@
 // The team-radio layer: a now-playing banner over a short replayable history.
 
+import type { CSSProperties } from 'react';
 import type { RaceState } from '../state/race';
 import { useComms } from '../hooks/useComms';
 import { teamColour } from './teamColours';
@@ -21,6 +22,14 @@ export function Comms({ state }: { state: RaceState }) {
   }
   function colourFor(driverNum: number) {
     return teamColour[state.cars[driverNum]?.team ?? ''] ?? 'var(--slate)';
+  }
+  // Team colour as a border accent, not the text fill (WCAG 1.4.3) — shared by
+  // the now-playing banner and every history row so the two sites can't drift.
+  function accentStyle(driverNum: number): CSSProperties {
+    return {
+      color: 'var(--chalk)', fontWeight: 700, borderLeft: `3px solid ${colourFor(driverNum)}`,
+      paddingLeft: 'var(--sp-1)',
+    };
   }
 
   return (
@@ -49,10 +58,7 @@ export function Comms({ state }: { state: RaceState }) {
               well under the 4.5:1 floor for this text size. Same pattern as the
               tower's constructor rule (components.css ~724-728) — colour identifies
               the team, --chalk keeps the code itself readable. */}
-          <span style={{
-            color: 'var(--chalk)', fontWeight: 700, borderLeft: `3px solid ${colourFor(nowPlaying.driverNum)}`,
-            paddingLeft: 'var(--sp-1)',
-          }}>
+          <span style={accentStyle(nowPlaying.driverNum)}>
             {codeFor(nowPlaying.driverNum)}
           </span>
           <span style={{ color: 'var(--slate)' }}>radio</span>
@@ -84,10 +90,7 @@ export function Comms({ state }: { state: RaceState }) {
               className={enabled ? 'comms-row' : 'comms-row comms-row-resting'}
             >
               <span style={{ fontVariantNumeric: 'tabular-nums' }}>{fmtClock(m.timeMs)}</span>
-              <span style={{
-                color: 'var(--chalk)', fontWeight: 700, borderLeft: `3px solid ${colourFor(m.driverNum)}`,
-                paddingLeft: 'var(--sp-1)',
-              }}>{codeFor(m.driverNum)}</span>
+              <span style={accentStyle(m.driverNum)}>{codeFor(m.driverNum)}</span>
               {/* No play button while comms is off. The clips are real and the
                   list is the substance of the resting state, but the one control
                   offered there has to be the toggle above — two ways to start

--- a/web/src/components/Comms.tsx
+++ b/web/src/components/Comms.tsx
@@ -44,7 +44,15 @@ export function Comms({ state }: { state: RaceState }) {
           display: 'flex', alignItems: 'center', gap: 'var(--sp-2)', padding: 'var(--sp-2) var(--sp-3)',
           background: 'var(--asphalt)', borderRadius: 'var(--radius)', fontSize: 'var(--fs-md)',
         }}>
-          <span style={{ color: colourFor(nowPlaying.driverNum), fontWeight: 700 }}>
+          {/* Team colour as a border accent, not the text fill (WCAG 1.4.3): the
+              AlphaTauri hex measured 1.97:1 on --asphalt / 1.82:1 on --carbon, both
+              well under the 4.5:1 floor for this text size. Same pattern as the
+              tower's constructor rule (components.css ~724-728) — colour identifies
+              the team, --chalk keeps the code itself readable. */}
+          <span style={{
+            color: 'var(--chalk)', fontWeight: 700, borderLeft: `3px solid ${colourFor(nowPlaying.driverNum)}`,
+            paddingLeft: 'var(--sp-1)',
+          }}>
             {codeFor(nowPlaying.driverNum)}
           </span>
           <span style={{ color: 'var(--slate)' }}>radio</span>
@@ -76,7 +84,10 @@ export function Comms({ state }: { state: RaceState }) {
               className={enabled ? 'comms-row' : 'comms-row comms-row-resting'}
             >
               <span style={{ fontVariantNumeric: 'tabular-nums' }}>{fmtClock(m.timeMs)}</span>
-              <span style={{ color: colourFor(m.driverNum), fontWeight: 700 }}>{codeFor(m.driverNum)}</span>
+              <span style={{
+                color: 'var(--chalk)', fontWeight: 700, borderLeft: `3px solid ${colourFor(m.driverNum)}`,
+                paddingLeft: 'var(--sp-1)',
+              }}>{codeFor(m.driverNum)}</span>
               {/* No play button while comms is off. The clips are real and the
                   list is the substance of the resting state, but the one control
                   offered there has to be the toggle above — two ways to start

--- a/web/src/components/CopyButton.tsx
+++ b/web/src/components/CopyButton.tsx
@@ -3,7 +3,7 @@
 // reused by the board's and overlay's "Copy link" buttons (ui-ux item 6) instead
 // of a second copy of the same catch/live-region logic.
 
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 export function CopyButton({
   getText, label, copiedLabel = '✓ copied', className = 'btn', ariaLabel,
@@ -18,13 +18,17 @@ export function CopyButton({
 }) {
   const [copied, setCopied] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => () => { if (timerRef.current) clearTimeout(timerRef.current); }, []);
 
   async function copy() {
     try {
       await navigator.clipboard.writeText(getText());
       setError(null);
       setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
+      if (timerRef.current) clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => setCopied(false), 2000);
     } catch {
       setCopied(false);
       setError('Copy failed — copy the URL from the address bar manually.');

--- a/web/src/components/CopyButton.tsx
+++ b/web/src/components/CopyButton.tsx
@@ -1,0 +1,47 @@
+// Shared "copy to clipboard" control: the success/failure live-region feedback
+// pattern that used to live only in Settings.tsx's Cmd (ui-ux item 9b), now
+// reused by the board's and overlay's "Copy link" buttons (ui-ux item 6) instead
+// of a second copy of the same catch/live-region logic.
+
+import { useState } from 'react';
+
+export function CopyButton({
+  getText, label, copiedLabel = '✓ copied', className = 'btn', ariaLabel,
+}: {
+  /** Read lazily on click, not at render time, so the copied text (e.g.
+      `location.href`) is always the value current at the moment of the click. */
+  getText: () => string;
+  label: string;
+  copiedLabel?: string;
+  className?: string;
+  ariaLabel?: string;
+}) {
+  const [copied, setCopied] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function copy() {
+    try {
+      await navigator.clipboard.writeText(getText());
+      setError(null);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      setCopied(false);
+      setError('Copy failed — copy the URL from the address bar manually.');
+    }
+  }
+
+  return (
+    <span className="cmd">
+      <button type="button" className={className} onClick={copy} aria-label={ariaLabel}>
+        {copied ? copiedLabel : label}
+      </button>
+      {/* Announces both the "copied" success and the failure message — see
+          Settings.tsx's Cmd, the pattern this was extracted from. */}
+      <span role="status" aria-live="polite">
+        {copied && <span className="visually-hidden">Copied</span>}
+        {error && <span className="src-error">{error}</span>}
+      </span>
+    </span>
+  );
+}

--- a/web/src/components/Ghost.tsx
+++ b/web/src/components/Ghost.tsx
@@ -15,6 +15,7 @@ import { useLane } from '../hooks/useLane';
 import { useReducedMotion } from '../hooks/useReducedMotion';
 import { StatusRail } from './StatusRail';
 import { Route } from './Route';
+import { CopyButton } from './CopyButton';
 import { buildHash, type OverlaySide } from '../routing';
 import { STATIC_DEMO, REPO_URL } from '../staticDemo';
 
@@ -370,6 +371,9 @@ function OverlayLive({ initialA, initialB }: { initialA: SideSel; initialB: Side
             style={{ flex: 1, minWidth: 160 }}
           />
           <span className="rail-clock">{fmtElapsed(tMs)}</span>
+          {/* The ?a=/?b= pair had no UI (ui-ux item 6) despite the effect above
+              already keeping the URL in sync with both sides via replaceState. */}
+          <CopyButton getText={() => location.href} label="Copy link" copiedLabel="✓ link copied" />
         </div>
       </Panel>
       <Panel label="Track">

--- a/web/src/components/RaceControl.tsx
+++ b/web/src/components/RaceControl.tsx
@@ -40,6 +40,11 @@ const CATEGORY: Record<string, { label: string; colour: string }> = {
 // RaceControl is a passive feed of the most recent race-control messages
 // (flags, safety car, investigations), newest first.
 export function RaceControl({ state, selected }: { state: RaceState; selected?: number | null }) {
+  // "No incidents." asserted a fact about the session before any snapshot had
+  // arrived — indistinguishable from a quiet race (ui-ux item 8, Nielsen #1).
+  // state.rev === 0 is the same warming-up discriminator App.tsx and
+  // StatusBadge already use.
+  if (state.rev === 0) return <div className="empty">⏳ Warming up the timing feed…</div>;
   if (state.messages.length === 0) return <div className="empty">No incidents.</div>;
   const recent = state.messages.slice(-MAX_SHOWN).reverse();
 

--- a/web/src/components/RaceControl.tsx
+++ b/web/src/components/RaceControl.tsx
@@ -1,7 +1,7 @@
 // The race-control log: the most recent marshalling messages, announced politely as
 // they arrive.
 
-import type { RaceControlMessage, RaceState } from '../state/race';
+import { isWarmingUp, type RaceControlMessage, type RaceState } from '../state/race';
 import { fmtClock, needsDriverTag, splitWallClock } from './timingHelpers';
 
 const MAX_SHOWN = 8;
@@ -44,7 +44,7 @@ export function RaceControl({ state, selected }: { state: RaceState; selected?: 
   // arrived — indistinguishable from a quiet race (ui-ux item 8, Nielsen #1).
   // state.rev === 0 is the same warming-up discriminator App.tsx and
   // StatusBadge already use.
-  if (state.rev === 0) return <div className="empty">⏳ Warming up the timing feed…</div>;
+  if (isWarmingUp(state)) return <div className="empty">⏳ Warming up the timing feed…</div>;
   if (state.messages.length === 0) return <div className="empty">No incidents.</div>;
   const recent = state.messages.slice(-MAX_SHOWN).reverse();
 

--- a/web/src/components/Settings.tsx
+++ b/web/src/components/Settings.tsx
@@ -7,6 +7,7 @@ import { StatusRail } from './StatusRail';
 import { Route } from './Route';
 import { parseAuthStatus, relativeExpiry, type AuthStatus } from '../state/f1auth';
 import { StaticDemoNotice } from './StaticDemoNotice';
+import { CopyButton } from './CopyButton';
 import { REPO_URL, STACK_LINE, STATIC_DEMO } from '../staticDemo';
 
 const POLL_MS = 5000;
@@ -15,41 +16,24 @@ const LINK_CMD = 'python ingest/f1tv_link.py';
 
 // The one control a setup page owes its reader, and the one it did not have: the
 // three commands here are meant to be run somewhere else, and selecting mono text
-// out of a wrapped paragraph by hand is the whole friction. Falls back to saying
-// so if the Clipboard API is unavailable (it needs a secure context).
+// out of a wrapped paragraph by hand is the whole friction. The copy button (and
+// its success/failure live-region feedback, ui-ux item 9b) is CopyButton — shared
+// now with the board's and overlay's "Copy link" buttons (ui-ux item 6) instead of
+// a second copy of the same logic.
 // children: string (not ReactNode) is load-bearing — it is what lets the
 // aria-label below interpolate the command text directly. Widening this to
 // ReactNode would make `Copy: ${children}` render "[object Object]" at every
 // call site (ui-ux item 9c) with no compile-time warning.
 function Cmd({ children }: { children: string }) {
-  const [copied, setCopied] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  async function copy() {
-    try {
-      await navigator.clipboard.writeText(children);
-      setError(null);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    } catch {
-      // Used to fail silently (ui-ux item 9b) — the button just sat there
-      // saying "copy" again with no explanation. Surfaced the same way
-      // Comms.tsx reports a blocked clip: an inline role="status" message.
-      setCopied(false);
-      setError('Copy failed — select the text and copy it manually.');
-    }
-  }
   return (
     <span className="cmd">
       <code>{children}</code>
-      <button type="button" className="btn cmd-copy" onClick={copy} aria-label={`Copy: ${children}`}>
-        {copied ? '✓ copied' : 'copy'}
-      </button>
-      {/* Announces both the "✓ copied" success and the failure message — the
-          success label change used to sit in no live region at all. */}
-      <span role="status" aria-live="polite">
-        {copied && <span className="visually-hidden">Copied</span>}
-        {error && <span className="src-error">{error}</span>}
-      </span>
+      <CopyButton
+        getText={() => children}
+        label="copy"
+        className="btn cmd-copy"
+        ariaLabel={`Copy: ${children}`}
+      />
     </span>
   );
 }

--- a/web/src/components/Settings.tsx
+++ b/web/src/components/Settings.tsx
@@ -17,15 +17,25 @@ const LINK_CMD = 'python ingest/f1tv_link.py';
 // three commands here are meant to be run somewhere else, and selecting mono text
 // out of a wrapped paragraph by hand is the whole friction. Falls back to saying
 // so if the Clipboard API is unavailable (it needs a secure context).
+// children: string (not ReactNode) is load-bearing — it is what lets the
+// aria-label below interpolate the command text directly. Widening this to
+// ReactNode would make `Copy: ${children}` render "[object Object]" at every
+// call site (ui-ux item 9c) with no compile-time warning.
 function Cmd({ children }: { children: string }) {
   const [copied, setCopied] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   async function copy() {
     try {
       await navigator.clipboard.writeText(children);
+      setError(null);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     } catch {
+      // Used to fail silently (ui-ux item 9b) — the button just sat there
+      // saying "copy" again with no explanation. Surfaced the same way
+      // Comms.tsx reports a blocked clip: an inline role="status" message.
       setCopied(false);
+      setError('Copy failed — select the text and copy it manually.');
     }
   }
   return (
@@ -34,6 +44,12 @@ function Cmd({ children }: { children: string }) {
       <button type="button" className="btn cmd-copy" onClick={copy} aria-label={`Copy: ${children}`}>
         {copied ? '✓ copied' : 'copy'}
       </button>
+      {/* Announces both the "✓ copied" success and the failure message — the
+          success label change used to sit in no live region at all. */}
+      <span role="status" aria-live="polite">
+        {copied && <span className="visually-hidden">Copied</span>}
+        {error && <span className="src-error">{error}</span>}
+      </span>
     </span>
   );
 }
@@ -131,6 +147,43 @@ function About() {
   );
 }
 
+// The four-step onboarding + the check/forget commands, factored out so it can
+// render either inline (not yet linked) or inside a <details> (already linked).
+function SigningInSteps() {
+  return (
+    <>
+      <ol>
+        <li>
+          Have a free F1 account — <Url href="https://account.formula1.com" />
+        </li>
+        <li>
+          Install the f1login browser extension —{' '}
+          <Url href="https://f1login.fastf1.dev" /> (this is FastF1’s own
+          extension; it is what hands the sign-in to this machine)
+        </li>
+        <li>
+          Install the Python dependencies:
+          <br />
+          <Cmd>pip install -r ingest/requirements.txt -r ingest/requirements-live.txt</Cmd>
+          <br />
+          <Cmd>pip install --no-deps -r ingest/requirements-live-nodeps.txt</Cmd>
+        </li>
+        <li>
+          Run <Cmd>{LINK_CMD}</Cmd>, then open the URL it prints and sign in.
+          It will say <em>“requires an active F1TV Access/Pro/Premium
+          subscription”</em> before the URL — that line is expected, not a
+          rejection; a free account signs in fine.
+        </li>
+      </ol>
+
+      <p>
+        To check without signing in again: <code>{LINK_CMD} --status</code>.
+        To forget the sign-in: <code>{LINK_CMD} --unlink</code>.
+      </p>
+    </>
+  );
+}
+
 // Settings is the #settings route: the operator's view of the beta F1TV link.
 // It only ever reads status — linking itself is a host command, because fastf1's
 // browser login POSTs to host loopback and a container cannot receive that
@@ -223,35 +276,22 @@ export function Settings() {
               </p>
             )}
 
-            <h3>Signing in</h3>
-            <ol>
-              <li>
-                Have a free F1 account — <Url href="https://account.formula1.com" />
-              </li>
-              <li>
-                Install the f1login browser extension —{' '}
-                <Url href="https://f1login.fastf1.dev" /> (this is FastF1’s own
-                extension; it is what hands the sign-in to this machine)
-              </li>
-              <li>
-                Install the Python dependencies:
-                <br />
-                <Cmd>pip install -r ingest/requirements.txt -r ingest/requirements-live.txt</Cmd>
-                <br />
-                <Cmd>pip install --no-deps -r ingest/requirements-live-nodeps.txt</Cmd>
-              </li>
-              <li>
-                Run <Cmd>{LINK_CMD}</Cmd>, then open the URL it prints and sign in.
-                It will say <em>“requires an active F1TV Access/Pro/Premium
-                subscription”</em> before the URL — that line is expected, not a
-                rejection; a free account signs in fine.
-              </li>
-            </ol>
-
-            <p>
-              To check without signing in again: <code>{LINK_CMD} --status</code>.
-              To forget the sign-in: <code>{LINK_CMD} --unlink</code>.
-            </p>
+            {/* A linked operator has nothing left to do here — NextStep already
+                says so — but used to scroll past the full four-step onboarding
+                and its commands regardless (ui-ux item 9a, Nielsen #8). <details>
+                keeps the steps one click away instead of removing them, since
+                the sign-in does lapse and the same operator will need them again. */}
+            {auth.state === 'linked' ? (
+              <details>
+                <summary>Signing in (already linked)</summary>
+                <SigningInSteps />
+              </details>
+            ) : (
+              <>
+                <h3>Signing in</h3>
+                <SigningInSteps />
+              </>
+            )}
 
             <p>
               Sign-in runs on this machine rather than in a container, because the

--- a/web/src/components/SourceToggle.tsx
+++ b/web/src/components/SourceToggle.tsx
@@ -8,7 +8,11 @@ import { SegmentedControl } from './SegmentedControl';
 const SOURCES = [
   { key: 'replay', label: '▶ Replay', caveat: undefined },
   {
-    key: 'live', label: '● Live',
+    // Visible label says "demo" up front (ui-ux review item 3): on the board's
+    // healthy path StatusBadge stands down (laneNamedElsewhere), so this segment
+    // is the only on-screen naming of the lane — the honest word cannot be left
+    // to the hover/visually-hidden caveat alone.
+    key: 'live', label: '● Live (demo)',
     caveat: 'Demo lane streaming a second replay clip — real live ingestion not yet verified',
   },
 ] as const;

--- a/web/src/components/StatusBadge.tsx
+++ b/web/src/components/StatusBadge.tsx
@@ -1,7 +1,7 @@
 // The connection/staleness badge: what the socket is doing and how old the data is.
 
 import type { ConnStatus } from '../realtime/socket';
-import type { RaceState } from '../state/race';
+import { isWarmingUp, type RaceState } from '../state/race';
 
 interface Props {
   status: ConnStatus;
@@ -50,7 +50,7 @@ function Chip({ status, state, staleSec, onReconnect, laneNamedElsewhere }: Prop
   if (status === 'reconnecting') {
     return <span className="chip chip-reconnect">↺ Reconnecting…</span>;
   }
-  if (state.rev === 0) {
+  if (isWarmingUp(state)) {
     return <span className="chip chip-warm">⏳ Warming up the timing feed…</span>;
   }
   if ((staleSec ?? 0) >= STALE_THRESHOLD_SEC) {

--- a/web/src/components/StintChart.tsx
+++ b/web/src/components/StintChart.tsx
@@ -3,7 +3,7 @@
 
 import { memo } from 'react';
 import type { RaceState } from '../state/race';
-import { axisTicks, leaderLapOf, orderCars, sameRunningOrder, TYRE_COLOUR } from './timingHelpers';
+import { axisTicks, leaderLapOf, orderCars, sameRunningOrder, TYRE_COLOUR, TYRE_LEGEND } from './timingHelpers';
 
 // StintChart is the full-race strategy timeline: one row per car (running
 // order), each stint drawn as a coloured segment on a 0..totalLaps axis, with
@@ -100,10 +100,13 @@ function StintChartInner({ state, selected, rival }: {
       </div>
       {/* The tyre key lived in the Timing panel, several hundred pixels away and
           in a different container — and on touch there is no hover to recover the
-          compound from. It costs one line to repeat it where the colours are. */}
+          compound from. It costs one line to repeat it where the colours are.
+          TYRE_LEGEND (shared with TimingTower) is what keeps the two in sync
+          instead of formatting the same five compounds two different ways
+          (ui-ux item 12) — this row used to have no leading glyph at all. */}
       <div className="empty tt-legend" style={{ fontSize: 'var(--fs-sm)' }}>
-        {(['SOFT', 'MEDIUM', 'HARD', 'INTERMEDIATE', 'WET'] as const).map((t) => (
-          <span key={t} style={{ color: TYRE_COLOUR[t] }}>{t[0]}{t.slice(1).toLowerCase()}</span>
+        {TYRE_LEGEND.map(([t, label]) => (
+          <span key={t} style={{ color: TYRE_COLOUR[t] }}>{label}</span>
         ))}
       </div>
       <div className="empty" style={{ fontSize: 'var(--fs-sm)', marginTop: 'var(--sp-0)' }}>

--- a/web/src/components/TelemetryPanel.tsx
+++ b/web/src/components/TelemetryPanel.tsx
@@ -196,6 +196,12 @@ export function TelemetryPanel({
           {/* "vs" said nothing about what the control does; the empty option said
               what the state IS rather than offering the action. */}
           Compare with
+          {/* `rival` here is already the caller's *effective* rival (App.tsx
+              collapses it to null when it matches the primary selection) — so
+              this reflects the same value the card below is keyed on. Without
+              that collapse the select would keep showing a rival the card no
+              longer renders, a control disagreeing with the view (ui-ux 14b).
+              onRivalChange still writes the raw, un-collapsed rival state. */}
           <select
             value={rival ?? ''}
             onChange={(e) => onRivalChange(e.target.value ? Number(e.target.value) : null)}

--- a/web/src/components/TelemetryPanel.tsx
+++ b/web/src/components/TelemetryPanel.tsx
@@ -202,10 +202,13 @@ export function TelemetryPanel({
               that collapse the select would keep showing a rival the card no
               longer renders, a control disagreeing with the view (ui-ux 14b).
               onRivalChange still writes the raw, un-collapsed rival state. */}
+          {/* .overlay-select, not .btn: .btn is transparent-background and left
+              this the only select on the board styled that way — one idiom for
+              a select, shared with the overlay's pickers (ui-ux item 11). */}
           <select
             value={rival ?? ''}
             onChange={(e) => onRivalChange(e.target.value ? Number(e.target.value) : null)}
-            className="btn"
+            className="overlay-select"
             style={{ fontSize: 'var(--fs-xs)' }}
           >
             <option value="">— pick a rival —</option>

--- a/web/src/components/TelemetryPanel.tsx
+++ b/web/src/components/TelemetryPanel.tsx
@@ -11,12 +11,24 @@ const MIN_SPARK_POINTS = 4;
 // both bars being green made a full-brake trace look like a full-throttle one
 // at a glance.
 function Bar({ label, value, tone }: { label: string; value: number; tone: 'good' | 'bad' }) {
+  const pct = Math.max(0, Math.min(100, value));
   return (
     <div className="tele-row">
       <span className="tele-label">{label}</span>
-      <div style={{ flex: 1, height: 8, background: 'var(--edge)', borderRadius: 'var(--radius)' }}>
+      {/* role="meter" (WIG best practice, not a WCAG conformance gap — label and
+          value are both real visible text already) ties the bar, its value and
+          its label into one readable unit for assistive tech instead of three
+          disconnected nodes. */}
+      <div
+        role="meter"
+        aria-label={`${label} ${value}%`}
+        aria-valuenow={pct}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        style={{ flex: 1, height: 8, background: 'var(--edge)', borderRadius: 'var(--radius)' }}
+      >
         <div style={{
-          width: `${Math.max(0, Math.min(100, value))}%`, height: '100%',
+          width: `${pct}%`, height: '100%',
           background: tone === 'good' ? 'var(--good)' : 'var(--bad)', borderRadius: 'var(--radius)',
         }} />
       </div>
@@ -34,17 +46,30 @@ const BAR_W = 15;
 // green = faster — the stint-degradation squint test. Reused for the gap
 // trend too, where the same colouring reads as "closing" (green) vs
 // "opening" (red).
+// The visual trend (up/down per bar, colour-coded) reduced to words: which way
+// the series moved overall, and the value a sighted reader reads off the last
+// bar — the two things the graphic conveys that the adjacent latest-value span
+// (WCAG 1.1.1) does not, since that span only ever shows the final point.
+function trendSummary(known: number[]) {
+  if (known.length < 2) return '';
+  const first = known[0], last = known[known.length - 1];
+  const direction = last > first ? 'rising' : last < first ? 'falling' : 'flat';
+  const min = Math.min(...known), max = Math.max(...known);
+  return `, ${direction} over the last ${known.length} laps, ranging ${min} to ${max}`;
+}
+
 function Sparkline({ values, label }: { values: (number | undefined)[]; label: string }) {
   const known = values.filter((v): v is number => v != null);
   if (known.length === 0) return null;
   const min = Math.min(...known), max = Math.max(...known);
   const span = max - min || 1;
+  const fullLabel = `${label}${trendSummary(known)}`;
   return (
     // minWidth reserves the full 8-lap span so the row does not reflow one bar at
     // a time as history accumulates. Not flex-pinned: the panel is already tight
     // when a rival card is open, and a hard floor there would push it wider still.
     <svg
-      width={values.length * 15} height={24} role="img" aria-label={label}
+      width={values.length * 15} height={24} role="img" aria-label={fullLabel}
       style={{ minWidth: MAX_SPARK_BARS * BAR_W }}
     >
       {values.map((v, i) => {

--- a/web/src/components/TelemetryPanel.tsx
+++ b/web/src/components/TelemetryPanel.tsx
@@ -1,5 +1,6 @@
 // The selected car's telemetry readout: speed, gear, pedal bars and lap/gap sparklines.
 
+import { memo } from 'react';
 import type { Car, RaceState } from '../state/race';
 import { fmtLap, fmtGapEstimate, type LapHistory, type GapHistory } from './timingHelpers';
 
@@ -21,7 +22,7 @@ function Bar({ label, value, tone }: { label: string; value: number; tone: 'good
           disconnected nodes. */}
       <div
         role="meter"
-        aria-label={`${label} ${value}%`}
+        aria-label={`${label} ${pct}%`}
         aria-valuenow={pct}
         aria-valuemin={0}
         aria-valuemax={100}
@@ -50,20 +51,25 @@ const BAR_W = 15;
 // the series moved overall, and the value a sighted reader reads off the last
 // bar — the two things the graphic conveys that the adjacent latest-value span
 // (WCAG 1.1.1) does not, since that span only ever shows the final point.
-function trendSummary(known: number[]) {
+function trendSummary(known: number[], min: number, max: number) {
   if (known.length < 2) return '';
   const first = known[0], last = known[known.length - 1];
   const direction = last > first ? 'rising' : last < first ? 'falling' : 'flat';
-  const min = Math.min(...known), max = Math.max(...known);
   return `, ${direction} over the last ${known.length} laps, ranging ${min} to ${max}`;
 }
 
-function Sparkline({ values, label }: { values: (number | undefined)[]; label: string }) {
+// React.memo with a contents comparator: `values` is rebuilt into a fresh array
+// every 10 Hz frame by the caller's lapHistory/gapHistory lookups, so identity
+// alone would defeat a plain memo — this bails out unless the label or the
+// actual numbers changed.
+const Sparkline = memo(function Sparkline(
+  { values, label }: { values: (number | undefined)[]; label: string },
+) {
   const known = values.filter((v): v is number => v != null);
   if (known.length === 0) return null;
   const min = Math.min(...known), max = Math.max(...known);
   const span = max - min || 1;
-  const fullLabel = `${label}${trendSummary(known)}`;
+  const fullLabel = `${label}${trendSummary(known, min, max)}`;
   return (
     // minWidth reserves the full 8-lap span so the row does not reflow one bar at
     // a time as history accumulates. Not flex-pinned: the panel is already tight
@@ -93,7 +99,10 @@ function Sparkline({ values, label }: { values: (number | undefined)[]; label: s
       })}
     </svg>
   );
-}
+}, (prev, next) =>
+  prev.label === next.label
+  && prev.values.length === next.values.length
+  && prev.values.every((v, i) => v === next.values[i]));
 
 // One shared hatch pattern for every Sparkline on the page.
 function SparkHatch() {

--- a/web/src/components/TimingTower.tsx
+++ b/web/src/components/TimingTower.tsx
@@ -393,7 +393,7 @@ export function TimingTower({
     {/* The ghost overlay was reachable only from the OVERLAY rail tab, with no
         pointer from the board itself (ui-ux item 2, Nielsen #6). One line, next
         to the reference-car hint it complements rather than a coach mark. */}
-    <div className="empty tt-note">
+    <div className="empty tt-overlay-link">
       <a className="demo-notice-link" href="#ghost">Compare laps in the overlay →</a>
     </div>
     </div>

--- a/web/src/components/TimingTower.tsx
+++ b/web/src/components/TimingTower.tsx
@@ -6,12 +6,13 @@ import type { RaceState } from '../state/race';
 import {
   fmtLap, fmtSec, fmtGap, gapLabel, intLabel,
   orderCars, bestSectors, updatePersonalBests, personalBestOf, sectorColour, sectorDelta,
-  TYRE_COLOUR, tyreLabel, statusLabel, sectorDeltaVs, fmtSigned, sectorMark,
+  TYRE_COLOUR, TYRE_LEGEND, tyreLabel, statusLabel, sectorDeltaVs, fmtSigned, sectorMark,
   updateGapSmoothing, displayGaps, hasNoData, holdOrder,
 } from './timingHelpers';
 import type { Bests, GapSmoothing } from './timingHelpers';
 import { teamColour } from './teamColours';
 import { SegmentedControl } from './SegmentedControl';
+import { CopyButton } from './CopyButton';
 
 const GAP_UNIT_OPTIONS = [
   { key: 'laps', label: 'Laps' },
@@ -364,20 +365,36 @@ export function TimingTower({
             Clear reference car
           </button>
           <span className="tt-hint-key"> (or press Esc)</span>
+          {' '}
+          {/* Deep links (?car=) had no UI at all (ui-ux item 6) — App.tsx already
+              keeps the URL in sync with the reference car via replaceState, so the
+              current href is always the shareable link the moment a car is set. */}
+          <CopyButton
+            getText={() => location.href}
+            label="Copy link"
+            copiedLabel="✓ link copied"
+            className="btn tt-clear"
+            ariaLabel={`Copy link to ${refCar.code}`}
+          />
         </>
       ) : (
         'Choose a driver row to set the reference car — sector deltas then compare against it.'
       )}
     </div>
     <div className="empty tt-note tt-legend">
-      {([['SOFT', 'S Soft'], ['MEDIUM', 'M Medium'], ['HARD', 'H Hard'],
-         ['INTERMEDIATE', 'I Inter'], ['WET', 'W Wet']] as const).map(([t, label]) => (
+      {TYRE_LEGEND.map(([t, label]) => (
         <span key={t} style={{ color: TYRE_COLOUR[t] }}>{label}</span>
       ))}
       {/* The S/P glyph is the colour-blind-safe half of the sector-best signal,
           but its meaning used to live only in a title attribute on a superscript
           — unreachable on touch. It gets a visible legend like the compounds do. */}
       <span>S = session best · P = personal best</span>
+    </div>
+    {/* The ghost overlay was reachable only from the OVERLAY rail tab, with no
+        pointer from the board itself (ui-ux item 2, Nielsen #6). One line, next
+        to the reference-car hint it complements rather than a coach mark. */}
+    <div className="empty tt-note">
+      <a className="demo-notice-link" href="#ghost">Compare laps in the overlay →</a>
     </div>
     </div>
   );

--- a/web/src/components/timingHelpers.ts
+++ b/web/src/components/timingHelpers.ts
@@ -1,5 +1,10 @@
 // Shared formatting and ordering helpers for the timing views: lap/gap/sector
 // rendering, running order, personal bests.
+//
+// Broadcast timing (m:ss.SSS, +s.SSS, …) is a fixed, locale-invariant wire
+// format, not a number the reader's own locale should reformat — so this file
+// hand-formats with padStart/toFixed throughout and deliberately never reaches
+// for Intl (ui-ux item 14d).
 
 import type { RaceState, Car } from '../state/race';
 
@@ -121,6 +126,16 @@ export const TYRE_COLOUR: Record<string, string> = {
   INTERMEDIATE: 'var(--tyre-inter)',
   WET: 'var(--tyre-wet)',
 };
+
+// TYRE_LEGEND: compound key -> glyph-prefixed legend label ("S Soft"), shared by
+// TimingTower's and StintChart's tyre-colour keys. The two used to format this
+// independently and drifted (ui-ux item 12): StintChart's own list carried no
+// leading glyph, which is exactly the non-colour signal 1.4.1 needs once the
+// swatch itself is the only other cue.
+export const TYRE_LEGEND: readonly (readonly [string, string])[] = [
+  ['SOFT', 'S Soft'], ['MEDIUM', 'M Medium'], ['HARD', 'H Hard'],
+  ['INTERMEDIATE', 'I Inter'], ['WET', 'W Wet'],
+];
 
 // tyreLabel is the single compact tyre readout shared by TimingTower and
 // Standings (previously formatted inconsistently between the two: "S 5" vs "S5").

--- a/web/src/hooks/useComms.ts
+++ b/web/src/hooks/useComms.ts
@@ -2,7 +2,7 @@
 // short history.
 
 import { useEffect, useRef, useState } from 'react';
-import type { RaceState, RadioMessage } from '../state/race';
+import { isWarmingUp, type RaceState, type RadioMessage } from '../state/race';
 import { stepComms, liveArrivals, isStale, isAllowedClip, type CommsCursor } from '../state/comms';
 
 const HISTORY_MAX = 6;
@@ -75,7 +75,7 @@ export function useComms(state: RaceState) {
   // snapshotSeq (not "have we ever seen a rev yet") so a mid-session reconnect is
   // caught too, not just the very first snapshot after mount.
   useEffect(() => {
-    if (state.rev === 0) return;
+    if (isWarmingUp(state)) return;
     clockRef.current = state.timeMs;
     const isSnapshot = lastSnapshotSeqRef.current !== state.snapshotSeq;
     lastSnapshotSeqRef.current = state.snapshotSeq;

--- a/web/src/state/race.ts
+++ b/web/src/state/race.ts
@@ -50,6 +50,13 @@ export interface RaceState {
   loopSeq: number;
 }
 
+// True before the first snapshot has arrived — the "nothing to show yet" state
+// several panels (App, StatusBadge, RaceControl, useComms) each tested for
+// separately as a raw `rev === 0` comparison.
+export function isWarmingUp(s: RaceState): boolean {
+  return s.rev === 0;
+}
+
 export function emptyState(): RaceState {
   return {
     session: '', mode: '', label: '', track: [], cars: {}, timeMs: 0, rev: 0,

--- a/web/src/styles/components.css
+++ b/web/src/styles/components.css
@@ -757,6 +757,13 @@ select.btn {
 
 /* The real control: an unstyled button that looks exactly like the driver code it
    replaced, but is a focusable, named, pressable thing to a screen reader. */
+/* WCAG 2.2 SC 2.5.8 Target Size (Minimum), AA: the unpadded button was the 13px
+   text's own line box (~16-19px) — under the 24x24 CSS-px floor at pointer:fine,
+   and the row itself isn't an accessible fallback target (no role/tabIndex). The
+   min box is grown with negative margins rather than padding, so the enlarged
+   hit area doesn't widen the column or push neighbouring cell content — same
+   inward-compensation idea as the focus ring below, applied to layout instead
+   of paint. */
 .tt-select {
   appearance: none;
   border: 0;
@@ -767,6 +774,11 @@ select.btn {
   font: inherit;
   cursor: pointer;
   touch-action: manipulation;
+  min-width: 24px;
+  min-height: 24px;
+  margin-block: -3px;
+  display: inline-flex;
+  align-items: center;
 }
 
 /* Drawn inside the row's own bounds: .panel is overflow:hidden and .tt-scroll is

--- a/web/src/styles/components.css
+++ b/web/src/styles/components.css
@@ -127,6 +127,19 @@
 .rail-tabs { order: 5; }
 .rail-exits { order: 6; gap: var(--sp-0); }
 
+/* Zone D holds two objects, not one: the lane pick (a persistent-state radiogroup)
+   and the transport verb (a momentary .btn). The scope label and the segments'
+   shared border already say "these two abut" (ui-ux item 10, Gestalt common
+   region) — this hairline plus extra gap is what says the standalone button after
+   them does not belong to that group. Scoped to the bare .btn that follows the
+   segmented control's wrapper, so a route with no lane control (nothing to
+   separate from) is unaffected. */
+.rail-controls > .rail-segmented ~ .btn {
+  margin-left: var(--sp-1);
+  padding-left: calc(var(--sp-2) + var(--sp-1));
+  border-left: 1px solid var(--edge);
+}
+
 /* STATE. A reserved slot: min-width rather than a fixed width, so the stall,
    FROZEN and CLIP-LOOPED chips arriving and leaving never reflow the rail, but
    the eight-second loop notice — the one chip that MUST be readable in the

--- a/web/src/styles/components.css
+++ b/web/src/styles/components.css
@@ -133,8 +133,10 @@
    region) — this hairline plus extra gap is what says the standalone button after
    them does not belong to that group. Scoped to the bare .btn that follows the
    segmented control's wrapper, so a route with no lane control (nothing to
-   separate from) is unaffected. */
-.rail-controls > .rail-segmented ~ .btn {
+   separate from) is unaffected. Applied directly to the Freeze/Resume button
+   rather than matched structurally, so the rule fires only where that button
+   actually sits, not wherever a `.btn` happens to follow a `.rail-segmented`. */
+.rail-divided {
   margin-left: var(--sp-1);
   padding-left: calc(var(--sp-2) + var(--sp-1));
   border-left: 1px solid var(--edge);
@@ -823,6 +825,14 @@ select.btn {
 }
 
 .tt-note {
+  font-size: var(--fs-sm);
+  margin-top: var(--sp-1);
+}
+
+/* The ghost-overlay pointer below the tower. It rendered identically to
+   .tt-note (same size, same top margin) but isn't one of the tower's own
+   notes, so it gets its own class rather than borrowing that one. */
+.tt-overlay-link {
   font-size: var(--fs-sm);
   margin-top: var(--sp-1);
 }


### PR DESCRIPTION
Fixes every confirmed finding from the 2026-08-31 three-standard UI/UX audit (WCAG 2.2 / Nielsen + laws of UX / Web Interface Guidelines), adversarially validated in `reviews/uiux-validation.md`. Refuted items (map aria, "[object Object]" label) were not touched; live-render-only items (scrubber focus, 400% reflow) are deferred.

## Section A — WCAG conformance
- **Comms driver codes** off raw team hex (1.82–4.02:1) onto the tower's colour-as-accent pattern — SC 1.4.3 AA
- **Sparkline labels** now convey the trend, not just "lap time trend" — SC 1.1.1 A
- **Throttle/Brake bars** get `role="meter"` + value attributes (WIG)
- **`.tt-select`** raised to a ≥24px target at pointer:fine — SC 2.5.8 AA

## Section B — status & feedback
- Visible lane label is now **"● Live (demo)"**
- **Reconnect button on the map's connection-lost overlay**, not just the rail
- Race Control distinguishes **warming-up vs. genuinely no incidents**
- Settings copy button surfaces clipboard failures and announces success (live region)
- Signing-in onboarding collapses into `<details>` once linked
- CLIP LOOPED chip is dismissable
- Rival select stays consistent with the effective comparison

## Section C — discoverability & consistency
- "Compare laps in the overlay →" pointer from the board
- **Copy-link buttons** (board + overlay) via a shared `CopyButton`, also reused by Settings
- Rival select restyled onto `.overlay-select` (explicit dark background)
- One shared tyre legend for Tower + StintChart (glyph prefix everywhere)
- Divider between Lane control and Freeze/Resume
- Locale-invariance comment in `timingHelpers.ts`

Audit + validation reports committed under `reviews/uiux-*.md`; per-section change logs in `reviews/fix-section-{a,b,c}.md`. Frontend gate: lint clean, 269/269 tests, build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
