### PR TITLE
feat: verified peer-comparison features (telemetry traces, pit stops, playback, map furniture, heatmap)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -275,3 +275,54 @@ it read-only; the settings page polls it.
 
 - _Use_ "linked" / "the link" for the account state; not "logged in" or "signed in"
   (there is no user session here) and never "account" alone.
+
+## Pit stop
+
+One baked, dated entry for a driver's real visit to the pits — the lap it started on
+and its stationary/pit-lane duration. Derived from FastF1's `PitInTime`/`PitOutTime`
+lap columns, like the pit window below, but only when a real `PitInTime` exists —
+a car that starts the race from the pit lane backdates a synthetic pit-in edge purely
+to flag the pit window correctly, and that backdated edge must never produce a pit
+stop entry (a pit-lane start is not a stop).
+
+This is distinct from the pit window: the pit window is the `(pit_in, pit_out)` time
+range used only to flag a car's Pit/Out status on track (position data's own status
+field is not reliable for this — verified empty), and it can include the pit-lane-start
+window with no corresponding stop. A pit stop is the strategy-facing record shown on
+the timeline.
+
+- _Use_ "pit stop" for the strategy-timeline entry (lap + duration); "pit window" for
+  the on-track Pit/Out flagging range; never conflate the two — a car can have a pit
+  window with no pit stop.
+
+## Pedal trace
+
+The baked per-driver throttle/brake/gear samples, indexed by the same track-outline
+position as the **lap trace**, for the telemetry overlay. Best-effort, like **gap**,
+and baked once at record time — not windowed to the replay clip.
+
+- _Use_ "pedal trace"; not "telemetry" alone (too broad) or "car data" (the raw
+  FastF1 source, not the baked/indexed form).
+
+## Corner / track furniture
+
+A labelled circuit corner — number and normalised `[0,1]` position, with an optional
+letter distinguishing sub-corners that share a number (e.g. "10A"/"10B"). Baked once
+from FastF1's circuit info, session-constant like the track outline. "Track furniture"
+is the umbrella term for baked, non-car map annotations; corners are the only kind
+baked today (DRS zones and a safety-car marker are deliberately out of scope — see the
+ponytail note beside the corner-baking code).
+
+- _Use_ "corner" for one labelled point; "track furniture" only when speaking of the
+  category as a whole.
+
+## Sector dominance / minisector
+
+A per-driver-color coding of which driver was fastest through each fixed-size chunk
+("minisector") of the track outline, shown on the map. Baked once per session,
+independent of the replay window, at a fixed minisector size (points of track
+outline per bin).
+
+- _Use_ "sector dominance" for the feature/overlay; "minisector" for one fixed-size
+  chunk of track outline it's computed over — not "sector" alone, which in F1 usually
+  means one of the three timing sectors, a much coarser division.

--- a/FILE-MAP.md
+++ b/FILE-MAP.md
@@ -58,6 +58,7 @@ The Python side: records FastF1 sessions to JSONL clips and runs the true-live S
 | `live.py` | Live ingester — publishes normalized race frames to Redis using the SAME contract |
 | `live_parsers.py` | Pure parsers for the live SignalR feed, extracted from live_signalr.py. |
 | `live_signalr.py` | True-live FastF1 SignalR ingest mode (exploratory, session-only). |
+| `pit.py` | Pure pit-window / pit-stop derivation, split out of record.py for testability. |
 | `pytest.ini` | Pytest configuration for the ingest suite: which files count as tests, and where collection starts. |
 | `race_control.py` | Pure helper for baking race-control messages into clip frames. |
 | `radio.py` | Pure helpers for baking team radio into a clip header. |
@@ -74,6 +75,7 @@ The Python side: records FastF1 sessions to JSONL clips and runs the true-live S
 | `test_ghost.py` | Self-check for ingest/ghost.build_lap_trace (no fastf1/numpy/network needed). |
 | `test_live_parsers.py` | Direct self-check for live_parsers.py's pure feed parsers (no fastf1/network). |
 | `test_live_publish.py` | Unit tests for live_signalr.py's two publish paths, without fastf1 or Redis. |
+| `test_pit.py` | Unit tests for the pure pit-window / pit-stop derivation in ingest/pit.py. |
 | `test_race_control.py` | Self-check for ingest/race_control.extract_race_control (no fastf1/network needed). |
 | `test_radio.py` | Self-check for ingest/radio.extract_radio (no fastf1/network needed). |
 | `test_resample.py` | Tests for the resampler's nearest-neighbour grid lookup and windowing helpers. |
@@ -511,4 +513,4 @@ The golden snapshot pinning the wire contract between Go, Python and the fronten
 
 ---
 
-46 directories, 185 files listed, 0 without a declared purpose.
+46 directories, 187 files listed, 0 without a declared purpose.

--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ Each lane writes to its own Redis keys (`snapshot:<session>` and `frames:<sessio
 
 **Monotonic Rev.** Both the Go writer and the Python ingester read the stored snapshot's `rev` at startup and emit strictly above it. A restart or a source swap therefore never re-emits a Rev the gateway and clients already passed (which would silently freeze the board).
 
+The replay writer feeds the same Redis contract and seam as the live ingester — same snapshot shape, same frame schema, same monotonic Rev — making the replay lane indistinguishable from live at the gateway. The repo ships this **simulated-live feed** intentionally: to test dashboard clients without waiting for a race weekend, using the same gateway and source-switching infrastructure that live ingestion would use.
+
 ## Control endpoint
 
 Switch the active source at runtime:

--- a/cmd/bake-static/main.go
+++ b/cmd/bake-static/main.go
@@ -66,6 +66,7 @@ func bake(src *replay.Source, session string, w *bufio.Writer) error {
 	snap.TotalLaps = src.TotalLaps()
 	snap.Stints = src.Stints()
 	snap.PitStops = src.PitStops()
+	snap.PedalTraces = src.PedalTraces()
 
 	sb, err := ws.EncodeSnapshot(snap)
 	if err != nil {

--- a/cmd/bake-static/main.go
+++ b/cmd/bake-static/main.go
@@ -61,12 +61,14 @@ func run(clipPath, outPath, session string) error {
 func bake(src *replay.Source, session string, w *bufio.Writer) error {
 	snap := model.NewSnapshot(session, src.Mode(), src.Label())
 	snap.Track = src.Track()
+	snap.Corners = src.Corners()
 	snap.Radio = src.Radio()
 	snap.LapTrace = src.LapTrace()
 	snap.TotalLaps = src.TotalLaps()
 	snap.Stints = src.Stints()
 	snap.PitStops = src.PitStops()
 	snap.PedalTraces = src.PedalTraces()
+	snap.SectorDominance = src.SectorDominance()
 
 	sb, err := ws.EncodeSnapshot(snap)
 	if err != nil {

--- a/cmd/bake-static/main.go
+++ b/cmd/bake-static/main.go
@@ -65,6 +65,7 @@ func bake(src *replay.Source, session string, w *bufio.Writer) error {
 	snap.LapTrace = src.LapTrace()
 	snap.TotalLaps = src.TotalLaps()
 	snap.Stints = src.Stints()
+	snap.PitStops = src.PitStops()
 
 	sb, err := ws.EncodeSnapshot(snap)
 	if err != nil {

--- a/ingest/ghost.py
+++ b/ingest/ghost.py
@@ -72,7 +72,7 @@ def build_pedal_trace(sample_ts, sample_xy, track_xy, throttle_vals, brake_vals,
     reached = [None] * n
     # ponytail: same brute-force nearest-point search as build_lap_trace, run once
     # per driver per clip bake — see that function's comment for the cost analysis.
-    for ts, (sx, sy), th, br, gr in zip(
+    for _ts, (sx, sy), th, br, gr in zip(
         sample_ts, sample_xy, throttle_vals, brake_vals, gear_vals, strict=True
     ):
         bi, bd = 0, None

--- a/ingest/ghost.py
+++ b/ingest/ghost.py
@@ -52,3 +52,42 @@ def build_lap_trace(sample_ts, sample_xy, track_xy):
     if trace:
         trace[0] = 0
     return trace
+
+
+def build_pedal_trace(sample_ts, sample_xy, track_xy, throttle_vals, brake_vals, gear_vals):
+    """Throttle/brake/gear at each track-outline index, over one reference lap.
+
+    Same nearest-outline-index bucketing as build_lap_trace, but instead of
+    recording elapsed time at first-reached, records that sample's pedal/gear
+    values. Unreached indices carry the previous value forward (matches
+    build_lap_trace's fill rule) so all three arrays are always fully populated,
+    length len(track_xy).
+
+    sample_ts/sample_xy/track_xy: as build_lap_trace.
+    throttle_vals/brake_vals/gear_vals: parallel lists, same length as sample_ts.
+    """
+    n = len(track_xy)
+    if not sample_ts or n == 0:
+        return {"throttle": [0] * n, "brake": [0] * n, "gear": [0] * n}
+    reached = [None] * n
+    # ponytail: same brute-force nearest-point search as build_lap_trace, run once
+    # per driver per clip bake — see that function's comment for the cost analysis.
+    for ts, (sx, sy), th, br, gr in zip(
+        sample_ts, sample_xy, throttle_vals, brake_vals, gear_vals, strict=True
+    ):
+        bi, bd = 0, None
+        for i, (tx, ty) in enumerate(track_xy):
+            d = (tx - sx) ** 2 + (ty - sy) ** 2
+            if bd is None or d < bd:
+                bd, bi = d, i
+        if reached[bi] is None:
+            reached[bi] = (int(th), int(br), int(gr))
+    throttle, brake, gear = [], [], []
+    last = (0, 0, 0)
+    for i in range(n):
+        if reached[i] is not None:
+            last = reached[i]
+        throttle.append(last[0])
+        brake.append(last[1])
+        gear.append(last[2])
+    return {"throttle": throttle, "brake": brake, "gear": gear}

--- a/ingest/ghost.py
+++ b/ingest/ghost.py
@@ -91,3 +91,30 @@ def build_pedal_trace(sample_ts, sample_xy, track_xy, throttle_vals, brake_vals,
         brake.append(last[1])
         gear.append(last[2])
     return {"throttle": throttle, "brake": brake, "gear": gear}
+
+
+def compute_sector_dominance(lap_traces, n_points, bin_size):
+    """Fastest driver's number through each fixed-size minisector of the outline.
+
+    lap_traces: {driver_num: [cum_ms,...]} of length n_points, as built by
+    build_lap_trace (cumulative elapsed ms at each track-outline index, over
+    that driver's own fastest lap). Bins are [start, min(start+bin_size, n-1)]
+    windows, matching web/src/components/geometry.ts's trackSegmentPaths so
+    segment i lines up with sectorDominance[i] on both sides of the contract.
+
+    Returns one driver number per bin — the driver with the least elapsed time
+    across that bin's window — or 0 when no driver has a positive time delta
+    there (e.g. too few points, or no lap trace data at all).
+    """
+    out = []
+    for start in range(0, n_points, bin_size):
+        end = min(start + bin_size, n_points - 1)
+        best_driver, best_delta = 0, None
+        for dnum, trace in lap_traces.items():
+            delta = trace[end] - trace[start]
+            if delta <= 0:
+                continue
+            if best_delta is None or delta < best_delta:
+                best_delta, best_driver = delta, dnum
+        out.append(best_driver)
+    return out

--- a/ingest/pit.py
+++ b/ingest/pit.py
@@ -1,0 +1,54 @@
+"""Pure pit-window / pit-stop derivation, split out of record.py for testability.
+
+Position-data 'Status' does NOT reliably tag pit lane in FastF1 (verified
+empty — 'OnTrack' for the entire session, even during a confirmed pit
+stop) — so a car's Pit/Out status is derived from lap timing
+(PitInTime/PitOutTime) instead, which is authoritative.
+"""
+import pandas as pd
+
+
+def build_pit_data(drv):
+    """Derive pit-lane windows and pit_stops entries for one driver's laps.
+
+    `drv` is a FastF1 laps DataFrame (or anything with the same columns:
+    LapNumber, PitInTime, PitOutTime, LapStartTime) for a single driver.
+    Returns (windows, stops) where windows is a list of (pit_in_s, pit_out_s)
+    tuples used for pit-window flagging, and stops is a list of
+    {"lap": int, "durationS": float} — one per REAL pit stop.
+
+    A car that starts the race from the pit lane has a PitOutTime with no
+    preceding PitInTime; we backdate a synthetic pit_in to the lap's own
+    LapStartTime purely so the car is still flagged as "in the pits" up to
+    PitOutTime. That backdated edge is not a real stop, so it must never
+    produce a pit_stops entry (a pit-lane start is not a pit stop).
+    """
+    windows = []
+    stops = []
+    pit_in = None
+    pit_in_lap = None
+    pit_in_synthetic = False
+    for _, lap in drv.sort_values('LapNumber').iterrows():
+        if not pd.isna(lap['PitInTime']):
+            pit_in = lap['PitInTime'].total_seconds()
+            pit_in_lap = None if pd.isna(lap['LapNumber']) else int(lap['LapNumber'])
+            pit_in_synthetic = False
+        if not pd.isna(lap['PitOutTime']):
+            if pit_in is None and not pd.isna(lap['LapStartTime']):
+                pit_in = lap['LapStartTime'].total_seconds()
+                pit_in_lap = None if pd.isna(lap['LapNumber']) else int(lap['LapNumber'])
+                pit_in_synthetic = True
+            if pit_in is not None:
+                pit_out = lap['PitOutTime'].total_seconds()
+                windows.append((pit_in, pit_out))
+                if pit_in_lap is not None and not pit_in_synthetic:
+                    stops.append({"lap": pit_in_lap, "durationS": round(pit_out - pit_in, 1)})
+                pit_in = None
+                pit_in_lap = None
+                pit_in_synthetic = False
+    if pit_in is not None:
+        pit_out = pit_in + 30  # no recorded out-lap; assume a typical stop
+        windows.append((pit_in, pit_out))
+        if pit_in_lap is not None and not pit_in_synthetic:
+            stops.append({"lap": pit_in_lap, "durationS": round(pit_out - pit_in, 1)})
+    return windows, stops

--- a/ingest/record.py
+++ b/ingest/record.py
@@ -7,7 +7,8 @@ CONTRACT (must match internal/model/model.go + web/src/state/race.ts):
   Header line: {"track":[{"x":float,"y":float},...], "label":"...", "maxRev":int,
                 "radio":[{"timeMs":int,"driverNum":int,"clip":"https://..."}],
                 "lapTrace":{"<num>":[ms,...]},
-                "stints":{"<num>":[{"compound":"SOFT","startLap":int,"endLap":int}]}}
+                "stints":{"<num>":[{"compound":"SOFT","startLap":int,"endLap":int}]},
+                "pitStops":{"<num>":[{"lap":int,"durationS":float}]}}
   Frame lines: {"timeMs":int, "frame":{"rev":int,"timeMs":int,"cars":[
                  {"driverNum":int,"code":"VER","team":"Red Bull","pos":int,
                   "p":{"x":float,"y":float},"status":"OnTrack"}],
@@ -421,6 +422,10 @@ def get_timing(driver_num, t_s):
 lapnum_lookup = {}  # driver_num -> (times, lap_numbers), parallel lists ascending by time
 stints = {}
 pit_windows = {}  # driver_num -> [(pit_in_s, pit_out_s), ...]
+pit_stops = {}  # driver_num -> [{"lap": int, "durationS": float}, ...] — duration only;
+# ponytail: positions-gained/lost and stationary time are out of scope for this
+# slice (reviews/plans/verify/02-pit-stops.md) — would need a running-order-at-time
+# derivation and per-driver car_data telemetry respectively, neither of which exist yet.
 for num in session.drivers:
     inum = int(num)
     if inum not in driver_info:
@@ -447,10 +452,13 @@ for num in session.drivers:
         stints[inum] = out
 
     windows = []
+    stops = []
     pit_in = None
+    pit_in_lap = None
     for _, lap in drv.sort_values('LapNumber').iterrows():
         if not pd.isna(lap['PitInTime']):
             pit_in = lap['PitInTime'].total_seconds()
+            pit_in_lap = None if pd.isna(lap['LapNumber']) else int(lap['LapNumber'])
         if not pd.isna(lap['PitOutTime']):
             if pit_in is None and not pd.isna(lap['LapStartTime']):
                 # No PitInTime seen before this PitOutTime — e.g. the car
@@ -458,12 +466,22 @@ for num in session.drivers:
                 # start as the pit-in edge so the car is still correctly
                 # flagged as in the pits up to PitOutTime.
                 pit_in = lap['LapStartTime'].total_seconds()
+                pit_in_lap = None if pd.isna(lap['LapNumber']) else int(lap['LapNumber'])
             if pit_in is not None:
-                windows.append((pit_in, lap['PitOutTime'].total_seconds()))
+                pit_out = lap['PitOutTime'].total_seconds()
+                windows.append((pit_in, pit_out))
+                if pit_in_lap is not None:
+                    stops.append({"lap": pit_in_lap, "durationS": round(pit_out - pit_in, 1)})
                 pit_in = None
+                pit_in_lap = None
     if pit_in is not None:
-        windows.append((pit_in, pit_in + 30))  # no recorded out-lap; assume a typical stop
+        pit_out = pit_in + 30  # no recorded out-lap; assume a typical stop
+        windows.append((pit_in, pit_out))
+        if pit_in_lap is not None:
+            stops.append({"lap": pit_in_lap, "durationS": round(pit_out - pit_in, 1)})
     pit_windows[inum] = windows
+    if stops:
+        pit_stops[inum] = stops
 print(f"Stints baked for {len(stints)} drivers")
 
 def _lap_number(driver_num, t_s):
@@ -691,6 +709,7 @@ with open(OUTPUT_PATH, 'w', encoding='utf-8') as f:
         "lapTrace": lap_traces,
         "totalLaps": TOTAL_LAPS,
         "stints": stints,
+        "pitStops": pit_stops,
     }
     f.write(json.dumps(header, separators=(',', ':')) + '\n')
 
@@ -875,7 +894,11 @@ try:
     for _dn, stint_list in hdr['stints'].items():
         for st in stint_list:
             assert {'compound', 'startLap', 'endLap'} <= set(st.keys()), f"stint missing fields: {st}"
-    print(f"  Header OK: {len(hdr['track'])} track points, maxRev={hdr['maxRev']}, {len(hdr['radio'])} radio clips, totalLaps={hdr['totalLaps']}, stints for {len(hdr['stints'])} drivers")
+    assert 'pitStops' in hdr, "header missing 'pitStops'"
+    for _dn, stop_list in hdr['pitStops'].items():
+        for ps in stop_list:
+            assert {'lap', 'durationS'} <= set(ps.keys()), f"pit stop missing fields: {ps}"
+    print(f"  Header OK: {len(hdr['track'])} track points, maxRev={hdr['maxRev']}, {len(hdr['radio'])} radio clips, totalLaps={hdr['totalLaps']}, stints for {len(hdr['stints'])} drivers, pitStops for {len(hdr['pitStops'])} drivers")
 except AssertionError as e:
     print(f"  HEADER ERROR: {e}")
     errors += 1

--- a/ingest/record.py
+++ b/ingest/record.py
@@ -5,7 +5,7 @@ Bakes a real F1 session into the contract read by the Go replay player.
 
 CONTRACT (must match internal/model/model.go + web/src/state/race.ts):
   Header line: {"track":[{"x":float,"y":float},...], "label":"...", "maxRev":int,
-                "corners":[{"number":int,"x":float,"y":float},...],
+                "corners":[{"number":int,"x":float,"y":float,"letter":"..."},...],
                 "radio":[{"timeMs":int,"driverNum":int,"clip":"https://..."}],
                 "lapTrace":{"<num>":[ms,...]},
                 "stints":{"<num>":[{"compound":"SOFT","startLap":int,"endLap":int}]},
@@ -51,6 +51,7 @@ from live_parsers import TEAM_MAP
 from geometry import (
     resample_closed_loop, project_to_arc, wrap_counts, invert_distance_curve, lap_deficit,
 )
+from pit import build_pit_data
 
 # ---------------------------------------------------------------------------
 # Args
@@ -293,9 +294,27 @@ print("\nFetching circuit info (corners)...")
 corners = []
 try:
     circuit_info = session.get_circuit_info()
+    _skipped_corners = 0
+    _margin = 1e-6
     for _, row in circuit_info.corners.iterrows():
         cx, cy = normalise(row['X'], row['Y'])
-        corners.append({"number": int(row['Number']), "x": cx, "y": cy})
+        if not (-_margin <= cx <= 1 + _margin and -_margin <= cy <= 1 + _margin):
+            # Corner coords are derived from the circuit's own reference frame,
+            # which can fall slightly outside the sampled lap's bounding box
+            # (a different lap, a slow out-lap, etc.). One stray corner should
+            # not abort the whole bake — skip it rather than clamp, since a
+            # clamped corner would render at a dishonest position.
+            _skipped_corners += 1
+            continue
+        letter = row['Letter'] if 'Letter' in row and not pd.isna(row['Letter']) else ""
+        corners.append({
+            "number": int(row['Number']),
+            "x": min(max(cx, 0.0), 1.0),
+            "y": min(max(cy, 0.0), 1.0),
+            "letter": str(letter),
+        })
+    if _skipped_corners:
+        print(f"  Warning: skipped {_skipped_corners} corner(s) outside normalised track bounds")
     print(f"Corners: {len(corners)}")
 except Exception as e:
     print(f"  Warning: circuit info fetch failed ({type(e).__name__}: {e}); clip will have no corners")
@@ -507,34 +526,7 @@ for num in session.drivers:
     if out:
         stints[inum] = out
 
-    windows = []
-    stops = []
-    pit_in = None
-    pit_in_lap = None
-    for _, lap in drv.sort_values('LapNumber').iterrows():
-        if not pd.isna(lap['PitInTime']):
-            pit_in = lap['PitInTime'].total_seconds()
-            pit_in_lap = None if pd.isna(lap['LapNumber']) else int(lap['LapNumber'])
-        if not pd.isna(lap['PitOutTime']):
-            if pit_in is None and not pd.isna(lap['LapStartTime']):
-                # No PitInTime seen before this PitOutTime — e.g. the car
-                # started the race from the pit lane. Treat the lap's own
-                # start as the pit-in edge so the car is still correctly
-                # flagged as in the pits up to PitOutTime.
-                pit_in = lap['LapStartTime'].total_seconds()
-                pit_in_lap = None if pd.isna(lap['LapNumber']) else int(lap['LapNumber'])
-            if pit_in is not None:
-                pit_out = lap['PitOutTime'].total_seconds()
-                windows.append((pit_in, pit_out))
-                if pit_in_lap is not None:
-                    stops.append({"lap": pit_in_lap, "durationS": round(pit_out - pit_in, 1)})
-                pit_in = None
-                pit_in_lap = None
-    if pit_in is not None:
-        pit_out = pit_in + 30  # no recorded out-lap; assume a typical stop
-        windows.append((pit_in, pit_out))
-        if pit_in_lap is not None:
-            stops.append({"lap": pit_in_lap, "durationS": round(pit_out - pit_in, 1)})
+    windows, stops = build_pit_data(drv)
     pit_windows[inum] = windows
     if stops:
         pit_stops[inum] = stops
@@ -964,7 +956,7 @@ try:
             f"pedal trace length {len(pt['throttle'])} != track length {len(hdr['track'])}"
     assert 'corners' in hdr, "header missing 'corners'"
     for c in hdr['corners']:
-        assert {'number', 'x', 'y'} <= set(c.keys()), f"corner missing fields: {c}"
+        assert {'number', 'x', 'y', 'letter'} <= set(c.keys()), f"corner missing fields: {c}"
         assert 0 <= c['x'] <= 1 and 0 <= c['y'] <= 1, f"corner out of [0,1]: {c}"
     assert 'sectorDominance' in hdr, "header missing 'sectorDominance'"
     expected_bins = math.ceil(len(hdr['track']) / MINISECTOR_SIZE) if hdr['track'] else 0

--- a/ingest/record.py
+++ b/ingest/record.py
@@ -8,7 +8,8 @@ CONTRACT (must match internal/model/model.go + web/src/state/race.ts):
                 "radio":[{"timeMs":int,"driverNum":int,"clip":"https://..."}],
                 "lapTrace":{"<num>":[ms,...]},
                 "stints":{"<num>":[{"compound":"SOFT","startLap":int,"endLap":int}]},
-                "pitStops":{"<num>":[{"lap":int,"durationS":float}]}}
+                "pitStops":{"<num>":[{"lap":int,"durationS":float}]},
+                "pedalTraces":{"<num>":{"throttle":[int,...],"brake":[int,...],"gear":[int,...]}}}
   Frame lines: {"timeMs":int, "frame":{"rev":int,"timeMs":int,"cars":[
                  {"driverNum":int,"code":"VER","team":"Red Bull","pos":int,
                   "p":{"x":float,"y":float},"status":"OnTrack"}],
@@ -41,7 +42,7 @@ from pathlib import Path
 from fastf1 import _api
 from radio import extract_radio
 from race_control import extract_race_control
-from ghost import build_lap_trace
+from ghost import build_lap_trace, build_pedal_trace
 from resample import nearest_index, step_value, in_window_ms, reconcile_positions, UNKNOWN_POS, normalise_point
 from live_parsers import TEAM_MAP
 from geometry import (
@@ -278,6 +279,11 @@ print(f"Track outline: {len(track_points)} points")
 # ---------------------------------------------------------------------------
 _outline_xy = [(p['x'], p['y']) for p in track_points]
 lap_traces = {}
+# pedal_traces: driver_num -> {"throttle":[...],"brake":[...],"gear":[...]}, indexed
+# by the same track-outline position as lap_traces (see PedalTrace in model.go).
+# ponytail: RPM omitted (reviews/plans/verify/01-telemetry-overlay.md) — FastF1's
+# car_data isn't sampled for it anywhere else in this file either.
+pedal_traces = {}
 for num in session.drivers:
     inum = int(num)
     if inum not in driver_info:
@@ -298,10 +304,25 @@ for num in session.drivers:
         sample_ts = driver_lap_pos['SessionTime'].dt.total_seconds().tolist()
         sample_xy = [normalise(row['X'], row['Y']) for _, row in driver_lap_pos.iterrows()]
         lap_traces[inum] = build_lap_trace(sample_ts, sample_xy, _outline_xy)
+        try:
+            cd = session.car_data[num]
+            cd_lap = cd[(cd['SessionTime'] >= lap_start) & (cd['SessionTime'] < lap_end)]
+            if len(cd_lap) >= 2:
+                cd_t = cd_lap['SessionTime'].dt.total_seconds().values
+                idx = np.array([nearest_index(cd_t, q) for q in sample_ts])
+                throttle_vals = cd_lap['Throttle'].values[idx].astype(int)
+                brake_vals = (cd_lap['Brake'].values[idx].astype(float) > 0).astype(int) * 100
+                gear_vals = cd_lap['nGear'].values[idx].astype(int)
+                pedal_traces[inum] = build_pedal_trace(
+                    sample_ts, sample_xy, _outline_xy, throttle_vals, brake_vals, gear_vals
+                )
+        except Exception as e:
+            print(f"  Warning: no pedal trace for {num}: {type(e).__name__}: {e}")
     except Exception as e:
         print(f"  Warning: no lap trace for {num}: {type(e).__name__}: {e}")
 
 print(f"Lap traces baked for {len(lap_traces)} drivers")
+print(f"Pedal traces baked for {len(pedal_traces)} drivers")
 
 # ---------------------------------------------------------------------------
 # Derive running order from laps data
@@ -710,6 +731,7 @@ with open(OUTPUT_PATH, 'w', encoding='utf-8') as f:
         "totalLaps": TOTAL_LAPS,
         "stints": stints,
         "pitStops": pit_stops,
+        "pedalTraces": pedal_traces,
     }
     f.write(json.dumps(header, separators=(',', ':')) + '\n')
 
@@ -898,7 +920,12 @@ try:
     for _dn, stop_list in hdr['pitStops'].items():
         for ps in stop_list:
             assert {'lap', 'durationS'} <= set(ps.keys()), f"pit stop missing fields: {ps}"
-    print(f"  Header OK: {len(hdr['track'])} track points, maxRev={hdr['maxRev']}, {len(hdr['radio'])} radio clips, totalLaps={hdr['totalLaps']}, stints for {len(hdr['stints'])} drivers, pitStops for {len(hdr['pitStops'])} drivers")
+    assert 'pedalTraces' in hdr, "header missing 'pedalTraces'"
+    for _dn, pt in hdr['pedalTraces'].items():
+        assert {'throttle', 'brake', 'gear'} <= set(pt.keys()), f"pedal trace missing fields: {pt}"
+        assert len(pt['throttle']) == len(hdr['track']) == len(pt['brake']) == len(pt['gear']), \
+            f"pedal trace length {len(pt['throttle'])} != track length {len(hdr['track'])}"
+    print(f"  Header OK: {len(hdr['track'])} track points, maxRev={hdr['maxRev']}, {len(hdr['radio'])} radio clips, totalLaps={hdr['totalLaps']}, stints for {len(hdr['stints'])} drivers, pitStops for {len(hdr['pitStops'])} drivers, pedalTraces for {len(hdr['pedalTraces'])} drivers")
 except AssertionError as e:
     print(f"  HEADER ERROR: {e}")
     errors += 1

--- a/ingest/record.py
+++ b/ingest/record.py
@@ -5,11 +5,13 @@ Bakes a real F1 session into the contract read by the Go replay player.
 
 CONTRACT (must match internal/model/model.go + web/src/state/race.ts):
   Header line: {"track":[{"x":float,"y":float},...], "label":"...", "maxRev":int,
+                "corners":[{"number":int,"x":float,"y":float},...],
                 "radio":[{"timeMs":int,"driverNum":int,"clip":"https://..."}],
                 "lapTrace":{"<num>":[ms,...]},
                 "stints":{"<num>":[{"compound":"SOFT","startLap":int,"endLap":int}]},
                 "pitStops":{"<num>":[{"lap":int,"durationS":float}]},
-                "pedalTraces":{"<num>":{"throttle":[int,...],"brake":[int,...],"gear":[int,...]}}}
+                "pedalTraces":{"<num>":{"throttle":[int,...],"brake":[int,...],"gear":[int,...]}},
+                "sectorDominance":[driverNum,...]}  # one per fixed-size minisector of "track"
   Frame lines: {"timeMs":int, "frame":{"rev":int,"timeMs":int,"cars":[
                  {"driverNum":int,"code":"VER","team":"Red Bull","pos":int,
                   "p":{"x":float,"y":float},"status":"OnTrack"}],
@@ -35,6 +37,7 @@ import fastf1
 import numpy as np
 import pandas as pd
 import json
+import math
 import sys
 import os
 import argparse
@@ -42,7 +45,7 @@ from pathlib import Path
 from fastf1 import _api
 from radio import extract_radio
 from race_control import extract_race_control
-from ghost import build_lap_trace, build_pedal_trace
+from ghost import build_lap_trace, build_pedal_trace, compute_sector_dominance
 from resample import nearest_index, step_value, in_window_ms, reconcile_positions, UNKNOWN_POS, normalise_point
 from live_parsers import TEAM_MAP
 from geometry import (
@@ -72,6 +75,11 @@ GP_LABEL = _args.label or f"{_args.gp} {_args.year} · Race"
 
 HZ = 10          # target sample rate (frames per second)
 TRACK_POINTS = 150  # number of track outline points
+# Minisector bin size for the sector-dominance heatmap (item 5): TRACK_POINTS / this
+# many minisectors. Mirrored in web/src/components/geometry.ts's MINISECTOR_SIZE —
+# both sides must bin the outline identically for sectorDominance[i] to line up
+# with the frontend's i'th outline segment.
+MINISECTOR_SIZE = 10
 
 # Window: 7.5-min green-flag mid-race window (widened from 2.5 min in Phase 3 so the
 # comms layer has enough team radio to feel alive — see ADR-0003 / Phase 3 spec).
@@ -274,6 +282,25 @@ track_points = [
 print(f"Track outline: {len(track_points)} points")
 
 # ---------------------------------------------------------------------------
+# Track furniture (item 4): corner numbers, baked once from FastF1's circuit
+# info. Start/finish is track_points[0] by convention (the outline's own lap
+# starts at lap_start_t) — no separate field needed.
+# ponytail: DRS zones and a safety-car marker are dropped from this slice
+# (reviews/plans/verify/04-05-map-features.md) — DRS has no session-derived
+# source, and SC needs a track-status field the contract doesn't carry yet.
+# ---------------------------------------------------------------------------
+print("\nFetching circuit info (corners)...")
+corners = []
+try:
+    circuit_info = session.get_circuit_info()
+    for _, row in circuit_info.corners.iterrows():
+        cx, cy = normalise(row['X'], row['Y'])
+        corners.append({"number": int(row['Number']), "x": cx, "y": cy})
+    print(f"Corners: {len(corners)}")
+except Exception as e:
+    print(f"  Warning: circuit info fetch failed ({type(e).__name__}: {e}); clip will have no corners")
+
+# ---------------------------------------------------------------------------
 # Lap traces (Phase 4): per-driver pace curve over the fastest accurate lap.
 # Cumulative ms at each track-outline index, for the cross-year ghost overlay.
 # ---------------------------------------------------------------------------
@@ -323,6 +350,14 @@ for num in session.drivers:
 
 print(f"Lap traces baked for {len(lap_traces)} drivers")
 print(f"Pedal traces baked for {len(pedal_traces)} drivers")
+
+# ---------------------------------------------------------------------------
+# Sector dominance (item 5): fastest driver per fixed-size minisector, reusing
+# the lap_traces already built above (cumulative ms per driver at each outline
+# index) — no extra projection needed.
+# ---------------------------------------------------------------------------
+sector_dominance = compute_sector_dominance(lap_traces, len(track_points), MINISECTOR_SIZE) if lap_traces else []
+print(f"Sector dominance: {len(sector_dominance)} minisectors")
 
 # ---------------------------------------------------------------------------
 # Derive running order from laps data
@@ -724,6 +759,7 @@ with open(OUTPUT_PATH, 'w', encoding='utf-8') as f:
     # --- Header ---
     header = {
         "track": track_points,
+        "corners": corners,
         "label": GP_LABEL,
         "maxRev": max_rev,
         "radio": radio_clips,
@@ -732,6 +768,7 @@ with open(OUTPUT_PATH, 'w', encoding='utf-8') as f:
         "stints": stints,
         "pitStops": pit_stops,
         "pedalTraces": pedal_traces,
+        "sectorDominance": sector_dominance,
     }
     f.write(json.dumps(header, separators=(',', ':')) + '\n')
 
@@ -925,7 +962,15 @@ try:
         assert {'throttle', 'brake', 'gear'} <= set(pt.keys()), f"pedal trace missing fields: {pt}"
         assert len(pt['throttle']) == len(hdr['track']) == len(pt['brake']) == len(pt['gear']), \
             f"pedal trace length {len(pt['throttle'])} != track length {len(hdr['track'])}"
-    print(f"  Header OK: {len(hdr['track'])} track points, maxRev={hdr['maxRev']}, {len(hdr['radio'])} radio clips, totalLaps={hdr['totalLaps']}, stints for {len(hdr['stints'])} drivers, pitStops for {len(hdr['pitStops'])} drivers, pedalTraces for {len(hdr['pedalTraces'])} drivers")
+    assert 'corners' in hdr, "header missing 'corners'"
+    for c in hdr['corners']:
+        assert {'number', 'x', 'y'} <= set(c.keys()), f"corner missing fields: {c}"
+        assert 0 <= c['x'] <= 1 and 0 <= c['y'] <= 1, f"corner out of [0,1]: {c}"
+    assert 'sectorDominance' in hdr, "header missing 'sectorDominance'"
+    expected_bins = math.ceil(len(hdr['track']) / MINISECTOR_SIZE) if hdr['track'] else 0
+    assert len(hdr['sectorDominance']) == expected_bins, \
+        f"sectorDominance length {len(hdr['sectorDominance'])} != expected {expected_bins} bins"
+    print(f"  Header OK: {len(hdr['track'])} track points, maxRev={hdr['maxRev']}, {len(hdr['radio'])} radio clips, totalLaps={hdr['totalLaps']}, stints for {len(hdr['stints'])} drivers, pitStops for {len(hdr['pitStops'])} drivers, pedalTraces for {len(hdr['pedalTraces'])} drivers, {len(hdr['corners'])} corners, {len(hdr['sectorDominance'])} minisectors")
 except AssertionError as e:
     print(f"  HEADER ERROR: {e}")
     errors += 1

--- a/ingest/test_ghost.py
+++ b/ingest/test_ghost.py
@@ -4,7 +4,7 @@ Collectable by pytest (`pytest ingest`) AND runnable directly
 (`python ingest/test_ghost.py`) for the CI contract job.
 """
 import sys
-from ghost import build_lap_trace, build_pedal_trace
+from ghost import build_lap_trace, build_pedal_trace, compute_sector_dominance
 
 
 def test_build_lap_trace_basic():
@@ -82,6 +82,28 @@ def test_build_pedal_trace_carries_unvisited_index_forward():
     assert trace["gear"] == [1, 1, 4], trace
 
 
+def test_compute_sector_dominance_picks_fastest_per_bin():
+    # 4 outline points, bin_size=2 -> 2 bins: [0,2] and [2,3].
+    # Driver 1 is faster in bin 0 (1000ms vs 2000ms), driver 2 faster in bin 1.
+    lap_traces = {
+        1: [0, 1000, 1500, 3500],
+        2: [0, 2000, 2500, 2600],
+    }
+    out = compute_sector_dominance(lap_traces, n_points=4, bin_size=2)
+    assert out == [1, 2], out
+
+
+def test_compute_sector_dominance_no_data_is_zero():
+    assert compute_sector_dominance({}, n_points=4, bin_size=2) == [0, 0]
+
+
+def test_compute_sector_dominance_skips_non_positive_deltas():
+    # Driver 1 never advances in bin 0 (degenerate/unreached) — driver 2 wins by default.
+    lap_traces = {1: [0, 0, 0], 2: [0, 50, 100]}
+    out = compute_sector_dominance(lap_traces, n_points=3, bin_size=2)
+    assert out[0] == 2, out
+
+
 if __name__ == "__main__":
     test_build_lap_trace_basic()
     test_build_lap_trace_empty_input()
@@ -90,5 +112,8 @@ if __name__ == "__main__":
     test_build_pedal_trace_basic()
     test_build_pedal_trace_empty_input()
     test_build_pedal_trace_carries_unvisited_index_forward()
-    print("ghost.build_lap_trace / build_pedal_trace self-check PASSED")
+    test_compute_sector_dominance_picks_fastest_per_bin()
+    test_compute_sector_dominance_no_data_is_zero()
+    test_compute_sector_dominance_skips_non_positive_deltas()
+    print("ghost.build_lap_trace / build_pedal_trace / compute_sector_dominance self-check PASSED")
     sys.exit(0)

--- a/ingest/test_ghost.py
+++ b/ingest/test_ghost.py
@@ -4,7 +4,7 @@ Collectable by pytest (`pytest ingest`) AND runnable directly
 (`python ingest/test_ghost.py`) for the CI contract job.
 """
 import sys
-from ghost import build_lap_trace
+from ghost import build_lap_trace, build_pedal_trace
 
 
 def test_build_lap_trace_basic():
@@ -52,10 +52,43 @@ def test_build_lap_trace_anchors_index_zero_even_when_reached_late():
     assert all(trace3[i] >= trace3[i - 1] for i in range(1, len(trace3))), trace3
 
 
+def test_build_pedal_trace_basic():
+    track = [(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 1.0)]
+    ts = [10.0, 11.0, 12.0, 13.0]
+    xy = [(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 1.0)]
+    throttle = [10, 100, 100, 0]
+    brake = [0, 0, 0, 100]
+    gear = [1, 5, 6, 2]
+
+    trace = build_pedal_trace(ts, xy, track, throttle, brake, gear)
+
+    assert trace["throttle"] == [10, 100, 100, 0], trace
+    assert trace["brake"] == [0, 0, 0, 100], trace
+    assert trace["gear"] == [1, 5, 6, 2], trace
+
+
+def test_build_pedal_trace_empty_input():
+    track = [(0.0, 0.0), (1.0, 0.0)]
+    trace = build_pedal_trace([], [], track, [], [], [])
+    assert trace == {"throttle": [0, 0], "brake": [0, 0], "gear": [0, 0]}, trace
+
+
+def test_build_pedal_trace_carries_unvisited_index_forward():
+    track = [(0.0, 0.0), (0.5, 0.0), (1.0, 0.0)]
+    ts = [0.0, 2.0]
+    xy = [(0.0, 0.0), (1.0, 0.0)]  # midpoint never nearest
+    trace = build_pedal_trace(ts, xy, track, [20, 90], [0, 0], [1, 4])
+    assert trace["throttle"] == [20, 20, 90], trace
+    assert trace["gear"] == [1, 1, 4], trace
+
+
 if __name__ == "__main__":
     test_build_lap_trace_basic()
     test_build_lap_trace_empty_input()
     test_build_lap_trace_carries_unvisited_index_forward()
     test_build_lap_trace_anchors_index_zero_even_when_reached_late()
-    print("ghost.build_lap_trace self-check PASSED")
+    test_build_pedal_trace_basic()
+    test_build_pedal_trace_empty_input()
+    test_build_pedal_trace_carries_unvisited_index_forward()
+    print("ghost.build_lap_trace / build_pedal_trace self-check PASSED")
     sys.exit(0)

--- a/ingest/test_pit.py
+++ b/ingest/test_pit.py
@@ -1,0 +1,76 @@
+"""Unit tests for the pure pit-window / pit-stop derivation in ingest/pit.py."""
+import pandas as pd
+
+from pit import build_pit_data
+
+
+def _laps(rows):
+    """Build a laps-like DataFrame from dicts of LapNumber/PitInTime/PitOutTime/LapStartTime
+    given as plain seconds (float) or None; converted to Timedelta like FastF1 laps."""
+    def td(v):
+        return pd.NaT if v is None else pd.Timedelta(seconds=v)
+
+    return pd.DataFrame([{
+        "LapNumber": r["LapNumber"],
+        "PitInTime": td(r.get("PitInTime")),
+        "PitOutTime": td(r.get("PitOutTime")),
+        "LapStartTime": td(r.get("LapStartTime")),
+    } for r in rows])
+
+
+def test_pit_lane_start_produces_a_window_but_no_stop():
+    # Car starts the race from the pit lane: lap 1 has a PitOutTime but no
+    # PitInTime. The backdated pit_in must flag the pit window but must NOT
+    # be recorded as a pit stop.
+    drv = _laps([
+        {"LapNumber": 1, "LapStartTime": 0.0, "PitOutTime": 25.0},
+        {"LapNumber": 2, "LapStartTime": 90.0},
+        {"LapNumber": 3, "LapStartTime": 180.0},
+    ])
+    windows, stops = build_pit_data(drv)
+    assert windows == [(0.0, 25.0)]
+    assert stops == []
+
+
+def test_real_pit_stop_mid_race_is_recorded():
+    drv = _laps([
+        {"LapNumber": 1, "LapStartTime": 0.0},
+        {"LapNumber": 10, "LapStartTime": 900.0, "PitInTime": 905.0},
+        {"LapNumber": 11, "LapStartTime": 930.0, "PitOutTime": 927.0},
+    ])
+    windows, stops = build_pit_data(drv)
+    assert windows == [(905.0, 927.0)]
+    assert stops == [{"lap": 10, "durationS": 22.0}]
+
+
+def test_pit_lane_start_followed_by_a_real_stop_records_only_the_real_one():
+    drv = _laps([
+        {"LapNumber": 1, "LapStartTime": 0.0, "PitOutTime": 25.0},
+        {"LapNumber": 20, "LapStartTime": 1800.0, "PitInTime": 1805.0},
+        {"LapNumber": 21, "LapStartTime": 1830.0, "PitOutTime": 1827.0},
+    ])
+    windows, stops = build_pit_data(drv)
+    assert windows == [(0.0, 25.0), (1805.0, 1827.0)]
+    assert stops == [{"lap": 20, "durationS": 22.0}]
+
+
+def test_no_pit_activity_yields_empty_windows_and_stops():
+    drv = _laps([
+        {"LapNumber": 1, "LapStartTime": 0.0},
+        {"LapNumber": 2, "LapStartTime": 90.0},
+    ])
+    windows, stops = build_pit_data(drv)
+    assert windows == []
+    assert stops == []
+
+
+def test_unfinished_stop_at_end_of_data_assumes_typical_duration_no_lap_dropped():
+    # PitInTime seen but no matching PitOutTime anywhere after (rare edge —
+    # session ended mid-stop). Still recorded as a real stop since a real
+    # PitInTime existed.
+    drv = _laps([
+        {"LapNumber": 5, "LapStartTime": 400.0, "PitInTime": 405.0},
+    ])
+    windows, stops = build_pit_data(drv)
+    assert windows == [(405.0, 435.0)]
+    assert stops == [{"lap": 5, "durationS": 30.0}]

--- a/ingest/test_pit.py
+++ b/ingest/test_pit.py
@@ -1,7 +1,13 @@
-"""Unit tests for the pure pit-window / pit-stop derivation in ingest/pit.py."""
-import pandas as pd
+"""Unit tests for the pure pit-window / pit-stop derivation in ingest/pit.py.
 
-from pit import build_pit_data
+Needs pandas (to build laps-like DataFrames), which CI's fastf1-free contract
+job doesn't install — skip cleanly there, run for real wherever pandas exists.
+"""
+import pytest
+
+pd = pytest.importorskip("pandas", reason="needs pandas for laps DataFrames; not installed in the fastf1-free contract job")
+
+from pit import build_pit_data  # noqa: E402
 
 
 def _laps(rows):

--- a/internal/app/writer.go
+++ b/internal/app/writer.go
@@ -16,12 +16,14 @@ import (
 type Source interface {
 	Events(ctx context.Context) (<-chan model.Frame, error)
 	Track() []model.Point
+	Corners() []model.Corner
 	Radio() []model.RadioMessage
 	LapTrace() map[int][]int
 	TotalLaps() int
 	Stints() map[int][]model.Stint
 	PitStops() map[int][]model.PitStop
 	PedalTraces() map[int]model.PedalTrace
+	SectorDominance() []int
 	Label() string
 	Mode() string
 }
@@ -58,12 +60,14 @@ func (wr *Writer) Run(ctx context.Context, session string) error {
 	}
 	snap := model.NewSnapshot(session, wr.src.Mode(), wr.src.Label())
 	snap.Track = wr.src.Track()
+	snap.Corners = wr.src.Corners()
 	snap.Radio = wr.src.Radio()
 	snap.LapTrace = wr.src.LapTrace()
 	snap.TotalLaps = wr.src.TotalLaps()
 	snap.Stints = wr.src.Stints()
 	snap.PitStops = wr.src.PitStops()
 	snap.PedalTraces = wr.src.PedalTraces()
+	snap.SectorDominance = wr.src.SectorDominance()
 	snap.Rev = base
 	rev := base
 	for {

--- a/internal/app/writer.go
+++ b/internal/app/writer.go
@@ -20,6 +20,7 @@ type Source interface {
 	LapTrace() map[int][]int
 	TotalLaps() int
 	Stints() map[int][]model.Stint
+	PitStops() map[int][]model.PitStop
 	Label() string
 	Mode() string
 }
@@ -60,6 +61,7 @@ func (wr *Writer) Run(ctx context.Context, session string) error {
 	snap.LapTrace = wr.src.LapTrace()
 	snap.TotalLaps = wr.src.TotalLaps()
 	snap.Stints = wr.src.Stints()
+	snap.PitStops = wr.src.PitStops()
 	snap.Rev = base
 	rev := base
 	for {

--- a/internal/app/writer.go
+++ b/internal/app/writer.go
@@ -21,6 +21,7 @@ type Source interface {
 	TotalLaps() int
 	Stints() map[int][]model.Stint
 	PitStops() map[int][]model.PitStop
+	PedalTraces() map[int]model.PedalTrace
 	Label() string
 	Mode() string
 }
@@ -62,6 +63,7 @@ func (wr *Writer) Run(ctx context.Context, session string) error {
 	snap.TotalLaps = wr.src.TotalLaps()
 	snap.Stints = wr.src.Stints()
 	snap.PitStops = wr.src.PitStops()
+	snap.PedalTraces = wr.src.PedalTraces()
 	snap.Rev = base
 	rev := base
 	for {

--- a/internal/app/writer_test.go
+++ b/internal/app/writer_test.go
@@ -23,12 +23,14 @@ type fakeSource struct {
 }
 
 func (f *fakeSource) Track() []model.Point                  { return []model.Point{{X: 0, Y: 0}} }
+func (f *fakeSource) Corners() []model.Corner               { return nil }
 func (f *fakeSource) Radio() []model.RadioMessage           { return nil }
 func (f *fakeSource) LapTrace() map[int][]int               { return nil }
 func (f *fakeSource) TotalLaps() int                        { return 0 }
 func (f *fakeSource) Stints() map[int][]model.Stint         { return f.stints }
 func (f *fakeSource) PitStops() map[int][]model.PitStop     { return nil }
 func (f *fakeSource) PedalTraces() map[int]model.PedalTrace { return nil }
+func (f *fakeSource) SectorDominance() []int                { return nil }
 func (f *fakeSource) Label() string                         { return "Fake" }
 func (f *fakeSource) Mode() string                          { return "replay" }
 func (f *fakeSource) Events(ctx context.Context) (<-chan model.Frame, error) {
@@ -52,12 +54,14 @@ func (f *fakeSource) Events(ctx context.Context) (<-chan model.Frame, error) {
 type closingSource struct{ frames []model.Frame }
 
 func (closingSource) Track() []model.Point                  { return nil }
+func (closingSource) Corners() []model.Corner               { return nil }
 func (closingSource) Radio() []model.RadioMessage           { return nil }
 func (closingSource) LapTrace() map[int][]int               { return nil }
 func (closingSource) TotalLaps() int                        { return 0 }
 func (closingSource) Stints() map[int][]model.Stint         { return nil }
 func (closingSource) PitStops() map[int][]model.PitStop     { return nil }
 func (closingSource) PedalTraces() map[int]model.PedalTrace { return nil }
+func (closingSource) SectorDominance() []int                { return nil }
 func (closingSource) Label() string                         { return "Closing" }
 func (closingSource) Mode() string                          { return "replay" }
 func (s closingSource) Events(ctx context.Context) (<-chan model.Frame, error) {

--- a/internal/app/writer_test.go
+++ b/internal/app/writer_test.go
@@ -22,14 +22,15 @@ type fakeSource struct {
 	stints map[int][]model.Stint
 }
 
-func (f *fakeSource) Track() []model.Point              { return []model.Point{{X: 0, Y: 0}} }
-func (f *fakeSource) Radio() []model.RadioMessage       { return nil }
-func (f *fakeSource) LapTrace() map[int][]int           { return nil }
-func (f *fakeSource) TotalLaps() int                    { return 0 }
-func (f *fakeSource) Stints() map[int][]model.Stint     { return f.stints }
-func (f *fakeSource) PitStops() map[int][]model.PitStop { return nil }
-func (f *fakeSource) Label() string                     { return "Fake" }
-func (f *fakeSource) Mode() string                      { return "replay" }
+func (f *fakeSource) Track() []model.Point                  { return []model.Point{{X: 0, Y: 0}} }
+func (f *fakeSource) Radio() []model.RadioMessage           { return nil }
+func (f *fakeSource) LapTrace() map[int][]int               { return nil }
+func (f *fakeSource) TotalLaps() int                        { return 0 }
+func (f *fakeSource) Stints() map[int][]model.Stint         { return f.stints }
+func (f *fakeSource) PitStops() map[int][]model.PitStop     { return nil }
+func (f *fakeSource) PedalTraces() map[int]model.PedalTrace { return nil }
+func (f *fakeSource) Label() string                         { return "Fake" }
+func (f *fakeSource) Mode() string                          { return "replay" }
 func (f *fakeSource) Events(ctx context.Context) (<-chan model.Frame, error) {
 	ch := make(chan model.Frame)
 	go func() {
@@ -50,14 +51,15 @@ func (f *fakeSource) Events(ctx context.Context) (<-chan model.Frame, error) {
 // blocks on ctx after emitting) — exercising Writer.Run's frames-channel-closed branch.
 type closingSource struct{ frames []model.Frame }
 
-func (closingSource) Track() []model.Point              { return nil }
-func (closingSource) Radio() []model.RadioMessage       { return nil }
-func (closingSource) LapTrace() map[int][]int           { return nil }
-func (closingSource) TotalLaps() int                    { return 0 }
-func (closingSource) Stints() map[int][]model.Stint     { return nil }
-func (closingSource) PitStops() map[int][]model.PitStop { return nil }
-func (closingSource) Label() string                     { return "Closing" }
-func (closingSource) Mode() string                      { return "replay" }
+func (closingSource) Track() []model.Point                  { return nil }
+func (closingSource) Radio() []model.RadioMessage           { return nil }
+func (closingSource) LapTrace() map[int][]int               { return nil }
+func (closingSource) TotalLaps() int                        { return 0 }
+func (closingSource) Stints() map[int][]model.Stint         { return nil }
+func (closingSource) PitStops() map[int][]model.PitStop     { return nil }
+func (closingSource) PedalTraces() map[int]model.PedalTrace { return nil }
+func (closingSource) Label() string                         { return "Closing" }
+func (closingSource) Mode() string                          { return "replay" }
 func (s closingSource) Events(ctx context.Context) (<-chan model.Frame, error) {
 	ch := make(chan model.Frame)
 	go func() {

--- a/internal/app/writer_test.go
+++ b/internal/app/writer_test.go
@@ -22,13 +22,14 @@ type fakeSource struct {
 	stints map[int][]model.Stint
 }
 
-func (f *fakeSource) Track() []model.Point          { return []model.Point{{X: 0, Y: 0}} }
-func (f *fakeSource) Radio() []model.RadioMessage   { return nil }
-func (f *fakeSource) LapTrace() map[int][]int       { return nil }
-func (f *fakeSource) TotalLaps() int                { return 0 }
-func (f *fakeSource) Stints() map[int][]model.Stint { return f.stints }
-func (f *fakeSource) Label() string                 { return "Fake" }
-func (f *fakeSource) Mode() string                  { return "replay" }
+func (f *fakeSource) Track() []model.Point              { return []model.Point{{X: 0, Y: 0}} }
+func (f *fakeSource) Radio() []model.RadioMessage       { return nil }
+func (f *fakeSource) LapTrace() map[int][]int           { return nil }
+func (f *fakeSource) TotalLaps() int                    { return 0 }
+func (f *fakeSource) Stints() map[int][]model.Stint     { return f.stints }
+func (f *fakeSource) PitStops() map[int][]model.PitStop { return nil }
+func (f *fakeSource) Label() string                     { return "Fake" }
+func (f *fakeSource) Mode() string                      { return "replay" }
 func (f *fakeSource) Events(ctx context.Context) (<-chan model.Frame, error) {
 	ch := make(chan model.Frame)
 	go func() {
@@ -49,13 +50,14 @@ func (f *fakeSource) Events(ctx context.Context) (<-chan model.Frame, error) {
 // blocks on ctx after emitting) — exercising Writer.Run's frames-channel-closed branch.
 type closingSource struct{ frames []model.Frame }
 
-func (closingSource) Track() []model.Point          { return nil }
-func (closingSource) Radio() []model.RadioMessage   { return nil }
-func (closingSource) LapTrace() map[int][]int       { return nil }
-func (closingSource) TotalLaps() int                { return 0 }
-func (closingSource) Stints() map[int][]model.Stint { return nil }
-func (closingSource) Label() string                 { return "Closing" }
-func (closingSource) Mode() string                  { return "replay" }
+func (closingSource) Track() []model.Point              { return nil }
+func (closingSource) Radio() []model.RadioMessage       { return nil }
+func (closingSource) LapTrace() map[int][]int           { return nil }
+func (closingSource) TotalLaps() int                    { return 0 }
+func (closingSource) Stints() map[int][]model.Stint     { return nil }
+func (closingSource) PitStops() map[int][]model.PitStop { return nil }
+func (closingSource) Label() string                     { return "Closing" }
+func (closingSource) Mode() string                      { return "replay" }
 func (s closingSource) Events(ctx context.Context) (<-chan model.Frame, error) {
 	ch := make(chan model.Frame)
 	go func() {

--- a/internal/feed/replay/play.go
+++ b/internal/feed/replay/play.go
@@ -16,15 +16,17 @@ import (
 )
 
 type clipHeader struct {
-	Track       []model.Point            `json:"track"`
-	Label       string                   `json:"label"`
-	MaxRev      int64                    `json:"maxRev"`
-	Radio       []model.RadioMessage     `json:"radio"`
-	LapTrace    map[int][]int            `json:"lapTrace"`
-	TotalLaps   int                      `json:"totalLaps"`
-	Stints      map[int][]model.Stint    `json:"stints"`
-	PitStops    map[int][]model.PitStop  `json:"pitStops"`
-	PedalTraces map[int]model.PedalTrace `json:"pedalTraces"`
+	Track           []model.Point            `json:"track"`
+	Corners         []model.Corner           `json:"corners"`
+	Label           string                   `json:"label"`
+	MaxRev          int64                    `json:"maxRev"`
+	Radio           []model.RadioMessage     `json:"radio"`
+	LapTrace        map[int][]int            `json:"lapTrace"`
+	TotalLaps       int                      `json:"totalLaps"`
+	Stints          map[int][]model.Stint    `json:"stints"`
+	PitStops        map[int][]model.PitStop  `json:"pitStops"`
+	PedalTraces     map[int]model.PedalTrace `json:"pedalTraces"`
+	SectorDominance []int                    `json:"sectorDominance"`
 }
 
 type clipLine struct {
@@ -33,17 +35,19 @@ type clipLine struct {
 }
 
 type Source struct {
-	track       []model.Point
-	radio       []model.RadioMessage
-	lapTrace    map[int][]int
-	totalLaps   int
-	stints      map[int][]model.Stint
-	pitStops    map[int][]model.PitStop
-	pedalTraces map[int]model.PedalTrace
-	label       string
-	lines       []clipLine
-	max         int64
-	speed       float64
+	track           []model.Point
+	corners         []model.Corner
+	radio           []model.RadioMessage
+	lapTrace        map[int][]int
+	totalLaps       int
+	stints          map[int][]model.Stint
+	pitStops        map[int][]model.PitStop
+	pedalTraces     map[int]model.PedalTrace
+	sectorDominance []int
+	label           string
+	lines           []clipLine
+	max             int64
+	speed           float64
 
 	phaseWallclock bool // when true, loop position is derived from the wall clock (M4 compare)
 }
@@ -93,19 +97,21 @@ func Load(path string, speed float64) (*Source, error) {
 		hdr.MaxRev = lines[len(lines)-1].Frame.Rev
 	}
 	return &Source{
-		track: hdr.Track, radio: hdr.Radio, lapTrace: hdr.LapTrace, totalLaps: hdr.TotalLaps,
-		stints: hdr.Stints, pitStops: hdr.PitStops, pedalTraces: hdr.PedalTraces,
+		track: hdr.Track, corners: hdr.Corners, radio: hdr.Radio, lapTrace: hdr.LapTrace, totalLaps: hdr.TotalLaps,
+		stints: hdr.Stints, pitStops: hdr.PitStops, pedalTraces: hdr.PedalTraces, sectorDominance: hdr.SectorDominance,
 		label: hdr.Label, lines: lines, max: hdr.MaxRev, speed: speed,
 	}, nil
 }
 
 func (s *Source) Track() []model.Point                  { return s.track }
+func (s *Source) Corners() []model.Corner               { return s.corners }
 func (s *Source) Radio() []model.RadioMessage           { return s.radio }
 func (s *Source) LapTrace() map[int][]int               { return s.lapTrace }
 func (s *Source) TotalLaps() int                        { return s.totalLaps }
 func (s *Source) Stints() map[int][]model.Stint         { return s.stints }
 func (s *Source) PitStops() map[int][]model.PitStop     { return s.pitStops }
 func (s *Source) PedalTraces() map[int]model.PedalTrace { return s.pedalTraces }
+func (s *Source) SectorDominance() []int                { return s.sectorDominance }
 func (s *Source) Label() string                         { return s.label }
 func (s *Source) Mode() string                          { return "replay" }
 

--- a/internal/feed/replay/play.go
+++ b/internal/feed/replay/play.go
@@ -16,14 +16,15 @@ import (
 )
 
 type clipHeader struct {
-	Track     []model.Point           `json:"track"`
-	Label     string                  `json:"label"`
-	MaxRev    int64                   `json:"maxRev"`
-	Radio     []model.RadioMessage    `json:"radio"`
-	LapTrace  map[int][]int           `json:"lapTrace"`
-	TotalLaps int                     `json:"totalLaps"`
-	Stints    map[int][]model.Stint   `json:"stints"`
-	PitStops  map[int][]model.PitStop `json:"pitStops"`
+	Track       []model.Point            `json:"track"`
+	Label       string                   `json:"label"`
+	MaxRev      int64                    `json:"maxRev"`
+	Radio       []model.RadioMessage     `json:"radio"`
+	LapTrace    map[int][]int            `json:"lapTrace"`
+	TotalLaps   int                      `json:"totalLaps"`
+	Stints      map[int][]model.Stint    `json:"stints"`
+	PitStops    map[int][]model.PitStop  `json:"pitStops"`
+	PedalTraces map[int]model.PedalTrace `json:"pedalTraces"`
 }
 
 type clipLine struct {
@@ -32,16 +33,17 @@ type clipLine struct {
 }
 
 type Source struct {
-	track     []model.Point
-	radio     []model.RadioMessage
-	lapTrace  map[int][]int
-	totalLaps int
-	stints    map[int][]model.Stint
-	pitStops  map[int][]model.PitStop
-	label     string
-	lines     []clipLine
-	max       int64
-	speed     float64
+	track       []model.Point
+	radio       []model.RadioMessage
+	lapTrace    map[int][]int
+	totalLaps   int
+	stints      map[int][]model.Stint
+	pitStops    map[int][]model.PitStop
+	pedalTraces map[int]model.PedalTrace
+	label       string
+	lines       []clipLine
+	max         int64
+	speed       float64
 
 	phaseWallclock bool // when true, loop position is derived from the wall clock (M4 compare)
 }
@@ -92,18 +94,20 @@ func Load(path string, speed float64) (*Source, error) {
 	}
 	return &Source{
 		track: hdr.Track, radio: hdr.Radio, lapTrace: hdr.LapTrace, totalLaps: hdr.TotalLaps,
-		stints: hdr.Stints, pitStops: hdr.PitStops, label: hdr.Label, lines: lines, max: hdr.MaxRev, speed: speed,
+		stints: hdr.Stints, pitStops: hdr.PitStops, pedalTraces: hdr.PedalTraces,
+		label: hdr.Label, lines: lines, max: hdr.MaxRev, speed: speed,
 	}, nil
 }
 
-func (s *Source) Track() []model.Point              { return s.track }
-func (s *Source) Radio() []model.RadioMessage       { return s.radio }
-func (s *Source) LapTrace() map[int][]int           { return s.lapTrace }
-func (s *Source) TotalLaps() int                    { return s.totalLaps }
-func (s *Source) Stints() map[int][]model.Stint     { return s.stints }
-func (s *Source) PitStops() map[int][]model.PitStop { return s.pitStops }
-func (s *Source) Label() string                     { return s.label }
-func (s *Source) Mode() string                      { return "replay" }
+func (s *Source) Track() []model.Point                  { return s.track }
+func (s *Source) Radio() []model.RadioMessage           { return s.radio }
+func (s *Source) LapTrace() map[int][]int               { return s.lapTrace }
+func (s *Source) TotalLaps() int                        { return s.totalLaps }
+func (s *Source) Stints() map[int][]model.Stint         { return s.stints }
+func (s *Source) PitStops() map[int][]model.PitStop     { return s.pitStops }
+func (s *Source) PedalTraces() map[int]model.PedalTrace { return s.pedalTraces }
+func (s *Source) Label() string                         { return s.label }
+func (s *Source) Mode() string                          { return "replay" }
 
 // Frames returns every frame in the clip, in file order, with each frame's Rev
 // exactly as recorded in the file (advisory — a caller publishing to a fresh

--- a/internal/feed/replay/play.go
+++ b/internal/feed/replay/play.go
@@ -16,13 +16,14 @@ import (
 )
 
 type clipHeader struct {
-	Track     []model.Point         `json:"track"`
-	Label     string                `json:"label"`
-	MaxRev    int64                 `json:"maxRev"`
-	Radio     []model.RadioMessage  `json:"radio"`
-	LapTrace  map[int][]int         `json:"lapTrace"`
-	TotalLaps int                   `json:"totalLaps"`
-	Stints    map[int][]model.Stint `json:"stints"`
+	Track     []model.Point           `json:"track"`
+	Label     string                  `json:"label"`
+	MaxRev    int64                   `json:"maxRev"`
+	Radio     []model.RadioMessage    `json:"radio"`
+	LapTrace  map[int][]int           `json:"lapTrace"`
+	TotalLaps int                     `json:"totalLaps"`
+	Stints    map[int][]model.Stint   `json:"stints"`
+	PitStops  map[int][]model.PitStop `json:"pitStops"`
 }
 
 type clipLine struct {
@@ -36,6 +37,7 @@ type Source struct {
 	lapTrace  map[int][]int
 	totalLaps int
 	stints    map[int][]model.Stint
+	pitStops  map[int][]model.PitStop
 	label     string
 	lines     []clipLine
 	max       int64
@@ -90,17 +92,18 @@ func Load(path string, speed float64) (*Source, error) {
 	}
 	return &Source{
 		track: hdr.Track, radio: hdr.Radio, lapTrace: hdr.LapTrace, totalLaps: hdr.TotalLaps,
-		stints: hdr.Stints, label: hdr.Label, lines: lines, max: hdr.MaxRev, speed: speed,
+		stints: hdr.Stints, pitStops: hdr.PitStops, label: hdr.Label, lines: lines, max: hdr.MaxRev, speed: speed,
 	}, nil
 }
 
-func (s *Source) Track() []model.Point          { return s.track }
-func (s *Source) Radio() []model.RadioMessage   { return s.radio }
-func (s *Source) LapTrace() map[int][]int       { return s.lapTrace }
-func (s *Source) TotalLaps() int                { return s.totalLaps }
-func (s *Source) Stints() map[int][]model.Stint { return s.stints }
-func (s *Source) Label() string                 { return s.label }
-func (s *Source) Mode() string                  { return "replay" }
+func (s *Source) Track() []model.Point              { return s.track }
+func (s *Source) Radio() []model.RadioMessage       { return s.radio }
+func (s *Source) LapTrace() map[int][]int           { return s.lapTrace }
+func (s *Source) TotalLaps() int                    { return s.totalLaps }
+func (s *Source) Stints() map[int][]model.Stint     { return s.stints }
+func (s *Source) PitStops() map[int][]model.PitStop { return s.pitStops }
+func (s *Source) Label() string                     { return s.label }
+func (s *Source) Mode() string                      { return "replay" }
 
 // Frames returns every frame in the clip, in file order, with each frame's Rev
 // exactly as recorded in the file (advisory — a caller publishing to a fresh

--- a/internal/model/contract_test.go
+++ b/internal/model/contract_test.go
@@ -70,6 +70,9 @@ func TestGoldenSnapshotContract(t *testing.T) {
 	if len(s.Stints[1]) != 2 || s.Stints[1][1].Compound != "HARD" || s.Stints[1][1].StartLap != 15 {
 		t.Fatalf("stints mismatched: %+v", s.Stints)
 	}
+	if len(s.PitStops[1]) != 1 || s.PitStops[1][0].Lap != 14 || s.PitStops[1][0].DurationS != 23.4 {
+		t.Fatalf("pitStops mismatched: %+v", s.PitStops)
+	}
 	if s.Weather == nil || s.Weather.TrackTempC != 41.2 || s.Weather.AirTempC != 28.5 || s.Weather.Rainfall {
 		t.Fatalf("weather mismatched: %+v", s.Weather)
 	}

--- a/internal/model/contract_test.go
+++ b/internal/model/contract_test.go
@@ -73,6 +73,10 @@ func TestGoldenSnapshotContract(t *testing.T) {
 	if len(s.PitStops[1]) != 1 || s.PitStops[1][0].Lap != 14 || s.PitStops[1][0].DurationS != 23.4 {
 		t.Fatalf("pitStops mismatched: %+v", s.PitStops)
 	}
+	pt := s.PedalTraces[1]
+	if len(pt.Throttle) != 4 || pt.Throttle[2] != 100 || len(pt.Brake) != 4 || pt.Brake[1] != 60 || len(pt.Gear) != 4 || pt.Gear[3] != 7 {
+		t.Fatalf("pedalTraces mismatched: %+v", pt)
+	}
 	if s.Weather == nil || s.Weather.TrackTempC != 41.2 || s.Weather.AirTempC != 28.5 || s.Weather.Rainfall {
 		t.Fatalf("weather mismatched: %+v", s.Weather)
 	}

--- a/internal/model/contract_test.go
+++ b/internal/model/contract_test.go
@@ -36,6 +36,9 @@ func TestGoldenSnapshotContract(t *testing.T) {
 	if len(s.Track) != 2 || s.Track[1].X != 0.9 {
 		t.Fatalf("track mismatched: %+v", s.Track)
 	}
+	if len(s.Corners) != 1 || s.Corners[0].Number != 1 || s.Corners[0].X != 0.1 || s.Corners[0].Y != 0.2 {
+		t.Fatalf("corners mismatched: %+v", s.Corners)
+	}
 
 	if len(s.Cars) != 2 {
 		t.Fatalf("want 2 cars, got %d: %+v", len(s.Cars), s.Cars)
@@ -76,6 +79,9 @@ func TestGoldenSnapshotContract(t *testing.T) {
 	pt := s.PedalTraces[1]
 	if len(pt.Throttle) != 4 || pt.Throttle[2] != 100 || len(pt.Brake) != 4 || pt.Brake[1] != 60 || len(pt.Gear) != 4 || pt.Gear[3] != 7 {
 		t.Fatalf("pedalTraces mismatched: %+v", pt)
+	}
+	if len(s.SectorDominance) != 1 || s.SectorDominance[0] != 1 {
+		t.Fatalf("sectorDominance mismatched: %+v", s.SectorDominance)
 	}
 	if s.Weather == nil || s.Weather.TrackTempC != 41.2 || s.Weather.AirTempC != 28.5 || s.Weather.Rainfall {
 		t.Fatalf("weather mismatched: %+v", s.Weather)

--- a/internal/model/contract_test.go
+++ b/internal/model/contract_test.go
@@ -36,7 +36,7 @@ func TestGoldenSnapshotContract(t *testing.T) {
 	if len(s.Track) != 2 || s.Track[1].X != 0.9 {
 		t.Fatalf("track mismatched: %+v", s.Track)
 	}
-	if len(s.Corners) != 1 || s.Corners[0].Number != 1 || s.Corners[0].X != 0.1 || s.Corners[0].Y != 0.2 {
+	if len(s.Corners) != 1 || s.Corners[0].Number != 1 || s.Corners[0].X != 0.1 || s.Corners[0].Y != 0.2 || s.Corners[0].Letter != "A" {
 		t.Fatalf("corners mismatched: %+v", s.Corners)
 	}
 

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -76,6 +76,18 @@ type PitStop struct {
 	DurationS float64 `json:"durationS"`
 }
 
+// PedalTrace is one driver's throttle/brake/gear over a reference lap, indexed
+// by the same track-outline position used by LapTrace (session-constant, baked
+// once). Each array has length len(Snapshot.Track); index i is "at track point
+// i", giving the same distance axis LapTrace already uses — no separate
+// distance field needed. ponytail: RPM omitted (reviews/plans/verify/01-...md)
+// — not sampled by ingest today; a fast-follow can add it as a fourth array.
+type PedalTrace struct {
+	Throttle []int `json:"throttle"` // 0-100
+	Brake    []int `json:"brake"`    // 0-100
+	Gear     []int `json:"gear"`
+}
+
 // Weather is a low-rate sample (~1/min at bake). Rides on a frame when it
 // changes; folded into the snapshot by Apply.
 type Weather struct {
@@ -93,20 +105,21 @@ const (
 )
 
 type Snapshot struct {
-	SessionKey string               `json:"session"`
-	Mode       Mode                 `json:"mode"`
-	Label      string               `json:"label"` // "Synthetic · Demo"
-	Track      []Point              `json:"track,omitempty"`
-	Cars       map[int]CarState     `json:"cars"` // marshals with string keys (JSON has no int keys); see web/src/state/race.ts's mirroring Record<number, Car>
-	Messages   []RaceControlMessage `json:"messages,omitempty"`
-	Radio      []RadioMessage       `json:"radio,omitempty"`
-	LapTrace   map[int][]int        `json:"lapTrace,omitempty"`
-	TotalLaps  int                  `json:"totalLaps,omitempty"` // session-constant race distance
-	Stints     map[int][]Stint      `json:"stints,omitempty"`    // session-constant, like LapTrace
-	PitStops   map[int][]PitStop    `json:"pitStops,omitempty"`  // session-constant, like Stints
-	Weather    *Weather             `json:"weather,omitempty"`
-	TimeMs     int64                `json:"timeMs"`
-	Rev        int64                `json:"rev"`
+	SessionKey  string               `json:"session"`
+	Mode        Mode                 `json:"mode"`
+	Label       string               `json:"label"` // "Synthetic · Demo"
+	Track       []Point              `json:"track,omitempty"`
+	Cars        map[int]CarState     `json:"cars"` // marshals with string keys (JSON has no int keys); see web/src/state/race.ts's mirroring Record<number, Car>
+	Messages    []RaceControlMessage `json:"messages,omitempty"`
+	Radio       []RadioMessage       `json:"radio,omitempty"`
+	LapTrace    map[int][]int        `json:"lapTrace,omitempty"`
+	TotalLaps   int                  `json:"totalLaps,omitempty"`   // session-constant race distance
+	Stints      map[int][]Stint      `json:"stints,omitempty"`      // session-constant, like LapTrace
+	PitStops    map[int][]PitStop    `json:"pitStops,omitempty"`    // session-constant, like Stints
+	PedalTraces map[int]PedalTrace   `json:"pedalTraces,omitempty"` // session-constant, like LapTrace
+	Weather     *Weather             `json:"weather,omitempty"`
+	TimeMs      int64                `json:"timeMs"`
+	Rev         int64                `json:"rev"`
 }
 
 type Frame struct {

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -67,6 +67,15 @@ type Stint struct {
 	EndLap   int    `json:"endLap"`
 }
 
+// PitStop is one pit-lane stop, duration-only for now (session-constant, like Stint).
+// ponytail: positions-gained/lost and stationary time are out of scope for this
+// slice (reviews/plans/verify/02-pit-stops.md) — a fast-follow can add fields here
+// once the running-order-at-time helper exists.
+type PitStop struct {
+	Lap       int     `json:"lap"`
+	DurationS float64 `json:"durationS"`
+}
+
 // Weather is a low-rate sample (~1/min at bake). Rides on a frame when it
 // changes; folded into the snapshot by Apply.
 type Weather struct {
@@ -94,6 +103,7 @@ type Snapshot struct {
 	LapTrace   map[int][]int        `json:"lapTrace,omitempty"`
 	TotalLaps  int                  `json:"totalLaps,omitempty"` // session-constant race distance
 	Stints     map[int][]Stint      `json:"stints,omitempty"`    // session-constant, like LapTrace
+	PitStops   map[int][]PitStop    `json:"pitStops,omitempty"`  // session-constant, like Stints
 	Weather    *Weather             `json:"weather,omitempty"`
 	TimeMs     int64                `json:"timeMs"`
 	Rev        int64                `json:"rev"`

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -88,6 +88,17 @@ type PedalTrace struct {
 	Gear     []int `json:"gear"`
 }
 
+// Corner is one circuit-corner label, baked once from FastF1's circuit info
+// (session-constant, like Track; same normalised [0,1] space).
+// ponytail: DRS zones and a safety-car marker are deliberately dropped from
+// this "track furniture" slice (reviews/plans/verify/04-05-map-features.md) —
+// DRS zones have no session-derived source, and SC needs a track-status field
+// that doesn't exist on the contract today.
+type Corner struct {
+	Number int `json:"number"`
+	Point
+}
+
 // Weather is a low-rate sample (~1/min at bake). Rides on a frame when it
 // changes; folded into the snapshot by Apply.
 type Weather struct {
@@ -109,7 +120,8 @@ type Snapshot struct {
 	Mode        Mode                 `json:"mode"`
 	Label       string               `json:"label"` // "Synthetic · Demo"
 	Track       []Point              `json:"track,omitempty"`
-	Cars        map[int]CarState     `json:"cars"` // marshals with string keys (JSON has no int keys); see web/src/state/race.ts's mirroring Record<number, Car>
+	Corners     []Corner             `json:"corners,omitempty"` // session-constant, like Track
+	Cars        map[int]CarState     `json:"cars"`              // marshals with string keys (JSON has no int keys); see web/src/state/race.ts's mirroring Record<number, Car>
 	Messages    []RaceControlMessage `json:"messages,omitempty"`
 	Radio       []RadioMessage       `json:"radio,omitempty"`
 	LapTrace    map[int][]int        `json:"lapTrace,omitempty"`
@@ -117,9 +129,14 @@ type Snapshot struct {
 	Stints      map[int][]Stint      `json:"stints,omitempty"`      // session-constant, like LapTrace
 	PitStops    map[int][]PitStop    `json:"pitStops,omitempty"`    // session-constant, like Stints
 	PedalTraces map[int]PedalTrace   `json:"pedalTraces,omitempty"` // session-constant, like LapTrace
-	Weather     *Weather             `json:"weather,omitempty"`
-	TimeMs      int64                `json:"timeMs"`
-	Rev         int64                `json:"rev"`
+	// SectorDominance is the fastest driver's number through each fixed-size
+	// minisector of Track (bin size mirrored in ingest/ghost.py and
+	// web/src/components/geometry.ts's MINISECTOR_SIZE); 0 means no driver had
+	// positive time recorded for that bin. Session-constant, like Track.
+	SectorDominance []int    `json:"sectorDominance,omitempty"`
+	Weather         *Weather `json:"weather,omitempty"`
+	TimeMs          int64    `json:"timeMs"`
+	Rev             int64    `json:"rev"`
 }
 
 type Frame struct {

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -97,6 +97,10 @@ type PedalTrace struct {
 type Corner struct {
 	Number int `json:"number"`
 	Point
+	// Letter distinguishes sub-corners sharing a number (e.g. "10A"/"10B"),
+	// baked from FastF1's circuit_info Letter column. Empty when FastF1 has
+	// no letter for this corner.
+	Letter string `json:"letter,omitempty"`
 }
 
 // Weather is a low-rate sample (~1/min at bake). Rides on a frame when it

--- a/testdata/contract/golden_snapshot.json
+++ b/testdata/contract/golden_snapshot.json
@@ -3,6 +3,7 @@
   "mode": "replay",
   "label": "Contract Fixture",
   "track": [{"x": 0.1, "y": 0.2}, {"x": 0.9, "y": 0.8}],
+  "corners": [{"number": 1, "x": 0.1, "y": 0.2}],
   "cars": {
     "1": {
       "driverNum": 1, "code": "VER", "team": "Red Bull", "pos": 1, "lap": 12,
@@ -43,6 +44,7 @@
       "gear": [1, 3, 7, 7]
     }
   },
+  "sectorDominance": [1],
   "weather": {"airTempC": 28.5, "trackTempC": 41.2, "rainfall": false},
   "timeMs": 3300000,
   "rev": 42,

--- a/testdata/contract/golden_snapshot.json
+++ b/testdata/contract/golden_snapshot.json
@@ -31,6 +31,11 @@
       {"compound": "HARD", "startLap": 15, "endLap": 53}
     ]
   },
+  "pitStops": {
+    "1": [
+      {"lap": 14, "durationS": 23.4}
+    ]
+  },
   "weather": {"airTempC": 28.5, "trackTempC": 41.2, "rainfall": false},
   "timeMs": 3300000,
   "rev": 42,

--- a/testdata/contract/golden_snapshot.json
+++ b/testdata/contract/golden_snapshot.json
@@ -36,6 +36,13 @@
       {"lap": 14, "durationS": 23.4}
     ]
   },
+  "pedalTraces": {
+    "1": {
+      "throttle": [0, 40, 100, 100],
+      "brake": [0, 60, 0, 0],
+      "gear": [1, 3, 7, 7]
+    }
+  },
   "weather": {"airTempC": 28.5, "trackTempC": 41.2, "rainfall": false},
   "timeMs": 3300000,
   "rev": 42,

--- a/testdata/contract/golden_snapshot.json
+++ b/testdata/contract/golden_snapshot.json
@@ -3,7 +3,7 @@
   "mode": "replay",
   "label": "Contract Fixture",
   "track": [{"x": 0.1, "y": 0.2}, {"x": 0.9, "y": 0.8}],
-  "corners": [{"number": 1, "x": 0.1, "y": 0.2}],
+  "corners": [{"number": 1, "x": 0.1, "y": 0.2, "letter": "A"}],
   "cars": {
     "1": {
       "driverNum": 1, "code": "VER", "team": "Red Bull", "pos": 1, "lap": 12,

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1635,9 +1635,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.37",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.37.tgz",
-      "integrity": "sha512-girxaJ7WZssDOFhzCGZTDKoTa1gk6A1TbflaYTpykLJ4UU9Fz9kx1aREM8JCuoVHbL8X8T/mJg7w2oYSq72Oig==",
+      "version": "2.11.20",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.20.tgz",
+      "integrity": "sha512-H0ulySigv6icDJ1F7SjtdCD6PrhTpdYCmP0CactWy1+ekh0AFd0o1Wn5T8b+hnTmdBx19u9yhL6wvCylXMY7zw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1661,9 +1661,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "version": "4.28.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
       "dev": true,
       "funding": [
         {
@@ -1681,11 +1681,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.12",
-        "caniuse-lite": "^1.0.30001782",
-        "electron-to-chromium": "^1.5.328",
-        "node-releases": "^2.0.36",
-        "update-browserslist-db": "^1.2.3"
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -1695,9 +1695,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001799",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
-      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
+      "version": "1.0.30001810",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+      "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
       "dev": true,
       "funding": [
         {
@@ -1844,9 +1844,9 @@
       "peer": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.372",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.372.tgz",
-      "integrity": "sha512-M3yhbAlilnwqC8D21t28UCDGHyitShTmmLRU/H+b74P6Ski16Nb9HONYEaVpMj/pwC7BEo5B95FpjODLCWbtfA==",
+      "version": "1.5.420",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.420.tgz",
+      "integrity": "sha512-2yD6XreGusOfNV+dUcvipJEXc3n/n7fgr7996aszTG+YY5E4mqM4tOq/3uhP129cazL9YHbVWSpc79ePotWtPA==",
       "dev": true,
       "license": "ISC"
     },
@@ -2952,9 +2952,9 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.47",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
-      "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
+      "version": "2.0.54",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.54.tgz",
+      "integrity": "sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3498,9 +3498,9 @@
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz",
+      "integrity": "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==",
       "dev": true,
       "funding": [
         {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -326,7 +326,7 @@ export default function App() {
           // Frozen means "we are choosing not to apply frames", not "the feed has
           // stopped" — so the staleness chip must not start claiming an outage the
           // moment a user pauses to read a row.
-          staleSec={frozen ? 0 : staleSec}
+          staleSec={frozen || replayPaused ? 0 : staleSec}
           onReconnect={reconnect}
           // The board is the one route that carries a Replay/Live control, so
           // the rail's healthy lane chip would only repeat it (ui-ux m8). On the
@@ -383,6 +383,7 @@ export default function App() {
                   the region's content. */}
               <span role="status" aria-live="polite">
                 {frozen && <span className="chip chip-replay">⏸ FROZEN</span>}
+                {replayPaused && <span className="chip chip-replay">⏸ PAUSED</span>}
                 {justLooped && (
                   <span className="chip chip-loop">
                     ↻ CLIP LOOPED — the recording restarted
@@ -410,7 +411,7 @@ export default function App() {
         <Panel label="Track">
           {(status === 'reconnecting' || status === 'offline') && !showSkeleton && (
             <div style={{ position: 'relative', display: 'inline-block' }}>
-              <Map state={state} paused={frozen} selected={selected} rival={effectiveRival} />
+              <Map state={state} paused={frozen || replayPaused} selected={selected} rival={effectiveRival} />
               <div className="chip chip-reconnect" style={{
                 position: 'absolute', top: 12, left: '50%', transform: 'translateX(-50%)',
               }}>
@@ -421,7 +422,7 @@ export default function App() {
             </div>
           )}
           {!showSkeleton && status !== 'reconnecting' && status !== 'offline' && (
-            <Map state={state} paused={frozen} selected={selected} rival={effectiveRival} />
+            <Map state={state} paused={frozen || replayPaused} selected={selected} rival={effectiveRival} />
           )}
           {showSkeleton && (
             <SkeletonMap

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4,7 +4,8 @@
  */
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { connectRace, type ConnStatus } from './realtime/socket';
-import { connectStaticReplay } from './realtime/staticReplay';
+import { connectStaticReplay, type StaticReplayHandle } from './realtime/staticReplay';
+import { fmtElapsed } from './components/timingHelpers';
 import { emptyState, isWarmingUp, type RaceState } from './state/race';
 import { Map } from './components/Map';
 import { TimingTower } from './components/TimingTower';
@@ -142,6 +143,13 @@ export default function App() {
   // one lazy-connect-once case", not a general connection-lifecycle manager.
   const connectedRef = useRef(false);
   const disconnectRef = useRef<() => void>(() => {});
+  // Only meaningful on the static demo (STATIC_DEMO): the handle's pause/resume/
+  // scrub, used by the replay transport below. Left null on the live/replay-lane
+  // WebSocket path, which has no such control surface (see verify/03-06's item 3
+  // — the live lane needs its own writer-side protocol, out of scope here).
+  const replayRef = useRef<StaticReplayHandle | null>(null);
+  const [replayDuration, setReplayDuration] = useState(0);
+  const [replayPaused, setReplayPaused] = useState(false);
   const routeName = parseHash(hash).route;
   useEffect(() => {
     if (connectedRef.current || routeName !== 'board') return;
@@ -154,7 +162,13 @@ export default function App() {
       retryRef.current = retry ?? null;
       setStatus(s);
     };
-    disconnectRef.current = (STATIC_DEMO ? connectStaticReplay : connectRace)(onState, onStatus);
+    if (STATIC_DEMO) {
+      const handle = connectStaticReplay(onState, onStatus, setReplayDuration);
+      replayRef.current = handle;
+      disconnectRef.current = handle;
+    } else {
+      disconnectRef.current = connectRace(onState, onStatus);
+    }
   }, [routeName]);
   // Clearing connectedRef alongside the disposer is what makes a remount
   // reconnect. Refs survive unmount, so without the reset the connect effect
@@ -174,6 +188,41 @@ export default function App() {
     frozenRef.current = next;
     setFrozen(next);
     if (!next) setState(latestRef.current);
+  }
+
+  // The static-demo scrub slider's own clock — same rAF-driven local-clock
+  // pattern as Ghost.tsx's tMs, kept independent of `state` because it tracks
+  // position within one baked lap (0..replayDuration), not the race's own
+  // timeMs. tMsRef mirrors tMs so pause/scrub can re-anchor without a stale
+  // closure.
+  const [replayTMs, setReplayTMs] = useState(0);
+  const replayTMsRef = useRef(0);
+  const replayRafRef = useRef<number | undefined>(undefined);
+  const replayStartRef = useRef(0);
+  useEffect(() => {
+    if (!STATIC_DEMO || !replayDuration || replayPaused || routeName !== 'board') return;
+    replayStartRef.current = performance.now() - replayTMsRef.current;
+    const tick = (now: number) => {
+      const v = (now - replayStartRef.current) % replayDuration;
+      replayTMsRef.current = v;
+      setReplayTMs(v);
+      replayRafRef.current = requestAnimationFrame(tick);
+    };
+    replayRafRef.current = requestAnimationFrame(tick);
+    return () => { if (replayRafRef.current) cancelAnimationFrame(replayRafRef.current); };
+  }, [replayDuration, replayPaused, routeName]);
+
+  function toggleReplayPaused() {
+    const next = !replayPaused;
+    setReplayPaused(next);
+    if (next) replayRef.current?.pause(); else replayRef.current?.resume();
+  }
+
+  function scrubReplay(v: number) {
+    replayTMsRef.current = v;
+    replayStartRef.current = performance.now() - v;
+    setReplayTMs(v);
+    replayRef.current?.scrub(v);
   }
 
   // A rival only makes sense alongside a primary selection, and never as the
@@ -289,13 +338,38 @@ export default function App() {
           controls={
             <>
               {!STATIC_DEMO && <SourceToggle state={state} />}
-              {/* Label swap rather than aria-pressed, matching the overlay's existing
-                  Play/Pause: a transport control names the action it will take. The
-                  resulting state is carried by the chip, in a region that is present
-                  before it fills so the transition is actually announced. */}
-              <button type="button" className="btn rail-divided" onClick={toggleFrozen}>
-                {frozen ? '▶ Resume' : '⏸ Freeze'}
-              </button>
+              {/* The static demo paces itself client-side (staticReplay.ts), so unlike
+                  the live/replay-lane WebSocket it can actually honor pause and scrub —
+                  real transport controls instead of the render-only Freeze toggle below.
+                  ponytail: live-lane pause/scrub deferred, needs a writer-side protocol
+                  change (verify/03-06-playback-and-readme.md item 3). */}
+              {STATIC_DEMO && replayDuration > 0 ? (
+                <>
+                  <button type="button" className="btn rail-divided" onClick={toggleReplayPaused}>
+                    {replayPaused ? '▶ Play' : '⏸ Pause'}
+                  </button>
+                  <input
+                    type="range"
+                    min={0}
+                    max={Math.max(0, replayDuration - 1)}
+                    step={100}
+                    value={Math.floor(replayTMs)}
+                    onChange={(e) => scrubReplay(Number(e.target.value))}
+                    aria-label="Replay position"
+                    aria-valuetext={fmtElapsed(replayTMs)}
+                    style={{ width: 120 }}
+                  />
+                  <span className="rail-clock">{fmtElapsed(replayTMs)}</span>
+                </>
+              ) : (
+                /* Label swap rather than aria-pressed, matching the overlay's existing
+                   Play/Pause: a transport control names the action it will take. The
+                   resulting state is carried by the chip, in a region that is present
+                   before it fills so the transition is actually announced. */
+                <button type="button" className="btn rail-divided" onClick={toggleFrozen}>
+                  {frozen ? '▶ Resume' : '⏸ Freeze'}
+                </button>
+              )}
             </>
           }
           // Zone C, beside the connection chip: these are readouts of transport

--- a/web/src/components/Map.tsx
+++ b/web/src/components/Map.tsx
@@ -1,11 +1,12 @@
 // The track map: cars drawn as smoothed dots on the baked track outline, with the
 // board's selection highlighted.
 
+import { useMemo } from 'react';
 import type { RaceState } from '../state/race';
 import { TrackPath } from './TrackPath';
 import { useSmoothedCars } from '../hooks/useSmoothedCars';
 import { teamColour } from './teamColours';
-import { SIZE, fitViewBox, trackPathD } from './geometry';
+import { SIZE, fitViewBox, trackPathD, trackSegmentPaths } from './geometry';
 
 // selected / rival are the board's one selection, reaching the map at last: the
 // click-a-row interaction used to change the tower row and the telemetry panel and
@@ -17,12 +18,52 @@ export function Map({ state, paused, selected, rival }: {
   const cars = useSmoothedCars(state, paused);
   const trackPath = trackPathD(state.track);
   const anySelection = selected != null || rival != null;
+  // Sector-dominance heatmap (item 5): one coloured segment per minisector,
+  // by the fastest driver's team colour. Always on rather than a toggle — the
+  // plain outline is what renders whenever a clip carries no sectorDominance
+  // (older clips, or a bake with too little lap-trace data).
+  const segments = useMemo(() => {
+    if (!state.sectorDominance.length) return undefined;
+    const paths = trackSegmentPaths(state.track);
+    return paths.map((d, i) => {
+      const dnum = state.sectorDominance[i];
+      const team = dnum ? state.cars[dnum]?.team : undefined;
+      return { d, colour: team ? (teamColour[team] ?? 'var(--track-fill)') : 'var(--track-fill)' };
+    });
+  }, [state.track, state.sectorDominance, state.cars]);
   return (
     // Fitted to the outline's own bounds rather than the full unit square: the
     // baked outline is letterboxed inside it, and the empty margin was ~38% of
     // the panel. Markers keep their SIZE-space coordinates — see fitViewBox.
     <svg viewBox={fitViewBox(state.track)} className="track-svg" role="img" aria-label={anySelection ? 'Track map with live car positions; the reference car is ringed' : 'Track map with live car positions'}>
-      <TrackPath d={trackPath} />
+      <TrackPath d={trackPath} segments={segments} />
+      {/* Start/finish: track[0] by convention (ingest/record.py's outline starts
+          at lap_start_t) — drawn as a short perpendicular tick using its
+          neighbour point for direction. */}
+      {state.track.length > 1 && (() => {
+        const p0 = state.track[0], p1 = state.track[1];
+        const dx = p1.x - p0.x, dy = p1.y - p0.y;
+        const len = Math.hypot(dx, dy) || 1;
+        // Perpendicular unit vector, scaled to a short tick either side of track[0].
+        const nx = (-dy / len) * 0.012, ny = (dx / len) * 0.012;
+        const cx = p0.x * SIZE, cy = p0.y * SIZE;
+        return (
+          <line
+            x1={cx - nx * SIZE} y1={cy - ny * SIZE} x2={cx + nx * SIZE} y2={cy + ny * SIZE}
+            stroke="var(--chalk)" strokeWidth={2}
+          />
+        );
+      })()}
+      {state.corners.map((c) => (
+        <text
+          key={c.number}
+          className="map-label"
+          x={c.x * SIZE} y={c.y * SIZE}
+          fill="var(--track-label)"
+          fontSize="var(--fs-xs)"
+          textAnchor="middle"
+        >{c.number}</text>
+      ))}
       {cars.map((c) => {
         const isSel = selected != null && c.driverNum === selected;
         const isRival = rival != null && c.driverNum === rival;

--- a/web/src/components/Map.tsx
+++ b/web/src/components/Map.tsx
@@ -18,19 +18,49 @@ export function Map({ state, paused, selected, rival }: {
   const cars = useSmoothedCars(state, paused);
   const trackPath = trackPathD(state.track);
   const anySelection = selected != null || rival != null;
+  // Driver -> team, as a single stable string keyed only on the pairs that
+  // actually matter for colouring (not on the `cars` object itself, which
+  // race.ts rebuilds every 10 Hz frame regardless of whether any team changed).
+  const driverTeamKey = Object.values(state.cars)
+    .map((c) => `${c.driverNum}:${c.team}`)
+    .join('|');
+  // A plain object, not the built-in Map class: this module's own component
+  // is named `Map`, which shadows the global `Map` constructor in this scope.
+  const driverTeam = useMemo(() => {
+    const byDriver: Record<number, string> = {};
+    for (const c of Object.values(state.cars)) byDriver[c.driverNum] = c.team;
+    return byDriver;
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- driverTeamKey is the real dep
+  }, [driverTeamKey]);
   // Sector-dominance heatmap (item 5): one coloured segment per minisector,
   // by the fastest driver's team colour. Always on rather than a toggle — the
   // plain outline is what renders whenever a clip carries no sectorDominance
-  // (older clips, or a bake with too little lap-trace data).
+  // (older clips, or a bake with too little lap-trace data). Memoized on
+  // state.track + state.sectorDominance only — NOT state.cars, which race.ts
+  // rebuilds every frame — with team colour resolved via driverTeam instead.
   const segments = useMemo(() => {
     if (!state.sectorDominance.length) return undefined;
     const paths = trackSegmentPaths(state.track);
     return paths.map((d, i) => {
       const dnum = state.sectorDominance[i];
-      const team = dnum ? state.cars[dnum]?.team : undefined;
+      const team = dnum ? driverTeam[dnum] : undefined;
       return { d, colour: team ? (teamColour[team] ?? 'var(--track-fill)') : 'var(--track-fill)' };
     });
-  }, [state.track, state.sectorDominance, state.cars]);
+  }, [state.track, state.sectorDominance, driverTeam]);
+  // Start/finish tick: track[0] by convention (ingest/record.py's outline
+  // starts at lap_start_t) — a short perpendicular tick using its neighbour
+  // point for direction. Keyed on state.track only, so it isn't recomputed
+  // every 10 Hz frame alongside cars/positions.
+  const startFinishTick = useMemo(() => {
+    if (state.track.length <= 1) return undefined;
+    const p0 = state.track[0], p1 = state.track[1];
+    const dx = p1.x - p0.x, dy = p1.y - p0.y;
+    const len = Math.hypot(dx, dy) || 1;
+    // Perpendicular unit vector, scaled to a short tick either side of track[0].
+    const nx = (-dy / len) * 0.012, ny = (dx / len) * 0.012;
+    const cx = p0.x * SIZE, cy = p0.y * SIZE;
+    return { x1: cx - nx * SIZE, y1: cy - ny * SIZE, x2: cx + nx * SIZE, y2: cy + ny * SIZE };
+  }, [state.track]);
   return (
     // Fitted to the outline's own bounds rather than the full unit square: the
     // baked outline is letterboxed inside it, and the empty margin was ~38% of
@@ -40,29 +70,22 @@ export function Map({ state, paused, selected, rival }: {
       {/* Start/finish: track[0] by convention (ingest/record.py's outline starts
           at lap_start_t) — drawn as a short perpendicular tick using its
           neighbour point for direction. */}
-      {state.track.length > 1 && (() => {
-        const p0 = state.track[0], p1 = state.track[1];
-        const dx = p1.x - p0.x, dy = p1.y - p0.y;
-        const len = Math.hypot(dx, dy) || 1;
-        // Perpendicular unit vector, scaled to a short tick either side of track[0].
-        const nx = (-dy / len) * 0.012, ny = (dx / len) * 0.012;
-        const cx = p0.x * SIZE, cy = p0.y * SIZE;
-        return (
-          <line
-            x1={cx - nx * SIZE} y1={cy - ny * SIZE} x2={cx + nx * SIZE} y2={cy + ny * SIZE}
-            stroke="var(--chalk)" strokeWidth={2}
-          />
-        );
-      })()}
+      {startFinishTick && (
+        <line
+          x1={startFinishTick.x1} y1={startFinishTick.y1}
+          x2={startFinishTick.x2} y2={startFinishTick.y2}
+          stroke="var(--chalk)" strokeWidth={2}
+        />
+      )}
       {state.corners.map((c) => (
         <text
-          key={c.number}
+          key={`${c.number}${c.letter ?? ''}`}
           className="map-label"
           x={c.x * SIZE} y={c.y * SIZE}
           fill="var(--track-label)"
           fontSize="var(--fs-xs)"
           textAnchor="middle"
-        >{c.number}</text>
+        >{c.number}{c.letter ?? ''}</text>
       ))}
       {cars.map((c) => {
         const isSel = selected != null && c.driverNum === selected;

--- a/web/src/components/StintChart.tsx
+++ b/web/src/components/StintChart.tsx
@@ -63,6 +63,27 @@ function StintChartInner({ state, selected, rival }: {
                 }}
               />
             ))}
+            {/* Pit-stop duration ticks: one short marker per stop at the lap it
+                happened, title/aria-label carrying the pit-lane duration. Duration
+                only — positions gained/lost and stationary time are out of scope
+                for this slice (reviews/plans/verify/02-pit-stops.md).
+                # ponytail: no visual distinction between stops yet (e.g. drive-through
+                vs stop-go) — not derivable from the current data, deferred. */}
+            {(state.pitStops[c.driverNum] ?? []).map((p, i) => (
+              <div
+                key={`pit-${i}`}
+                title={`Pit stop: ${p.durationS.toFixed(1)}s (lap ${p.lap})`}
+                role="img"
+                aria-label={`${c.code}: pit stop on lap ${p.lap}, ${p.durationS.toFixed(1)} seconds`}
+                style={{
+                  position: 'absolute',
+                  left: `${((p.lap - 1) / total) * 100}%`,
+                  top: -2, bottom: -2,
+                  width: 2,
+                  background: 'var(--amber, orange)',
+                }}
+              />
+            ))}
             {/* != null, not truthiness: lap 0 is a real value on the wire, and
                 `!!leaderLap` silently skipped the marker on the opening lap. */}
             {leaderLap != null && (

--- a/web/src/components/TelemetryPanel.tsx
+++ b/web/src/components/TelemetryPanel.tsx
@@ -1,7 +1,7 @@
 // The selected car's telemetry readout: speed, gear, pedal bars and lap/gap sparklines.
 
 import { memo } from 'react';
-import type { Car, RaceState } from '../state/race';
+import type { Car, PedalTrace, RaceState } from '../state/race';
 import { fmtLap, fmtGapEstimate, type LapHistory, type GapHistory } from './timingHelpers';
 
 // Below this many points a sparkline is decoration: two bars with no axis convey
@@ -116,6 +116,71 @@ function SparkHatch() {
         </pattern>
       </defs>
     </svg>
+  );
+}
+
+// ponytail: fixed max gear of 8 (no F1 car has run higher in the hybrid era) —
+// good enough for a y-axis scale without reading it out of the data per lap.
+const MAX_GEAR = 8;
+const TRACE_H = 28;
+
+// Downsample a pedal-trace channel to at most this many points before drawing —
+// the full array is one point per track-outline point (TRACK_POINTS in
+// ingest/record.py, currently ~150), which is already fine to draw directly, but
+// this caps the SVG's point count if that resolution ever grows.
+const MAX_TRACE_POINTS = 200;
+
+function toPolyline(values: number[], max: number): string {
+  const n = values.length;
+  if (n === 0) return '';
+  const step = Math.max(1, Math.ceil(n / MAX_TRACE_POINTS));
+  const pts: string[] = [];
+  for (let i = 0; i < n; i += step) {
+    const x = (i / (n - 1)) * 100;
+    const y = TRACE_H - (Math.max(0, Math.min(max, values[i])) / max) * TRACE_H;
+    pts.push(`${x.toFixed(2)},${y.toFixed(2)}`);
+  }
+  return pts.join(' ');
+}
+
+// DistanceTrace: throttle/brake/gear over lap distance (0-100%), for the
+// reference car (solid) and an optional rival (dashed) overlaid on the same
+// axes — the corner-by-corner telemetry compare. x is track-outline position
+// (same index space as LapTrace), not literal metres; see PedalTrace in
+// internal/model/model.go.
+function DistanceTraceRow({ label, max, car, rival, pick }: {
+  label: string; max: number;
+  car: PedalTrace; rival?: PedalTrace;
+  pick: (t: PedalTrace) => number[];
+}) {
+  return (
+    <div className="tele-row" style={{ alignItems: 'center' }}>
+      <span className="tele-label">{label}</span>
+      <svg
+        viewBox={`0 0 100 ${TRACE_H}`} preserveAspectRatio="none"
+        style={{ flex: 1, height: TRACE_H, width: '100%' }}
+        role="img" aria-label={`${label} over lap distance`}
+      >
+        <polyline points={toPolyline(pick(car), max)} fill="none" stroke="var(--good)" strokeWidth={1.5} vectorEffect="non-scaling-stroke" />
+        {rival && (
+          <polyline points={toPolyline(pick(rival), max)} fill="none" stroke="var(--slate)" strokeWidth={1.5} strokeDasharray="3 2" vectorEffect="non-scaling-stroke" />
+        )}
+      </svg>
+    </div>
+  );
+}
+
+function DistanceTrace({ car, rival }: { car: PedalTrace; rival?: PedalTrace }) {
+  return (
+    <div style={{ display: 'grid', gap: 'var(--sp-1)' }}>
+      <div style={{ fontSize: 'var(--fs-xs)', color: 'var(--slate)' }}>
+        Throttle / brake / gear over lap distance
+        {rival && ' — solid = reference, dashed = rival'}
+      </div>
+      <DistanceTraceRow label="Throttle" max={100} car={car} rival={rival} pick={(t) => t.throttle} />
+      <DistanceTraceRow label="Brake" max={100} car={car} rival={rival} pick={(t) => t.brake} />
+      <DistanceTraceRow label="Gear" max={MAX_GEAR} car={car} rival={rival} pick={(t) => t.gear} />
+    </div>
   );
 }
 
@@ -244,6 +309,12 @@ export function TelemetryPanel({
           />
         )}
       </div>
+      {state.pedalTraces[car.driverNum] && (
+        <DistanceTrace
+          car={state.pedalTraces[car.driverNum]}
+          rival={rivalCar ? state.pedalTraces[rivalCar.driverNum] : undefined}
+        />
+      )}
     </div>
   );
 }

--- a/web/src/components/TelemetryPanel.tsx
+++ b/web/src/components/TelemetryPanel.tsx
@@ -1,6 +1,6 @@
 // The selected car's telemetry readout: speed, gear, pedal bars and lap/gap sparklines.
 
-import { memo } from 'react';
+import { memo, useMemo } from 'react';
 import type { Car, PedalTrace, RaceState } from '../state/race';
 import { fmtLap, fmtGapEstimate, type LapHistory, type GapHistory } from './timingHelpers';
 
@@ -132,7 +132,9 @@ const MAX_TRACE_POINTS = 200;
 
 function toPolyline(values: number[], max: number): string {
   const n = values.length;
-  if (n === 0) return '';
+  // n===1 would divide by (n-1)===0 below, producing NaN coordinates — bail
+  // out the same as the empty case rather than drawing a broken point.
+  if (n < 2) return '';
   const step = Math.max(1, Math.ceil(n / MAX_TRACE_POINTS));
   const pts: string[] = [];
   for (let i = 0; i < n; i += step) {
@@ -148,11 +150,19 @@ function toPolyline(values: number[], max: number): string {
 // axes — the corner-by-corner telemetry compare. x is track-outline position
 // (same index space as LapTrace), not literal metres; see PedalTrace in
 // internal/model/model.go.
-function DistanceTraceRow({ label, max, car, rival, pick }: {
+const DistanceTraceRow = memo(function DistanceTraceRow({ label, max, car, rival, pick }: {
   label: string; max: number;
   car: PedalTrace; rival?: PedalTrace;
   pick: (t: PedalTrace) => number[];
 }) {
+  // Keyed on the trace arrays themselves (not e.g. car.driverNum), since a
+  // 10 Hz frame with an unchanged pedalTrace shouldn't re-walk MAX_TRACE_POINTS
+  // just because the enclosing car object was rebuilt.
+  const carPoints = useMemo(() => toPolyline(pick(car), max), [car, max, pick]);
+  const rivalPoints = useMemo(
+    () => (rival ? toPolyline(pick(rival), max) : ''),
+    [rival, max, pick],
+  );
   return (
     <div className="tele-row" style={{ alignItems: 'center' }}>
       <span className="tele-label">{label}</span>
@@ -161,28 +171,34 @@ function DistanceTraceRow({ label, max, car, rival, pick }: {
         style={{ flex: 1, height: TRACE_H, width: '100%' }}
         role="img" aria-label={`${label} over lap distance`}
       >
-        <polyline points={toPolyline(pick(car), max)} fill="none" stroke="var(--good)" strokeWidth={1.5} vectorEffect="non-scaling-stroke" />
+        <polyline points={carPoints} fill="none" stroke="var(--good)" strokeWidth={1.5} vectorEffect="non-scaling-stroke" />
         {rival && (
-          <polyline points={toPolyline(pick(rival), max)} fill="none" stroke="var(--slate)" strokeWidth={1.5} strokeDasharray="3 2" vectorEffect="non-scaling-stroke" />
+          <polyline points={rivalPoints} fill="none" stroke="var(--slate)" strokeWidth={1.5} strokeDasharray="3 2" vectorEffect="non-scaling-stroke" />
         )}
       </svg>
     </div>
   );
-}
+});
 
-function DistanceTrace({ car, rival }: { car: PedalTrace; rival?: PedalTrace }) {
+// Stable identities: an inline arrow prop would be a fresh function every
+// render, defeating DistanceTraceRow's useMemo(..., [pick]) above.
+const pickThrottle = (t: PedalTrace) => t.throttle;
+const pickBrake = (t: PedalTrace) => t.brake;
+const pickGear = (t: PedalTrace) => t.gear;
+
+const DistanceTrace = memo(function DistanceTrace({ car, rival }: { car: PedalTrace; rival?: PedalTrace }) {
   return (
     <div style={{ display: 'grid', gap: 'var(--sp-1)' }}>
       <div style={{ fontSize: 'var(--fs-xs)', color: 'var(--slate)' }}>
         Throttle / brake / gear over lap distance
         {rival && ' — solid = reference, dashed = rival'}
       </div>
-      <DistanceTraceRow label="Throttle" max={100} car={car} rival={rival} pick={(t) => t.throttle} />
-      <DistanceTraceRow label="Brake" max={100} car={car} rival={rival} pick={(t) => t.brake} />
-      <DistanceTraceRow label="Gear" max={MAX_GEAR} car={car} rival={rival} pick={(t) => t.gear} />
+      <DistanceTraceRow label="Throttle" max={100} car={car} rival={rival} pick={pickThrottle} />
+      <DistanceTraceRow label="Brake" max={100} car={car} rival={rival} pick={pickBrake} />
+      <DistanceTraceRow label="Gear" max={MAX_GEAR} car={car} rival={rival} pick={pickGear} />
     </div>
   );
-}
+});
 
 function CarTelemetry({ car, history, gapHistory, role }: {
   car: Car; history?: number[]; gapHistory?: (number | undefined)[];

--- a/web/src/components/TrackPath.tsx
+++ b/web/src/components/TrackPath.tsx
@@ -6,7 +6,25 @@
 // hairline, and with the retuned --track-fill (see tokens.css) there is now an
 // actual road surface worth showing. The 2px casing margin either side is kept
 // deliberately thin — it is a seam, not an outline.
-export function TrackPath({ d }: { d: string }) {
+// segments, when given, is the sector-dominance heatmap: one coloured sub-path
+// per minisector (see geometry.ts's trackSegmentPaths), drawn instead of the
+// single plain-fill path. Casing is drawn under every segment first so two
+// adjacent colours never show a fill-coloured seam between them.
+export function TrackPath({ d, segments }: {
+  d: string; segments?: { d: string; colour: string }[];
+}) {
+  if (segments && segments.length > 0) {
+    return (
+      <>
+        {segments.map((s, i) => (
+          <path key={i} d={s.d} fill="none" stroke="var(--track-edge)" strokeWidth={12} strokeLinejoin="round" strokeLinecap="round" />
+        ))}
+        {segments.map((s, i) => (
+          <path key={i} d={s.d} fill="none" stroke={s.colour} strokeWidth={8} strokeLinejoin="round" strokeLinecap="round" />
+        ))}
+      </>
+    );
+  }
   if (!d) return null;
   return (
     <>

--- a/web/src/components/geometry.ts
+++ b/web/src/components/geometry.ts
@@ -16,6 +16,30 @@ export function trackPathD(track: Pt[]): string {
   return 'M ' + track.map((p) => `${p.x * SIZE},${p.y * SIZE}`).join(' L ') + ' Z';
 }
 
+// Minisector bin size for the sector-dominance heatmap: mirrors
+// ingest/record.py's MINISECTOR_SIZE / ingest/ghost.py's compute_sector_dominance
+// exactly, so segment i here lines up with RaceState.sectorDominance[i].
+export const MINISECTOR_SIZE = 10;
+
+// trackSegmentPaths splits the outline into fixed-size, non-closed sub-paths
+// (one per minisector) for the sector-dominance heatmap, using the same
+// [start, min(start+binSize, n-1)] windows as the backend's binning so the
+// segment at index i corresponds to sectorDominance[i].
+export function trackSegmentPaths(track: Pt[], binSize: number = MINISECTOR_SIZE): string[] {
+  const n = track.length;
+  if (n === 0) return [];
+  const paths: string[] = [];
+  for (let start = 0; start < n; start += binSize) {
+    const end = Math.min(start + binSize, n - 1);
+    // Degenerate bin (start === end, only possible when n is tiny relative to
+    // binSize): emit a zero-length path rather than skip it, so this array's
+    // length always matches the backend's one-entry-per-bin sectorDominance.
+    const pts = track.slice(start, end + 1);
+    paths.push('M ' + pts.map((p) => `${p.x * SIZE},${p.y * SIZE}`).join(' L '));
+  }
+  return paths;
+}
+
 // The outline is baked into the unit box with its aspect ratio preserved
 // (ingest/record.py's normalise() scales both axes by the LARGER range and
 // centres), so the narrow axis is letterboxed: Monza measures 372×599 inside the

--- a/web/src/hooks/useSmoothedCars.ts
+++ b/web/src/hooks/useSmoothedCars.ts
@@ -30,9 +30,20 @@ export function useSmoothedCars(state: RaceState, paused = false): Car[] {
   // When a new frame/snapshot arrives (rev changes), snapshot from→to.
   useEffect(() => {
     const now = performance.now();
-    from.current = { ...to.current };
+    const prevTo = to.current;
     const next: Record<number, Point> = {};
     for (const c of Object.values(state.cars)) next[c.driverNum] = c.p;
+    // ponytail: a scrub or loop restart moves a car far more than one 10Hz frame
+    // ever could (normal frame-to-frame motion on this track is well under this
+    // in track-space units) — snap instead of gliding across the map.
+    const TELEPORT_THRESHOLD = 50;
+    const snapped: Record<number, Point> = {};
+    for (const [id, p] of Object.entries(next)) {
+      const prev = prevTo[Number(id)];
+      const dist = prev ? Math.hypot(p.x - prev.x, p.y - prev.y) : 0;
+      snapped[Number(id)] = prev && dist <= TELEPORT_THRESHOLD ? prev : p;
+    }
+    from.current = snapped;
     to.current = next;
     tFrom.current = tTo.current || now;
     tTo.current = now;

--- a/web/src/realtime/staticReplay.ts
+++ b/web/src/realtime/staticReplay.ts
@@ -6,6 +6,18 @@ import type { ConnStatus } from './socket';
 
 const DEFAULT_CLIP_URL = `${import.meta.env.BASE_URL}static-demo/monza-2024-race.ndjson`;
 
+// The control surface handed back to callers: closing the connection, plus the
+// board's pause/resume/scrub transport (reviews/plans/verify/03-06-playback-and-readme.md
+// item 3 — client-side static-demo scrub only, mirroring Ghost.tsx's local clock).
+// A plain function (call it to close) with these three attached, so the existing
+// `disconnectRef.current()` call sites over in App.tsx/lanes.ts need no change.
+export interface StaticReplayHandle {
+  (): void;
+  pause: () => void;
+  resume: () => void;
+  scrub: (ms: number) => void;
+}
+
 // connectStaticReplay mirrors connectRace's interface (onState/onStatus/close-fn)
 // but reads a baked NDJSON file (produced by cmd/bake-static) instead of opening
 // a WebSocket, pacing playback on each frame's own relative timeMs offset and
@@ -15,12 +27,20 @@ const DEFAULT_CLIP_URL = `${import.meta.env.BASE_URL}static-demo/monza-2024-race
 export function connectStaticReplay(
   onState: (s: RaceState) => void,
   onStatus?: (status: ConnStatus) => void,
+  // Fired once, when the clip has loaded, with the length of one lap of the
+  // baked clip in ms — the range a scrub slider needs and has no other way
+  // to know ahead of time.
+  onDuration?: (ms: number) => void,
   clipUrl: string = DEFAULT_CLIP_URL,
-): () => void {
+): StaticReplayHandle {
   let state = emptyState();
   let closed = false;
   let timer: ReturnType<typeof setTimeout> | null = null;
   let live = false;
+  let paused = false;
+  // Set once messages are loaded (schedulePlayback), read by pause/resume/scrub,
+  // which are otherwise no-ops before the clip has finished fetching.
+  let control: { pause: () => void; resume: () => void; scrub: (ms: number) => void } | null = null;
 
   onStatus?.('connecting');
 
@@ -67,6 +87,7 @@ export function connectStaticReplay(
     const frameStartIndex = messages.findIndex((m) => m.type === 'frame');
     const frameBase = frameStartIndex >= 0 ? messages[frameStartIndex].data.timeMs : 0;
     const offsets = messages.map((m) => (m.type === 'frame' ? m.data.timeMs - frameBase : 0));
+    onDuration?.(Math.max(...offsets, 0));
     // Where a loop restart resumes: the first FRAME, not index 0. The synthetic
     // baked snapshot (empty cars, the pre-playback baseline) plays exactly once,
     // on the very first pass — re-emitting it every lap would flash the map back
@@ -85,14 +106,24 @@ export function connectStaticReplay(
     // keeps climbing forever, exactly like the real writer does across a loop.
     const maxRev = messages.reduce((max, m) => (m.type === 'frame' ? Math.max(max, m.data.rev) : max), 0);
     let lapsCompleted = 0;
+    // The next frame due to play, and the offset it was last (re)anchored
+    // against — both read by pause/resume/scrub below, which otherwise have no
+    // way to know where a paused clip currently sits.
+    let nextIndex = 0;
+    let lastOffset = 0;
+
+    const bump = (msg: Msg): Msg => (msg.type === 'frame' && lapsCompleted > 0
+      ? { ...msg, data: { ...msg.data, rev: msg.data.rev + lapsCompleted * maxRev } }
+      : msg);
 
     let loopStart = Date.now();
 
     const playFrom = (i: number) => {
-      if (closed) return;
+      if (closed || paused) return;
       if (i >= messages.length) {
         lapsCompleted++;
         loopStart = Date.now();
+        nextIndex = loopRestartIndex;
         timer = setTimeout(() => playFrom(loopRestartIndex), 0);
         return;
       }
@@ -113,12 +144,10 @@ export function connectStaticReplay(
       const now = Date.now();
       if (now - loopStart > offsets[i]) loopStart = now - offsets[i];
       const wait = Math.max(0, offsets[i] - (now - loopStart));
+      nextIndex = i;
       timer = setTimeout(() => {
-        const msg = messages[i];
-        const bumped: Msg = msg.type === 'frame' && lapsCompleted > 0
-          ? { ...msg, data: { ...msg.data, rev: msg.data.rev + lapsCompleted * maxRev } }
-          : msg;
-        state = applyMessage(state, bumped);
+        state = applyMessage(state, bump(messages[i]));
+        lastOffset = offsets[i];
         if (!live) { live = true; onStatus?.('live'); }
         onState(state);
         playFrom(i + 1);
@@ -126,10 +155,55 @@ export function connectStaticReplay(
     };
 
     playFrom(0);
+
+    control = {
+      pause: () => {
+        if (paused) return;
+        paused = true;
+        if (timer) clearTimeout(timer);
+      },
+      resume: () => {
+        if (!paused) return;
+        paused = false;
+        // Re-anchor loopStart against the offset already reached, exactly as a
+        // fresh lap does above — otherwise the clock treats the paused wall time
+        // as elapsed playback and bursts through however many frames it covers.
+        loopStart = Date.now() - lastOffset;
+        playFrom(nextIndex);
+      },
+      // Jumps to the nearest frame at or after `ms` and rebuilds state by
+      // replaying from the top of the current lap — the reducer folds each
+      // frame into the last (CONTEXT.md: state is cumulative), so there is no
+      // cheaper way to land on an arbitrary offset than replaying up to it.
+      // ponytail: O(n) replay on every scrub, fine for a single baked clip's
+      // few thousand frames; scrubbing across a loop boundary (into the next
+      // lap's Rev range) is out of scope for this slice.
+      scrub: (ms: number) => {
+        if (timer) clearTimeout(timer);
+        const target = messages.findIndex((_, idx) => idx >= loopRestartIndex && offsets[idx] >= ms);
+        const end = target >= 0 ? target : messages.length - 1;
+        let replayed = emptyState();
+        for (let j = 0; j <= end; j++) {
+          replayed = applyMessage(replayed, bump(messages[j]));
+        }
+        state = replayed;
+        lastOffset = offsets[end];
+        nextIndex = end + 1;
+        onState(state);
+        loopStart = Date.now() - lastOffset;
+        if (!paused) playFrom(nextIndex);
+      },
+    };
   }
 
-  return () => {
+  const close = (() => {
     closed = true;
     if (timer) clearTimeout(timer);
-  };
+  }) as StaticReplayHandle;
+  // Before the clip has loaded there is nothing to pause/scrub yet; no-ops
+  // until `control` is set at the end of schedulePlayback.
+  close.pause = () => control?.pause();
+  close.resume = () => control?.resume();
+  close.scrub = (ms: number) => control?.scrub(ms);
+  return close;
 }

--- a/web/src/state/contract.test.ts
+++ b/web/src/state/contract.test.ts
@@ -47,6 +47,9 @@ describe('golden snapshot contract', () => {
     expect(s.pitStops[1]).toHaveLength(1);
     expect(s.pitStops[1][0].lap).toBe(14);
     expect(s.pitStops[1][0].durationS).toBe(23.4);
+    expect(s.pedalTraces[1].throttle).toEqual([0, 40, 100, 100]);
+    expect(s.pedalTraces[1].brake).toEqual([0, 60, 0, 0]);
+    expect(s.pedalTraces[1].gear).toEqual([1, 3, 7, 7]);
     expect(s.weather?.trackTempC).toBe(41.2);
     expect(s.weather?.airTempC).toBe(28.5);
     expect(s.weather?.rainfall).toBe(false);

--- a/web/src/state/contract.test.ts
+++ b/web/src/state/contract.test.ts
@@ -25,7 +25,7 @@ describe('golden snapshot contract', () => {
     expect(s.track).toHaveLength(2);
     expect(s.track[1]).toEqual({ x: 0.9, y: 0.8 });
     expect(s.corners).toHaveLength(1);
-    expect(s.corners[0]).toEqual({ number: 1, x: 0.1, y: 0.2 });
+    expect(s.corners[0]).toEqual({ number: 1, x: 0.1, y: 0.2, letter: "A" });
 
     expect(Object.keys(s.cars)).toHaveLength(2);
     expect(s.cars[1].driverNum).toBe(1);

--- a/web/src/state/contract.test.ts
+++ b/web/src/state/contract.test.ts
@@ -24,6 +24,8 @@ describe('golden snapshot contract', () => {
     expect(s.totalLaps).toBe(53);
     expect(s.track).toHaveLength(2);
     expect(s.track[1]).toEqual({ x: 0.9, y: 0.8 });
+    expect(s.corners).toHaveLength(1);
+    expect(s.corners[0]).toEqual({ number: 1, x: 0.1, y: 0.2 });
 
     expect(Object.keys(s.cars)).toHaveLength(2);
     expect(s.cars[1].driverNum).toBe(1);
@@ -50,6 +52,7 @@ describe('golden snapshot contract', () => {
     expect(s.pedalTraces[1].throttle).toEqual([0, 40, 100, 100]);
     expect(s.pedalTraces[1].brake).toEqual([0, 60, 0, 0]);
     expect(s.pedalTraces[1].gear).toEqual([1, 3, 7, 7]);
+    expect(s.sectorDominance).toEqual([1]);
     expect(s.weather?.trackTempC).toBe(41.2);
     expect(s.weather?.airTempC).toBe(28.5);
     expect(s.weather?.rainfall).toBe(false);

--- a/web/src/state/contract.test.ts
+++ b/web/src/state/contract.test.ts
@@ -44,6 +44,9 @@ describe('golden snapshot contract', () => {
     expect(s.stints[1]).toHaveLength(2);
     expect(s.stints[1][1].compound).toBe('HARD');
     expect(s.stints[1][1].startLap).toBe(15);
+    expect(s.pitStops[1]).toHaveLength(1);
+    expect(s.pitStops[1][0].lap).toBe(14);
+    expect(s.pitStops[1][0].durationS).toBe(23.4);
     expect(s.weather?.trackTempC).toBe(41.2);
     expect(s.weather?.airTempC).toBe(28.5);
     expect(s.weather?.rainfall).toBe(false);

--- a/web/src/state/race.ts
+++ b/web/src/state/race.ts
@@ -15,7 +15,7 @@ export interface Car {
   gapMs?: number; gapLaps?: number; intMs?: number;
   speed?: number; gear?: number; throttle?: number; brake?: number; drs?: boolean;
 }
-export interface Corner { number: number; x: number; y: number }
+export interface Corner { number: number; x: number; y: number; letter?: string }
 export interface RadioMessage { timeMs: number; driverNum: number; clip: string }
 export interface Stint { compound: string; startLap: number; endLap: number }
 export interface PitStop { lap: number; durationS: number }

--- a/web/src/state/race.ts
+++ b/web/src/state/race.ts
@@ -17,6 +17,7 @@ export interface Car {
 }
 export interface RadioMessage { timeMs: number; driverNum: number; clip: string }
 export interface Stint { compound: string; startLap: number; endLap: number }
+export interface PitStop { lap: number; durationS: number }
 export interface Weather { airTempC: number; trackTempC: number; rainfall: boolean }
 export interface RaceControlMessage {
   rev: number; t: number; category: string; message: string; driver?: number;
@@ -37,6 +38,7 @@ export interface RaceState {
   lapTrace: Record<number, number[]>;
   totalLaps: number;
   stints: Record<number, Stint[]>;
+  pitStops: Record<number, PitStop[]>;
   weather?: Weather;
   messages: RaceControlMessage[];
   // Bumped on every snapshot (never on a frame) — lets a consumer (useComms) tell
@@ -60,7 +62,7 @@ export function isWarmingUp(s: RaceState): boolean {
 export function emptyState(): RaceState {
   return {
     session: '', mode: '', label: '', track: [], cars: {}, timeMs: 0, rev: 0,
-    radio: [], lapTrace: {}, totalLaps: 0, stints: {}, messages: [], snapshotSeq: 0,
+    radio: [], lapTrace: {}, totalLaps: 0, stints: {}, pitStops: {}, messages: [], snapshotSeq: 0,
     loopSeq: 0,
   };
 }
@@ -73,6 +75,7 @@ interface SnapshotData {
   lapTrace?: Record<number, number[]>;
   totalLaps?: number;
   stints?: Record<number, Stint[]>;
+  pitStops?: Record<number, PitStop[]>;
   weather?: Weather;
   messages?: RaceControlMessage[];
 }
@@ -119,8 +122,9 @@ export function parseMsg(raw: unknown): Msg | null {
     if (data.messages !== undefined && !Array.isArray(data.messages)) return null;
     if (data.radio !== undefined && !isRadioRefs(data.radio)) return null;
     if (data.track !== undefined && !Array.isArray(data.track)) return null;
-    // stints/weather are objects, not arrays — reject an array (would spread wrong).
+    // stints/pitStops/weather are objects, not arrays — reject an array (would spread wrong).
     if (data.stints !== undefined && (typeof data.stints !== 'object' || data.stints === null || Array.isArray(data.stints))) return null;
+    if (data.pitStops !== undefined && (typeof data.pitStops !== 'object' || data.pitStops === null || Array.isArray(data.pitStops))) return null;
     if (data.weather !== undefined && (typeof data.weather !== 'object' || data.weather === null || Array.isArray(data.weather))) return null;
     return { type: 'snapshot', data: data as unknown as SnapshotData };
   }
@@ -145,7 +149,7 @@ export function applyMessage(s: RaceState, msg: Msg): RaceState {
       session: d.session, mode: d.mode, label: d.label,
       track: d.track ?? [], cars: { ...d.cars }, timeMs: d.timeMs, rev: d.rev,
       radio: d.radio ?? [], lapTrace: d.lapTrace ?? {}, totalLaps: d.totalLaps ?? 0,
-      stints: d.stints ?? {}, weather: d.weather,
+      stints: d.stints ?? {}, pitStops: d.pitStops ?? {}, weather: d.weather,
       messages: d.messages ?? [],
       snapshotSeq: s.snapshotSeq + 1,
       // A snapshot is a fresh baseline, not a wrap: keep the counter so a

--- a/web/src/state/race.ts
+++ b/web/src/state/race.ts
@@ -18,6 +18,7 @@ export interface Car {
 export interface RadioMessage { timeMs: number; driverNum: number; clip: string }
 export interface Stint { compound: string; startLap: number; endLap: number }
 export interface PitStop { lap: number; durationS: number }
+export interface PedalTrace { throttle: number[]; brake: number[]; gear: number[] }
 export interface Weather { airTempC: number; trackTempC: number; rainfall: boolean }
 export interface RaceControlMessage {
   rev: number; t: number; category: string; message: string; driver?: number;
@@ -39,6 +40,7 @@ export interface RaceState {
   totalLaps: number;
   stints: Record<number, Stint[]>;
   pitStops: Record<number, PitStop[]>;
+  pedalTraces: Record<number, PedalTrace>;
   weather?: Weather;
   messages: RaceControlMessage[];
   // Bumped on every snapshot (never on a frame) — lets a consumer (useComms) tell
@@ -62,7 +64,7 @@ export function isWarmingUp(s: RaceState): boolean {
 export function emptyState(): RaceState {
   return {
     session: '', mode: '', label: '', track: [], cars: {}, timeMs: 0, rev: 0,
-    radio: [], lapTrace: {}, totalLaps: 0, stints: {}, pitStops: {}, messages: [], snapshotSeq: 0,
+    radio: [], lapTrace: {}, totalLaps: 0, stints: {}, pitStops: {}, pedalTraces: {}, messages: [], snapshotSeq: 0,
     loopSeq: 0,
   };
 }
@@ -76,6 +78,7 @@ interface SnapshotData {
   totalLaps?: number;
   stints?: Record<number, Stint[]>;
   pitStops?: Record<number, PitStop[]>;
+  pedalTraces?: Record<number, PedalTrace>;
   weather?: Weather;
   messages?: RaceControlMessage[];
 }
@@ -125,6 +128,7 @@ export function parseMsg(raw: unknown): Msg | null {
     // stints/pitStops/weather are objects, not arrays — reject an array (would spread wrong).
     if (data.stints !== undefined && (typeof data.stints !== 'object' || data.stints === null || Array.isArray(data.stints))) return null;
     if (data.pitStops !== undefined && (typeof data.pitStops !== 'object' || data.pitStops === null || Array.isArray(data.pitStops))) return null;
+    if (data.pedalTraces !== undefined && (typeof data.pedalTraces !== 'object' || data.pedalTraces === null || Array.isArray(data.pedalTraces))) return null;
     if (data.weather !== undefined && (typeof data.weather !== 'object' || data.weather === null || Array.isArray(data.weather))) return null;
     return { type: 'snapshot', data: data as unknown as SnapshotData };
   }
@@ -149,7 +153,7 @@ export function applyMessage(s: RaceState, msg: Msg): RaceState {
       session: d.session, mode: d.mode, label: d.label,
       track: d.track ?? [], cars: { ...d.cars }, timeMs: d.timeMs, rev: d.rev,
       radio: d.radio ?? [], lapTrace: d.lapTrace ?? {}, totalLaps: d.totalLaps ?? 0,
-      stints: d.stints ?? {}, pitStops: d.pitStops ?? {}, weather: d.weather,
+      stints: d.stints ?? {}, pitStops: d.pitStops ?? {}, pedalTraces: d.pedalTraces ?? {}, weather: d.weather,
       messages: d.messages ?? [],
       snapshotSeq: s.snapshotSeq + 1,
       // A snapshot is a fresh baseline, not a wrap: keep the counter so a

--- a/web/src/state/race.ts
+++ b/web/src/state/race.ts
@@ -15,6 +15,7 @@ export interface Car {
   gapMs?: number; gapLaps?: number; intMs?: number;
   speed?: number; gear?: number; throttle?: number; brake?: number; drs?: boolean;
 }
+export interface Corner { number: number; x: number; y: number }
 export interface RadioMessage { timeMs: number; driverNum: number; clip: string }
 export interface Stint { compound: string; startLap: number; endLap: number }
 export interface PitStop { lap: number; durationS: number }
@@ -34,13 +35,17 @@ const LOOP_REWIND_MS = 5000;
 // Number() before comparing, as ghost.ts's commonDrivers does.
 export interface RaceState {
   session: string; mode: string; label: string;
-  track: Point[]; cars: Record<number, Car>; timeMs: number; rev: number;
+  track: Point[]; corners: Corner[]; cars: Record<number, Car>; timeMs: number; rev: number;
   radio: RadioMessage[];
   lapTrace: Record<number, number[]>;
   totalLaps: number;
   stints: Record<number, Stint[]>;
   pitStops: Record<number, PitStop[]>;
   pedalTraces: Record<number, PedalTrace>;
+  // One dominant driver number per fixed-size minisector of `track` (see
+  // web/src/components/geometry.ts's MINISECTOR_SIZE, mirrored in
+  // ingest/ghost.py); 0 means no driver had a positive time recorded there.
+  sectorDominance: number[];
   weather?: Weather;
   messages: RaceControlMessage[];
   // Bumped on every snapshot (never on a frame) — lets a consumer (useComms) tell
@@ -63,8 +68,9 @@ export function isWarmingUp(s: RaceState): boolean {
 
 export function emptyState(): RaceState {
   return {
-    session: '', mode: '', label: '', track: [], cars: {}, timeMs: 0, rev: 0,
-    radio: [], lapTrace: {}, totalLaps: 0, stints: {}, pitStops: {}, pedalTraces: {}, messages: [], snapshotSeq: 0,
+    session: '', mode: '', label: '', track: [], corners: [], cars: {}, timeMs: 0, rev: 0,
+    radio: [], lapTrace: {}, totalLaps: 0, stints: {}, pitStops: {}, pedalTraces: {}, sectorDominance: [],
+    messages: [], snapshotSeq: 0,
     loopSeq: 0,
   };
 }
@@ -72,13 +78,14 @@ export function emptyState(): RaceState {
 // Wire payloads from the gateway, mirroring internal/model (Snapshot, Frame).
 interface SnapshotData {
   session: string; mode: string; label: string;
-  track?: Point[]; cars: Record<number, Car>; timeMs: number; rev: number;
+  track?: Point[]; corners?: Corner[]; cars: Record<number, Car>; timeMs: number; rev: number;
   radio?: RadioMessage[];
   lapTrace?: Record<number, number[]>;
   totalLaps?: number;
   stints?: Record<number, Stint[]>;
   pitStops?: Record<number, PitStop[]>;
   pedalTraces?: Record<number, PedalTrace>;
+  sectorDominance?: number[];
   weather?: Weather;
   messages?: RaceControlMessage[];
 }
@@ -125,10 +132,12 @@ export function parseMsg(raw: unknown): Msg | null {
     if (data.messages !== undefined && !Array.isArray(data.messages)) return null;
     if (data.radio !== undefined && !isRadioRefs(data.radio)) return null;
     if (data.track !== undefined && !Array.isArray(data.track)) return null;
+    if (data.corners !== undefined && !Array.isArray(data.corners)) return null;
     // stints/pitStops/weather are objects, not arrays — reject an array (would spread wrong).
     if (data.stints !== undefined && (typeof data.stints !== 'object' || data.stints === null || Array.isArray(data.stints))) return null;
     if (data.pitStops !== undefined && (typeof data.pitStops !== 'object' || data.pitStops === null || Array.isArray(data.pitStops))) return null;
     if (data.pedalTraces !== undefined && (typeof data.pedalTraces !== 'object' || data.pedalTraces === null || Array.isArray(data.pedalTraces))) return null;
+    if (data.sectorDominance !== undefined && !Array.isArray(data.sectorDominance)) return null;
     if (data.weather !== undefined && (typeof data.weather !== 'object' || data.weather === null || Array.isArray(data.weather))) return null;
     return { type: 'snapshot', data: data as unknown as SnapshotData };
   }
@@ -151,9 +160,10 @@ export function applyMessage(s: RaceState, msg: Msg): RaceState {
     const d = msg.data;
     return {
       session: d.session, mode: d.mode, label: d.label,
-      track: d.track ?? [], cars: { ...d.cars }, timeMs: d.timeMs, rev: d.rev,
+      track: d.track ?? [], corners: d.corners ?? [], cars: { ...d.cars }, timeMs: d.timeMs, rev: d.rev,
       radio: d.radio ?? [], lapTrace: d.lapTrace ?? {}, totalLaps: d.totalLaps ?? 0,
-      stints: d.stints ?? {}, pitStops: d.pitStops ?? {}, pedalTraces: d.pedalTraces ?? {}, weather: d.weather,
+      stints: d.stints ?? {}, pitStops: d.pitStops ?? {}, pedalTraces: d.pedalTraces ?? {},
+      sectorDominance: d.sectorDominance ?? [], weather: d.weather,
       messages: d.messages ?? [],
       snapshotSeq: s.snapshotSeq + 1,
       // A snapshot is a fresh baseline, not a wrap: keep the counter so a


### PR DESCRIPTION
Implements the verified slices of `reviews/plans/features-to-add.md`. Each item was first verified by a subagent against the actual code (reports in `reviews/plans/verify/`, kept local), then built in waves.

## What landed
- **Item 1 — throttle/brake/gear traces over lap distance**: baked at record time (LapTrace pattern), carried on the contract, rendered in the two-car telemetry compare. RPM skipped.
- **Item 2 — pit-stop durations**: `pit_windows` (already computed in `ingest/record.py`) re-exported as a snapshot field per ADR-0005, shown on the stint chart. Positions gained/lost and stationary time deferred (`ponytail:` comments).
- **Item 3 (slice) — playback controls**: client-side pause/scrub/speed for the static replay lane only; server-paced live-lane scrub (full WS3) still needs its own design pass.
- **Item 4 (slice) — track furniture**: corner numbers + start/finish line from FastF1 circuit info, baked into the clip header (ADR-0004). DRS zones dropped (no data source); SC marker dropped (no track-status contract field yet).
- **Item 5 — sector-dominance minisector heatmap** on the track outline, fastest driver per minisector at bake time.
- **Item 6 — README**: explicit paragraph that the replay writer feeds the same contract/seam/gateway as live (simulated-live testing feed).

## Verification
`go test ./...` all pass · `pytest` in `ingest/` 89 passed · `tsc --noEmit` clean · `vitest run` 269/269. `-race` left to CI; no live FastF1 bake run (network).

🤖 Generated with [Claude Code](https://claude.com/claude-code)