### PR TITLE
chore(memory): record the route-all-commits-through-PRs rule

### DIFF
--- a/FILE-MAP.md
+++ b/FILE-MAP.md
@@ -487,6 +487,7 @@ Portable cross-session agent memory: one fact per file, indexed by memory/MEMORY
 | `code-review-level.md` | "Default /code-review effort is `high --fix`; `max` only when the user explicitly asks for it" |
 | `f1-build-gotchas.md` | F1 tracker build/verify gotchas — vite wipes web/dist/.gitkeep; bench artifacts are canonical; no cgo locally so go test -race only works in CI; live SignalR feed needs F1TV auth; running the static demo locally needs a bake plus a temporary web/.env.local |
 | `f1-tracker-direction.md` | "F1 Race Tracker: Phases 1-5 shipped, WS5 merged, signalrcore blocker resolved; 2026-08-28 improvement survey in reviews/{backlog-still-open,tech-debt-scan,peer-comparison}.md" |
+| `no-direct-pushes.md` | Feedback memory: never push directly to main, even for chores — always go through a PR. |
 | `plain-english-preference.md` | "User prefers plain-English, low-jargon explanations of technical options" |
 | `subagent-model-hook.md` | "Subagent model hook defaults to sonnet only when Agent call omits model; explicit model now wins" |
 | `token-economy.md` | "Token-economy rules are GLOBAL now (~/.claude/CLAUDE.md \"Subagents & Token Economy\") — this file keeps only the project-specific history" |
@@ -513,4 +514,4 @@ The golden snapshot pinning the wire contract between Go, Python and the fronten
 
 ---
 
-46 directories, 187 files listed, 0 without a declared purpose.
+46 directories, 188 files listed, 0 without a declared purpose.

--- a/memory/MEMORY.md
+++ b/memory/MEMORY.md
@@ -16,5 +16,6 @@ ones; don't duplicate what CLAUDE.md, FILE-MAP.md, CONTEXT.md, or git history al
 - [Token economy](token-economy.md) â€” rules are GLOBAL in ~/.claude/CLAUDE.md ("Subagents & Token Economy"); file keeps the why/history
 - [Code-review level](code-review-level.md) â€” default `code-review high --fix`; `max` only when the user explicitly asks
 - [Subagent model hook](subagent-model-hook.md) â€” omit `model` â†’ hook defaults sonnet; explicit model (e.g. opus) is respected
+- [No direct pushes](no-direct-pushes.md) — ALL commits (even chores) go through PRs; never push main directly
 - [F1 build gotchas](f1-build-gotchas.md) â€” vite wipes .gitkeep; bench/results.* canonical; no cgo locally, -race is CI-only; static demo needs a bake + temp web/.env.local
 

--- a/memory/MEMORY.md
+++ b/memory/MEMORY.md
@@ -1,8 +1,8 @@
 <!-- Index of the repo's portable agent memory: one line per memory file, plus the convention for adding one. -->
 # Memory Index
 
-This directory IS the memory system â€” it lives in the repo, not in `.claude/`, so it
-survives switching machines and works for any agent (Claude Code, Codex, Cursor, â€¦).
+This directory IS the memory system — it lives in the repo, not in `.claude/`, so it
+survives switching machines and works for any agent (Claude Code, Codex, Cursor, …).
 Read every file here at the start of a session.
 
 Convention: one fact per file, kebab-case name, frontmatter `name` / `description` /
@@ -11,11 +11,10 @@ memories as `[[other-file-name]]`. Add or update a file, then add/update its one
 pointer below. Never put memory content in this index. Update stale files, delete wrong
 ones; don't duplicate what CLAUDE.md, FILE-MAP.md, CONTEXT.md, or git history already say.
 
-- [Plain-English preference](plain-english-preference.md) â€” unpack jargon; lead with why it matters
-- [F1 Tracker direction](f1-tracker-direction.md) â€” 2026-08-28: signalrcore blocker RESOLVED, WS5 merged; fresh improvement survey in reviews/{backlog-still-open,tech-debt-scan,peer-comparison}.md
-- [Token economy](token-economy.md) â€” rules are GLOBAL in ~/.claude/CLAUDE.md ("Subagents & Token Economy"); file keeps the why/history
-- [Code-review level](code-review-level.md) â€” default `code-review high --fix`; `max` only when the user explicitly asks
-- [Subagent model hook](subagent-model-hook.md) â€” omit `model` â†’ hook defaults sonnet; explicit model (e.g. opus) is respected
+- [Plain-English preference](plain-english-preference.md) — unpack jargon; lead with why it matters
+- [F1 Tracker direction](f1-tracker-direction.md) — 2026-09-02: PR #94 merged all 6 peer-comparison features; static demo re-baked with the new clip-header fields
+- [Token economy](token-economy.md) — rules are GLOBAL in ~/.claude/CLAUDE.md ("Subagents & Token Economy"); file keeps the why/history
+- [Code-review level](code-review-level.md) — default `code-review high --fix`; `max` only when the user explicitly asks
+- [Subagent model hook](subagent-model-hook.md) — omit `model` → hook defaults sonnet; explicit model (e.g. opus) is respected
 - [No direct pushes](no-direct-pushes.md) — ALL commits (even chores) go through PRs; never push main directly
-- [F1 build gotchas](f1-build-gotchas.md) â€” vite wipes .gitkeep; bench/results.* canonical; no cgo locally, -race is CI-only; static demo needs a bake + temp web/.env.local
-
+- [F1 build gotchas](f1-build-gotchas.md) — vite wipes .gitkeep; bench/results.* canonical; no cgo locally, -race is CI-only; static demo needs a bake + temp web/.env.local

--- a/memory/no-direct-pushes.md
+++ b/memory/no-direct-pushes.md
@@ -1,0 +1,21 @@
+<!-- Feedback memory: never push directly to main, even for chores — always go through a PR. -->
+---
+name: no-direct-pushes
+description: Route ALL commits through PRs, including chore/docs/data commits — never push directly to main via the admin bypass
+metadata:
+  type: feedback
+---
+
+On 2026-09-02 four chore commits (memory updates, clip re-bake, FILE-MAP regen, BOM fix)
+were pushed straight to main using the owner's admin bypass; the ruleset flagged
+"Changes must be made through a pull request" each time. The user then said:
+route chore commits through PRs from now on.
+
+**Why:** the repo's branch protection ([[f1-tracker-direction]], protect-repo ruleset)
+exists so every change lands with the 7 required checks green *before* merge — the
+bypass skips that gate and puts red-main risk on even "safe" commits (the FILE-MAP
+staleness failure on main proved the point).
+
+**How to apply:** for any commit — chore, docs, data, memory — create a branch,
+push it, open a PR, and merge once checks pass (`gh pr merge --auto --squash` is fine).
+Never `git push` to main directly, regardless of how small the change is.


### PR DESCRIPTION
Records the new working agreement as a repo memory: every commit — chore, docs, data, memory — goes through a PR with checks green; no direct pushes to main via the admin bypass. Prompted by today''s four bypass pushes (one of which broke main CI on the FILE-MAP gate).

Gotcha captured along the way: `scripts/gen_file_map.py` only indexes git-tracked files, so regenerate AFTER `git add`-ing new files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)