### PR TITLE
chore: add the house ROADMAP.md (retro-filled)

### DIFF
--- a/FILE-MAP.md
+++ b/FILE-MAP.md
@@ -31,6 +31,7 @@ Repo root: module definition, container build, compose stack, and the top-level 
 | `Dockerfile` | Multi-stage image for the single Go binary: builds the React SPA, embeds it, and ships the gateway/replay server. |
 | `FILE-MAP.md` | Where every directory and source file lives and why — the layout half of the repo's memory system, generated from the DIRS table and each file's own header comment. |
 | `README.md` | What this project is, what it looks like, and how to run it. |
+| `ROADMAP.md` | **Current stage: Review** |
 | `SECURITY.md` | Security posture and vulnerability-reporting policy for this self-hosted app. |
 | `docker-compose.yml` | The local stack: Redis, a replay writer per compare lane, and the gateway serving the embedded SPA. |
 | `go.mod` | Go module definition and dependency set for the gateway, replay writer and command-line tools. |
@@ -514,4 +515,4 @@ The golden snapshot pinning the wire contract between Go, Python and the fronten
 
 ---
 
-46 directories, 188 files listed, 0 without a declared purpose.
+46 directories, 189 files listed, 0 without a declared purpose.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,7 +1,7 @@
 # Roadmap — f1-race-tracker
 
 **Current stage: Review**
-**Next up:** 2026-09-06 full-repo re-review (architecture, security, code-review of #94, UI guidelines + a11y on #94's new components, testing strategy, docs/repo-review), then file survivors as issues.
+**Next up:** work the 2026-09-06 re-review issues #99–#124 (start with #99 a11y blocker, #100 pit-stop bug, #101 host check, #102 scrub snap, #103 gap-estimator gate); owner decisions on the three `ready-for-human` issues.
 
 Lifecycle: Define → Plan → Build → Verify → Review → Ship.
 Agents: read this file at session start, state the current stage and next unchecked item before any other work, and update this file (checkboxes + Current stage + Next up) before ending. Product and design decisions belong to the user — elicit them with questions, never decide for them.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,64 @@
+# Roadmap — f1-race-tracker
+
+**Current stage: Review**
+**Next up:** 2026-09-06 full-repo re-review (architecture, security, code-review of #94, UI guidelines + a11y on #94's new components, testing strategy, docs/repo-review), then file survivors as issues.
+
+Lifecycle: Define → Plan → Build → Verify → Review → Ship.
+Agents: read this file at session start, state the current stage and next unchecked item before any other work, and update this file (checkboxes + Current stage + Next up) before ending. Product and design decisions belong to the user — elicit them with questions, never decide for them.
+
+> Retro-filled 2026-09-06: this repo predates the house roadmap. Boxes below are ticked only where the artifact verifiably exists in the repo (scope docs, ADRs, CI, README, Pages demo); unticked items are genuinely open.
+
+## 1 · Define — why this exists (before any code)
+
+- [x] One paragraph: who is this for, what pain does it remove? If the honest answer is "my resume", still pick a fictional real user — it forces every later decision. (`docs/F1_Race_Tracker_Product_Scope.md`)
+- [x] One sentence: what does this repo prove to a recruiter (stack keywords + one differentiator)? (README "why I built this")
+- [x] Name the cut line: the smallest version that is complete and presentable. (Phases 1–5 shipped)
+- [x] `docs/Product_Scope.md`: background & problem · proposed solution (behaviour, not tech) · hard rules/validation with exact UI copy · decision matrix for any state machine · explicit out-of-scope list · phases with the cut line marked. (`docs/F1_Race_Tracker_Product_Scope.md`)
+
+Exit: user has signed off the product scope. Skills: superpowers:brainstorming, grill-with-docs, feature-scope-docs.
+
+## 2 · Plan — how it gets built
+
+- [x] `docs/Tech_Scope.md`: stack with versions · data model sketch · core logic/formulae with a worked example · numbered tasks in vertical slices (each ends runnable + committed) · ⚠️ gotchas · test strategy per slice. (`docs/F1_Race_Tracker_Tech_Scope.md`)
+- [x] One ADR in `docs/adr/` per non-obvious decision, written when the decision is made, not after. (ADR-0001…0009)
+- [ ] `docs/Design_Direction.md` (any project with a UI): ground it in the subject's own world. Tokens: 4–6 named colors, 2–3 typefaces with roles, layout concept. One signature element; restraint everywhere else. Explicit loading/empty/error states with copy. Quality floor: focus visible, contrast, reduced motion, responsive to 375px. Self-check: "what would the generic default be, and where did I deviate?" (tokens live in `web/src/styles/tokens.css`; no written direction doc yet)
+
+Exit: numbered vertical slices exist and the user approves. Skills: superpowers:writing-plans, to-issues, hallmark (design direction).
+
+## 3 · Build — the only stage where feature code happens
+
+- [x] Day-1 hygiene, before feature work: sensible `.gitignore` · README stub with the purpose paragraph · OKF knowledge bundle + validator (local + CI) · CI running the test command (even if 0 tests yet) · /protect-repo once pushed public · Docker/compose for backing services · config via env vars from the start.
+- [x] Vertical slices from the Tech Scope, in order. Every slice: implement → test → commit with a message that names the slice. No slice starts while the previous one is red.
+
+Exit: all slices to the cut line done, CI green. Skills: tdd, ponytail.
+
+## 4 · Verify — does the real thing work
+
+- [x] Run the actual app end-to-end (not just tests): the happy path plus each hard rule from Product_Scope. (docker-compose demo + static Pages demo; live F1TV lane still needs a real race weekend)
+- [x] UI: check the built screens against Design_Direction.md — states (loading/empty/error), 375px, keyboard focus. (UI/UX audit applied in #93)
+
+Exit: no known broken flows. Skills: run, webapp-testing, diagnose.
+
+## 5 · Review — quality gate before polish
+
+- [x] `/code-review high --fix` on the accumulated work. (#72, #94 pre-merge)
+- [ ] `/simplify` pass.
+- [x] UI: web-design-guidelines audit. (#93; #94's new components not yet covered — this session)
+
+Exit: findings addressed or explicitly waived. Skills: code-review, simplify, web-design-guidelines.
+
+## 6 · Ship — recruiter-ready
+
+- [x] README rewrite: screenshots, architecture diagram, run-in-3-commands, "why I built this". (#86)
+- [ ] API docs/Swagger if applicable.
+- [x] Deployed demo link. (GitHub Pages static demo)
+- [ ] Final pass with /repo-review.
+
+Exit: /repo-review comes back clean. Skills: repo-review.
+
+## House rules
+
+- Docs before code; scope doc changes are cheaper than code changes.
+- Enforcement lives in the backend; the UI mirrors it.
+- One well-finished project beats three tutorial follow-alongs.
+- If a stage feels like ceremony for a tiny project, shrink the doc to a few sentences — but never skip the stage.


### PR DESCRIPTION
Adds the six-stage house roadmap. Boxes are ticked only where the artifact verifiably exists; Current stage is Review (this session's re-review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)