### PR TITLE
fix: gateway hardening (Host allowlist gaps, security headers, zlib cap)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,7 +33,8 @@ ALLOWED_ORIGINS=
 ALLOWED_SESSIONS=
 
 # Gateway role only: comma-separated Host-header allowlist (hostname only, no port) for
-# POST /control/source, on top of the Sec-Fetch-Site guard. Closes the DNS-rebinding gap
-# where a cross-site attacker page gets relabelled same-origin. Loopback (localhost,
-# 127.0.0.1, ::1) is always allowed; empty = loopback only.
+# POST /control/source, GET /api/f1auth and /ws, on top of the Sec-Fetch-Site guard.
+# Closes the DNS-rebinding gap where a cross-site attacker page gets relabelled
+# same-origin. Loopback (localhost, 127.0.0.1, ::1) is always allowed; this list is
+# additive on top of that default — ALLOWED_HOSTS="" does NOT restrict below loopback.
 ALLOWED_HOSTS=

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,3 +13,26 @@ privately rather than opening a public issue:
 
 Please include what you found, where (file/line if possible), and how to reproduce it.
 There's no fixed response-time guarantee, but reports will be looked at and credited.
+
+## Threat model
+
+This app is meant to run two ways, and everything above is weighed against those two
+cases only:
+
+1. **Single-operator local deployment.** You run the Go gateway and Python ingest on
+   your own machine (or LAN), reachable at `localhost`/`127.0.0.1` (or a host you've
+   explicitly added to `ALLOWED_HOSTS`). There's one user — you — and no login, because
+   there's no one else to authenticate against. The gateway trusts whoever can reach its
+   port, the same way a personal `localhost:3000` dev server does; it is not designed to
+   be exposed to the public internet or a shared/untrusted network.
+2. **Static GitHub Pages demo.** The public demo at
+   `https://natcat38.github.io/f1-race-tracker/` is a pre-built, static replay with no
+   backend, no ingest, and no control endpoints — it's a read-only artifact, not a
+   running instance of the gateway.
+
+Findings are judged as "real" when they'd let an attacker cross one of those boundaries:
+reach the gateway from a page it didn't intend to trust (the DNS-rebinding class of
+issue this file's history covers), exhaust resources it wasn't given a way to bound, or
+get more out of a response than the single operator asked for. Findings that assume a
+multi-tenant server, a public deployment with untrusted concurrent users, or an
+authentication system are out of scope until the project actually takes on that shape.

--- a/ingest/live_parsers.py
+++ b/ingest/live_parsers.py
@@ -8,7 +8,10 @@ the other cross-module dedup).
 """
 import base64
 import json
+import logging
 import zlib
+
+_log = logging.getLogger(__name__)
 
 # Upper bound on a decompressed Position.z payload (#117/L-3). A single frame's worth of
 # car positions is a few KB of JSON at most; 8 MiB is generous headroom while still
@@ -65,9 +68,16 @@ def _decode_position_payload(payload) -> list:
             decompressor = zlib.decompressobj(-15)  # raw deflate (no header)
             decompressed = decompressor.decompress(raw, _MAX_DECOMPRESSED_BYTES)
             if decompressor.unconsumed_tail:
-                raise ValueError(
-                    f"Position.z payload exceeds {_MAX_DECOMPRESSED_BYTES} bytes decompressed"
+                # Oversized payload: this is a distinct, loggable condition (a
+                # zip-bomb-shaped or corrupt frame), not "not zlib" — don't let it
+                # fall through to the plain-JSON fallback below and disappear as an
+                # ordinary empty result (#117 review: silent truncation looked
+                # identical to a benign non-zlib payload).
+                _log.warning(
+                    "Position.z payload exceeds %d bytes decompressed; dropping frame",
+                    _MAX_DECOMPRESSED_BYTES,
                 )
+                return []
             decoded = json.loads(decompressed)
             return decoded.get('Position', [])
         except Exception:

--- a/ingest/live_parsers.py
+++ b/ingest/live_parsers.py
@@ -10,6 +10,11 @@ import base64
 import json
 import zlib
 
+# Upper bound on a decompressed Position.z payload (#117/L-3). A single frame's worth of
+# car positions is a few KB of JSON at most; 8 MiB is generous headroom while still
+# refusing a zip-bomb-shaped payload before it can exhaust memory.
+_MAX_DECOMPRESSED_BYTES = 8 * 1024 * 1024
+
 # FastF1 team name -> frontend colour map key (from web/src/components/teamColours.ts)
 TEAM_MAP = {
     'Red Bull Racing': 'Red Bull',
@@ -54,7 +59,15 @@ def _decode_position_payload(payload) -> list:
         # Try zlib-compressed base64 (fastf1._api.parse zipped=True path)
         try:
             raw = base64.b64decode(payload)
-            decompressed = zlib.decompress(raw, -15)  # raw deflate (no header)
+            # ponytail: stdlib decompressobj with max_length is simpler than a custom
+            # chunked-read loop and gives us exactly what we need — decompress up to the
+            # cap, then check for leftover input instead of trusting a declared size.
+            decompressor = zlib.decompressobj(-15)  # raw deflate (no header)
+            decompressed = decompressor.decompress(raw, _MAX_DECOMPRESSED_BYTES)
+            if decompressor.unconsumed_tail:
+                raise ValueError(
+                    f"Position.z payload exceeds {_MAX_DECOMPRESSED_BYTES} bytes decompressed"
+                )
             decoded = json.loads(decompressed)
             return decoded.get('Position', [])
         except Exception:

--- a/ingest/test_live_parsers.py
+++ b/ingest/test_live_parsers.py
@@ -151,6 +151,20 @@ def test_decode_position_payload_unparseable_returns_empty_list():
     assert _decode_position_payload("not json and not base64 either!!") == []
 
 
+def test_decode_position_payload_zip_bomb_capped_not_exhausted():
+    # #117: a highly compressible payload that would decompress to well beyond
+    # live_parsers._MAX_DECOMPRESSED_BYTES must be refused, not decompressed in full.
+    import live_parsers
+
+    huge = b"0" * (live_parsers._MAX_DECOMPRESSED_BYTES * 4)
+    compressor = zlib.compressobj(9, zlib.DEFLATED, -15)  # raw deflate, no header
+    compressed = compressor.compress(huge) + compressor.flush()
+    payload = base64.b64encode(compressed).decode()
+    # The oversized decompression is caught and treated like any other unparseable
+    # payload (empty list), never a multi-hundred-MB buffer in memory.
+    assert _decode_position_payload(payload) == []
+
+
 def test_team_map_matches_frontend_colour_keys():
     # Spot-check a couple of entries rather than the whole dict — the exhaustive
     # mapping is a data table, not logic worth asserting entry-by-entry here.
@@ -175,6 +189,7 @@ if __name__ == "__main__":
     test_decode_position_payload_zlib_b64_string()
     test_decode_position_payload_plain_json_string()
     test_decode_position_payload_unparseable_returns_empty_list()
+    test_decode_position_payload_zip_bomb_capped_not_exhausted()
     test_team_map_matches_frontend_colour_keys()
     print("live_parsers self-check PASSED")
     sys.exit(0)

--- a/internal/app/gateway.go
+++ b/internal/app/gateway.go
@@ -206,6 +206,12 @@ func (g *Gateway) getOrCreateHub(session string) (*ws.Hub, error) {
 // wsHandler routes /ws to the active hub (M3 toggle path) or, when ?session=<key>
 // is present, to that session's registry hub.
 func (g *Gateway) wsHandler(w http.ResponseWriter, r *http.Request) {
+	// Host allowlist (L-1/#101): same DNS-rebinding gap as handleControl — an attacker
+	// domain re-resolved to loopback would otherwise reach the hub as if same-origin.
+	if !hostAllowed(r.Host, g.allowedHosts) {
+		http.Error(w, "unrecognized host", http.StatusForbidden)
+		return
+	}
 	session := r.URL.Query().Get("session")
 	if session == "" {
 		g.mu.Lock()
@@ -229,13 +235,44 @@ func (g *Gateway) wsHandler(w http.ResponseWriter, r *http.Request) {
 
 // Mount registers the gateway routes on mux. staticHandler serves the SPA (Task 9).
 func (g *Gateway) Mount(mux *http.ServeMux, staticHandler http.Handler) {
-	mux.HandleFunc("/ws", g.wsHandler)
-	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
-	mux.HandleFunc("/control/source", g.handleControl)
-	mux.HandleFunc("/api/f1auth", g.handleAuthStatus)
+	mux.Handle("/ws", securityHeaders(http.HandlerFunc(g.wsHandler)))
+	mux.Handle("/healthz", securityHeaders(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })))
+	mux.Handle("/control/source", securityHeaders(http.HandlerFunc(g.handleControl)))
+	mux.Handle("/api/f1auth", securityHeaders(http.HandlerFunc(g.handleAuthStatus)))
 	if staticHandler != nil {
-		mux.Handle("/", staticHandler)
+		mux.Handle("/", securityHeaders(noDirListing(staticHandler)))
 	}
+}
+
+// securityHeaders wraps every route with baseline response headers for a browser
+// rendering this app's pages (#116/L-2). No CSP: the SPA build (web/index.html,
+// vite.config.ts) has no inline scripts/styles today, but Vite's dev/preview
+// output isn't guaranteed nonce/hash-friendly across builds, and a broken CSP fails
+// silent-and-blank for a single-operator local tool — not worth the risk for a
+// loopback-only deployment. ponytail: headers only, no CSP report-only plumbing.
+func securityHeaders(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h := w.Header()
+		h.Set("X-Content-Type-Options", "nosniff")
+		h.Set("X-Frame-Options", "DENY")
+		h.Set("Referrer-Policy", "no-referrer")
+		next.ServeHTTP(w, r)
+	})
+}
+
+// noDirListing wraps a static file handler so a directory-shaped request (no
+// index.html present) 404s instead of falling through to http.FileServer's
+// directory listing (#116/I-4). ponytail: a trailing-slash check on the request
+// path is enough here — the embedded SPA has no directories an operator should
+// browse into, so there's no need to inspect the underlying fs.FS.
+func noDirListing(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/" && strings.HasSuffix(r.URL.Path, "/") {
+			http.NotFound(w, r)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
 }
 
 // handleAuthStatus serves the Python-published F1TV auth status verbatim (ADR-0007).
@@ -244,6 +281,12 @@ func (g *Gateway) Mount(mux *http.ServeMux, staticHandler http.Handler) {
 func (g *Gateway) handleAuthStatus(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	// Host allowlist (L-1/#101): the disclosed data (F1TV tier/expiry) is sensitive
+	// enough that the same DNS-rebinding guard used on /control/source applies here.
+	if !hostAllowed(r.Host, g.allowedHosts) {
+		http.Error(w, "unrecognized host", http.StatusForbidden)
 		return
 	}
 	raw, err := g.bus.GetAuthStatus(r.Context())

--- a/internal/app/gateway_test.go
+++ b/internal/app/gateway_test.go
@@ -420,3 +420,140 @@ func TestAuthStatusRoute(t *testing.T) {
 		t.Errorf("POST status = %d, want 405", resp.StatusCode)
 	}
 }
+
+// #101: GET /api/f1auth applies the same Host allowlist as /control/source — a
+// DNS-rebound foreign Host is rejected, loopback still works.
+func TestAuthStatusRoute_RejectsForeignHost(t *testing.T) {
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mr.Close()
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	defer func() { _ = rdb.Close() }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	g, err := NewGateway(ctx, bus.New(rdb), "replay", slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	mux := http.NewServeMux()
+	g.Mount(mux, nil)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	get := func(host string) int {
+		req, _ := http.NewRequest(http.MethodGet, srv.URL+"/api/f1auth", nil)
+		req.Host = host
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_ = resp.Body.Close()
+		return resp.StatusCode
+	}
+
+	if code := get("evil.com"); code != http.StatusForbidden {
+		t.Errorf("rebound-host GET status = %d, want 403", code)
+	}
+	if code := get("127.0.0.1"); code != http.StatusOK {
+		t.Errorf("loopback-host GET status = %d, want 200", code)
+	}
+}
+
+// #101: /ws applies the same Host allowlist — a DNS-rebound foreign Host never
+// reaches the hub, loopback still upgrades normally.
+func TestWsHandler_RejectsForeignHost(t *testing.T) {
+	b := testBus(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	g, err := NewGateway(ctx, b, "replay", slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	mux := http.NewServeMux()
+	g.Mount(mux, nil)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	get := func(host string) int {
+		req, _ := http.NewRequest(http.MethodGet, srv.URL+"/ws", nil)
+		req.Host = host
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_ = resp.Body.Close()
+		return resp.StatusCode
+	}
+
+	if code := get("evil.com"); code != http.StatusForbidden {
+		t.Errorf("rebound-host /ws status = %d, want 403", code)
+	}
+	// Loopback isn't rejected by the Host check; a plain GET without the WebSocket
+	// upgrade headers fails at the coder/websocket layer instead (400), which is
+	// enough to prove the Host check itself let it through.
+	if code := get("127.0.0.1"); code == http.StatusForbidden {
+		t.Errorf("loopback-host /ws status = %d, want != 403", code)
+	}
+}
+
+// #116: every mounted route sets the baseline security headers.
+func TestSecurityHeaders_SetOnEveryRoute(t *testing.T) {
+	b := testBus(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	g, err := NewGateway(ctx, b, "replay", slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	mux := http.NewServeMux()
+	g.Mount(mux, http.NotFoundHandler())
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	for _, path := range []string{"/healthz", "/api/f1auth", "/"} {
+		resp, err := http.Get(srv.URL + path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_ = resp.Body.Close()
+		if got := resp.Header.Get("X-Content-Type-Options"); got != "nosniff" {
+			t.Errorf("%s: X-Content-Type-Options = %q, want nosniff", path, got)
+		}
+		if got := resp.Header.Get("X-Frame-Options"); got != "DENY" {
+			t.Errorf("%s: X-Frame-Options = %q, want DENY", path, got)
+		}
+		if got := resp.Header.Get("Referrer-Policy"); got != "no-referrer" {
+			t.Errorf("%s: Referrer-Policy = %q, want no-referrer", path, got)
+		}
+	}
+}
+
+// #116: a directory-shaped static request 404s instead of falling through to
+// http.FileServer's directory listing.
+func TestNoDirListing_RejectsDirectoryRequest(t *testing.T) {
+	b := testBus(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	g, err := NewGateway(ctx, b, "replay", slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	mux := http.NewServeMux()
+	// A FileServer over a directory with no index.html at "/assets" would otherwise
+	// emit a listing; noDirListing must reject the directory-shaped request first.
+	g.Mount(mux, http.FileServer(http.Dir(t.TempDir())))
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/assets/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("GET /assets/ status = %d, want 404", resp.StatusCode)
+	}
+}


### PR DESCRIPTION
## #101 — Host allowlist gap on /api/f1auth and /ws
`hostAllowed` was only checked on `POST /control/source`. A DNS-rebinding attack (an attacker domain re-resolving to loopback mid-session) could still reach `GET /api/f1auth` (leaking F1TV account tier/expiry) and `/ws` with no Host check at all. Added the same `hostAllowed(r.Host, g.allowedHosts)` check to both handlers, and clarified in `.env.example` that `ALLOWED_HOSTS` is additive on top of the always-allowed loopback default.

## #116 — Security headers, directory listing, threat model
- Added a small `securityHeaders` middleware wrapping every mounted route: `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Referrer-Policy: no-referrer`.
- Skipped a CSP: the SPA (`web/index.html`) has no inline scripts/styles today, but Vite's build output isn't guaranteed nonce/hash-stable across builds, and a broken CSP fails silently for a single-operator local tool — noted as a `// ponytail:` comment in `gateway.go` rather than guessing at a policy.
- Added `noDirListing` so a directory-shaped static request (e.g. `/assets/` with no `index.html`) 404s instead of falling through to `http.FileServer`'s directory listing.
- Added a plain-English "Threat model" section to `SECURITY.md` covering the two real deployments (single-operator local, static GitHub Pages demo) and what's out of scope.

## #117 — Unbounded zlib decompression on Position.z
`zlib.decompress(raw, -15)` had no cap. Switched to `zlib.decompressobj(-15).decompress(raw, max_length)` with an 8 MiB cap, rejecting an oversized/bomb-like payload the same way any other unparseable payload is handled (empty position list) instead of decompressing it in full.

## Test plan
- [x] `go test ./...` — all pass (new tests: `TestAuthStatusRoute_RejectsForeignHost`, `TestWsHandler_RejectsForeignHost`, `TestSecurityHeaders_SetOnEveryRoute`, `TestNoDirListing_RejectsDirectoryRequest`)
- [x] `gofmt -l .` — empty
- [x] `go vet ./...` — clean
- [x] `cd ingest && python -m pytest -q` — 94 passed, 1 skipped (pre-existing `check_gap_estimator` skip, #103, unrelated)
- [x] `python scripts/gen_file_map.py` — no diff

Closes #101
Closes #116
Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)