### PR TITLE
Fix replay-scrub teleport threshold and scrubber styling

### DIFF
--- a/FILE-MAP.md
+++ b/FILE-MAP.md
@@ -213,6 +213,7 @@ The app shell: entry point, root component, error boundary, static-demo bootstra
 
 | File | Purpose |
 | --- | --- |
+| `App.replayScrub.test.tsx` | Static-markup coverage for the replay scrub row (issues #107, #108): the range input must reuse the Ghost scrubber's shared dark-mode/touch-target class instead of being a bare, unclassed input, and the elapsed readout must NOT reuse the hero session-clock class (.rail-clock) — it needs its own smaller class so it doesn't visually outrank the real session clock. |
 | `App.test.tsx` | Regression coverage for the shell's data-source connection: opened once when the board is first shown, and kept alive across route changes. |
 | `App.tsx` | The React app shell: mounts the root component, wires the live WebSocket or static-replay data source into race state, and lays out the dashboard panels. |
 | `ErrorBoundary.tsx` | React error boundary that keeps one component's render-time exception from blanking the whole app. |
@@ -271,6 +272,7 @@ Hooks deriving UI-facing state (staleness, gap/lap history, smoothed positions, 
 | `useLane.ts` | React binding for the shared lane registry: one session key, one connection, however many overlay sides name it. |
 | `useReducedMotion.ts` | Subscribes to prefers-reduced-motion for the two places motion is driven from JavaScript. |
 | `useRollingHistory.ts` | The shared fold behind the lap and gap histories, including reset on session switch or replay-loop restart. |
+| `useSmoothedCars.test.ts` | Pure-function coverage for issue #102: TELEPORT_THRESHOLD must be compared in the same [0,1] normalised track-space as the car positions themselves, so a scrub-sized jump actually snaps instead of gliding across the map. |
 | `useSmoothedCars.ts` | Interpolates car positions at display refresh rate so 10 Hz frames render as continuous motion. |
 | `useStale.ts` | Tracks how long it has been since the last frame, so the UI can say when data has gone stale. |
 
@@ -517,4 +519,4 @@ The golden snapshot pinning the wire contract between Go, Python and the fronten
 
 ---
 
-46 directories, 191 files listed, 0 without a declared purpose.
+46 directories, 193 files listed, 0 without a declared purpose.

--- a/web/src/App.replayScrub.test.tsx
+++ b/web/src/App.replayScrub.test.tsx
@@ -1,0 +1,48 @@
+/**
+ * Static-markup coverage for the replay scrub row (issues #107, #108): the
+ * range input must reuse the Ghost scrubber's shared dark-mode/touch-target
+ * class instead of being a bare, unclassed input, and the elapsed readout
+ * must NOT reuse the hero session-clock class (.rail-clock) — it needs its
+ * own smaller class so it doesn't visually outrank the real session clock.
+ *
+ * @vitest-environment jsdom
+ */
+
+import { describe, test, expect, vi, afterEach } from 'vitest';
+import { render, cleanup, screen } from '@testing-library/react';
+
+vi.mock('./staticDemo', () => ({ STATIC_DEMO: true, REPO_URL: 'https://example.test/repo' }));
+vi.mock('./components/Ghost', () => ({ Ghost: () => <div>ghost stub</div> }));
+vi.mock('./realtime/staticReplay', () => ({
+  connectStaticReplay: (
+    onState: (s: unknown) => void,
+    onStatus: (s: string) => void,
+    setDuration: (d: number) => void,
+  ) => {
+    onStatus('connected');
+    onState({ cars: {}, rev: 1, timeMs: 0, track: [], lapTrace: {}, label: '' });
+    setDuration(60_000); // non-zero so the scrub row renders
+    return () => {};
+  },
+}));
+vi.mock('./realtime/socket', () => ({ connectRace: vi.fn(() => vi.fn()) }));
+
+const { default: App } = await import('./App');
+
+afterEach(cleanup);
+
+describe('replay scrub row styling (#107, #108)', () => {
+  test('the range input carries the shared dark/touch-target range class, not a raw width', () => {
+    render(<App />);
+    const input = screen.getByLabelText('Replay position');
+    expect(input.className).toContain('range-dark');
+  });
+
+  test('the elapsed readout does not reuse the hero .rail-clock class', () => {
+    render(<App />);
+    const input = screen.getByLabelText('Replay position');
+    const readout = input.parentElement?.querySelector('span:last-of-type');
+    expect(readout?.className).not.toContain('rail-clock');
+    expect(readout?.className).toContain('rail-scrub-clock');
+  });
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -350,6 +350,7 @@ export default function App() {
                   </button>
                   <input
                     type="range"
+                    className="range-dark"
                     min={0}
                     max={Math.max(0, replayDuration - 1)}
                     step={100}
@@ -357,9 +358,9 @@ export default function App() {
                     onChange={(e) => scrubReplay(Number(e.target.value))}
                     aria-label="Replay position"
                     aria-valuetext={fmtElapsed(replayTMs)}
-                    style={{ width: 120 }}
+                    style={{ minWidth: 80, flex: '1 1 120px' }}
                   />
-                  <span className="rail-clock">{fmtElapsed(replayTMs)}</span>
+                  <span className="rail-scrub-clock">{fmtElapsed(replayTMs)}</span>
                 </>
               ) : (
                 /* Label swap rather than aria-pressed, matching the overlay's existing

--- a/web/src/hooks/useSmoothedCars.test.ts
+++ b/web/src/hooks/useSmoothedCars.test.ts
@@ -1,0 +1,18 @@
+// Pure-function coverage for issue #102: TELEPORT_THRESHOLD must be compared
+// in the same [0,1] normalised track-space as the car positions themselves,
+// so a scrub-sized jump actually snaps instead of gliding across the map.
+
+import { describe, test, expect } from 'vitest';
+import { snapTeleports } from './useSmoothedCars';
+
+describe('snapTeleports (#102)', () => {
+  test('a scrub-sized jump snaps (from starts at the new point)', () => {
+    const prevTo = { 1: { x: 0.1, y: 0.1 } };
+    // Far larger than any real frame-to-frame motion, but well within [0,1]²
+    // — this is the exact case the old SIZE-scale threshold (50) could never
+    // catch, since the max possible [0,1]-space distance is only ~1.41.
+    const next = { 1: { x: 0.9, y: 0.9 } };
+    const snapped = snapTeleports(next, prevTo);
+    expect(snapped[1]).toEqual(next[1]);
+  });
+});

--- a/web/src/hooks/useSmoothedCars.ts
+++ b/web/src/hooks/useSmoothedCars.ts
@@ -5,6 +5,29 @@ import { useEffect, useRef, useState } from 'react';
 import type { Car, RaceState, Point } from '../state/race';
 import { useReducedMotion } from './useReducedMotion';
 
+// ponytail: a scrub or loop restart moves a car far more than one 10Hz frame
+// ever could (normal frame-to-frame motion on this track is well under this
+// in track-space units) — snap instead of gliding across the map.
+// CarState.P is normalised track-space in [0,1] (Map.tsx, geometry.ts scale
+// by SIZE only at render time), so the threshold must be in that same unit.
+export const TELEPORT_THRESHOLD = 0.08;
+
+// Pure helper (exported for testing without rendering the hook): for each
+// car, decides whether the animation should glide from its previous point or
+// snap by starting the "from" point at the new point itself.
+export function snapTeleports(
+  next: Record<number, Point>,
+  prevTo: Record<number, Point>,
+): Record<number, Point> {
+  const snapped: Record<number, Point> = {};
+  for (const [id, p] of Object.entries(next)) {
+    const prev = prevTo[Number(id)];
+    const dist = prev ? Math.hypot(p.x - prev.x, p.y - prev.y) : 0;
+    snapped[Number(id)] = prev && dist <= TELEPORT_THRESHOLD ? prev : p;
+  }
+  return snapped;
+}
+
 // Returns cars with positions interpolated at display refresh rate.
 // Cars glide from their previous position to their current position over one
 // frame interval (~100 ms at 10 Hz), keeping motion smooth at the display's
@@ -33,17 +56,7 @@ export function useSmoothedCars(state: RaceState, paused = false): Car[] {
     const prevTo = to.current;
     const next: Record<number, Point> = {};
     for (const c of Object.values(state.cars)) next[c.driverNum] = c.p;
-    // ponytail: a scrub or loop restart moves a car far more than one 10Hz frame
-    // ever could (normal frame-to-frame motion on this track is well under this
-    // in track-space units) — snap instead of gliding across the map.
-    const TELEPORT_THRESHOLD = 50;
-    const snapped: Record<number, Point> = {};
-    for (const [id, p] of Object.entries(next)) {
-      const prev = prevTo[Number(id)];
-      const dist = prev ? Math.hypot(p.x - prev.x, p.y - prev.y) : 0;
-      snapped[Number(id)] = prev && dist <= TELEPORT_THRESHOLD ? prev : p;
-    }
-    from.current = snapped;
+    from.current = snapTeleports(next, prevTo);
     to.current = next;
     tFrom.current = tTo.current || now;
     tTo.current = now;

--- a/web/src/styles/components.css
+++ b/web/src/styles/components.css
@@ -328,6 +328,16 @@
   font-size: var(--fs-sm);
 }
 
+/* The replay-scrub elapsed readout is a control-size number beside the
+   scrubber, not the rail's one hero session clock — .rail-clock's display
+   size would misrank it (issue #108). */
+.rail-scrub-clock {
+  font-family: var(--data);
+  font-variant-numeric: tabular-nums;
+  font-size: var(--fs-sm);
+  color: var(--slate);
+}
+
 /* The gap between the readout zones and the control zones. An element rather
    than margin-left:auto on the first control zone, because which zone that is
    depends on the route: the overlay has no lane control and Settings has no
@@ -1057,7 +1067,8 @@ select.btn {
 /* Range input — the default Windows chrome is light even under color-scheme:
    dark, so the ghost scrubber gets an explicit dark track and thumb. */
 
-.ghost-controls input[type="range"] {
+.ghost-controls input[type="range"],
+.range-dark {
   appearance: none;
   -webkit-appearance: none;
   background: transparent;
@@ -1065,24 +1076,28 @@ select.btn {
   cursor: pointer;
 }
 
-.ghost-controls input[type="range"]:disabled {
+.ghost-controls input[type="range"]:disabled,
+.range-dark:disabled {
   cursor: not-allowed;
   opacity: 0.5;
 }
 
-.ghost-controls input[type="range"]::-webkit-slider-runnable-track {
+.ghost-controls input[type="range"]::-webkit-slider-runnable-track,
+.range-dark::-webkit-slider-runnable-track {
   height: 4px;
   border-radius: 2px;
   background: var(--edge);
 }
 
-.ghost-controls input[type="range"]::-moz-range-track {
+.ghost-controls input[type="range"]::-moz-range-track,
+.range-dark::-moz-range-track {
   height: 4px;
   border-radius: 2px;
   background: var(--edge);
 }
 
-.ghost-controls input[type="range"]::-webkit-slider-thumb {
+.ghost-controls input[type="range"]::-webkit-slider-thumb,
+.range-dark::-webkit-slider-thumb {
   appearance: none;
   -webkit-appearance: none;
   width: 14px;
@@ -1093,7 +1108,8 @@ select.btn {
   border: 1px solid var(--asphalt);
 }
 
-.ghost-controls input[type="range"]::-moz-range-thumb {
+.ghost-controls input[type="range"]::-moz-range-thumb,
+.range-dark::-moz-range-thumb {
   width: 14px;
   height: 14px;
   border: 1px solid var(--asphalt);
@@ -1184,7 +1200,8 @@ select.btn {
 
   /* The overlay's primary control was a 20px-tall target for a precision drag.
      The visual track stays 4px — only the hit box grows. */
-  .ghost-controls input[type="range"] {
+  .ghost-controls input[type="range"],
+  .range-dark {
     height: 44px;
   }
 


### PR DESCRIPTION
## Summary

- **#102** — the teleport-snap threshold compared a normalised [0,1] track-space distance against a SIZE-space constant (50), so it could never trip; scrubbing glided cars across the map instead of snapping. Extracted the snap decision into a pure `snapTeleports()` helper and set the threshold to `0.08` in the same [0,1] unit as the distance.
- **#107** — the replay-scrub `<input type="range">` was bare and unclassed, so it missed the Ghost overlay scrubber's dark-mode track/thumb styling and 44px touch-target rule, and used a hardcoded 120px width. Extracted a shared `.range-dark` class (covering the existing `.ghost-controls input[type="range"]` rules too) and replaced the fixed width with a flexible `min-width`.
- **#108** — the replay-elapsed readout reused `.rail-clock`, the hero session-clock class, so it rendered at display size next to the real session clock. Gave it its own `.rail-scrub-clock` class at normal body-text size.

## Test plan

- [x] `npx eslint src --max-warnings 0` — clean
- [x] `npx tsc -b` — clean
- [x] `npx vitest run` — 272/272 passing, including one new pure-function test for the snap threshold and one static-markup test asserting the new class names
- [x] `python scripts/gen_file_map.py` — no changes needed

Closes #102
Closes #107
Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)