### PR TITLE
fix(ingest): correct pit-stop derivation, drop pandas from pit.py

### DIFF
--- a/ingest/pit.py
+++ b/ingest/pit.py
@@ -4,51 +4,77 @@ Position-data 'Status' does NOT reliably tag pit lane in FastF1 (verified
 empty — 'OnTrack' for the entire session, even during a confirmed pit
 stop) — so a car's Pit/Out status is derived from lap timing
 (PitInTime/PitOutTime) instead, which is authoritative.
+
+Deliberately pandas-free (see issue #114): callers (record.py) convert the
+FastF1 laps DataFrame's Timedelta columns to plain floats/None before calling
+build_pit_data, so this module imports cleanly in CI's fastf1-free contract
+job like ghost.py/radio.py/race_control.py/resample.py.
 """
-import pandas as pd
 
 
-def build_pit_data(drv):
+def build_pit_data(laps):
     """Derive pit-lane windows and pit_stops entries for one driver's laps.
 
-    `drv` is a FastF1 laps DataFrame (or anything with the same columns:
-    LapNumber, PitInTime, PitOutTime, LapStartTime) for a single driver.
+    `laps` is an iterable of (lap_number, pit_in_s, pit_out_s, lap_start_s)
+    tuples for a single driver, in any order — one per lap. lap_number is an
+    int or None; the three time fields are floats (seconds) or None.
+
     Returns (windows, stops) where windows is a list of (pit_in_s, pit_out_s)
     tuples used for pit-window flagging, and stops is a list of
-    {"lap": int, "durationS": float} — one per REAL pit stop.
+    {"lap": int, "durationS": float} — one per REAL, completed pit stop.
 
-    A car that starts the race from the pit lane has a PitOutTime with no
-    preceding PitInTime; we backdate a synthetic pit_in to the lap's own
-    LapStartTime purely so the car is still flagged as "in the pits" up to
-    PitOutTime. That backdated edge is not a real stop, so it must never
+    A car that starts the race from the pit lane has a pit_out_s with no
+    preceding pit_in_s; we backdate a synthetic pit_in to the lap's own
+    lap_start_s purely so the car is still flagged as "in the pits" up to
+    pit_out_s. That backdated edge is not a real stop, so it must never
     produce a pit_stops entry (a pit-lane start is not a pit stop).
+
+    A driver who retires while stationary in the pits (pit_in_s seen but no
+    pit_out_s ever follows) gets a window out to the end of the data so it
+    still reads as "in the pits", but no pit_stops entry — there is no real
+    duration to report, and fabricating one (e.g. a flat 30s) would misrepresent
+    a retirement as a completed stop downstream (see issue #110).
     """
     windows = []
     stops = []
     pit_in = None
     pit_in_lap = None
     pit_in_synthetic = False
-    for _, lap in drv.sort_values('LapNumber').iterrows():
-        if not pd.isna(lap['PitInTime']):
-            pit_in = lap['PitInTime'].total_seconds()
-            pit_in_lap = None if pd.isna(lap['LapNumber']) else int(lap['LapNumber'])
-            pit_in_synthetic = False
-        if not pd.isna(lap['PitOutTime']):
-            if pit_in is None and not pd.isna(lap['LapStartTime']):
-                pit_in = lap['LapStartTime'].total_seconds()
-                pit_in_lap = None if pd.isna(lap['LapNumber']) else int(lap['LapNumber'])
+    for lap_number, pit_in_s, pit_out_s, lap_start_s in sorted(
+        laps, key=lambda r: (r[0] is None, r[0])
+    ):
+        # Process PitOutTime (closing any pending window) before PitInTime
+        # (opening a new one) — a same-row PitOutTime+PitInTime pair (e.g. a
+        # double-stack) must close stop 1 with THIS row's pit_out before
+        # stop 2's pit_in overwrites the pending state (issue #100).
+        if pit_out_s is not None:
+            if pit_in is None and lap_start_s is not None:
+                pit_in = lap_start_s
+                pit_in_lap = lap_number
                 pit_in_synthetic = True
             if pit_in is not None:
-                pit_out = lap['PitOutTime'].total_seconds()
-                windows.append((pit_in, pit_out))
+                windows.append((pit_in, pit_out_s))
                 if pit_in_lap is not None and not pit_in_synthetic:
-                    stops.append({"lap": pit_in_lap, "durationS": round(pit_out - pit_in, 1)})
+                    stops.append({"lap": pit_in_lap, "durationS": round(pit_out_s - pit_in, 1)})
                 pit_in = None
                 pit_in_lap = None
                 pit_in_synthetic = False
+        if pit_in_s is not None:
+            pit_in = pit_in_s
+            pit_in_lap = lap_number
+            pit_in_synthetic = False
     if pit_in is not None:
-        pit_out = pit_in + 30  # no recorded out-lap; assume a typical stop
+        # No PitOutTime ever arrived for this pending window: either the
+        # session's data just ends mid-stop, or the driver retired in the
+        # pits. Keep flagging the car as "in the pits" for a typical stop
+        # window (windows only drive position-flagging, not the stint
+        # timeline), but do not fabricate a pit_stops entry — there is no
+        # real duration to report for a stop that never completed.
+        # ponytail: omitting the entry (vs. carrying a null-duration/incomplete
+        # flag through the contract) is the simplest fix that matches how
+        # StintChart consumes pitStops today — it only ever reads real,
+        # completed stops, so a missing entry just means "no stop shown" and
+        # can't crash anything.
+        pit_out = pit_in + 30
         windows.append((pit_in, pit_out))
-        if pit_in_lap is not None and not pit_in_synthetic:
-            stops.append({"lap": pit_in_lap, "durationS": round(pit_out - pit_in, 1)})
     return windows, stops

--- a/ingest/record.py
+++ b/ingest/record.py
@@ -526,7 +526,16 @@ for num in session.drivers:
     if out:
         stints[inum] = out
 
-    windows, stops = build_pit_data(drv)
+    pit_laps = [
+        (
+            None if pd.isna(lap['LapNumber']) else int(lap['LapNumber']),
+            None if pd.isna(lap['PitInTime']) else lap['PitInTime'].total_seconds(),
+            None if pd.isna(lap['PitOutTime']) else lap['PitOutTime'].total_seconds(),
+            None if pd.isna(lap['LapStartTime']) else lap['LapStartTime'].total_seconds(),
+        )
+        for _, lap in drv.iterrows()
+    ]
+    windows, stops = build_pit_data(pit_laps)
     pit_windows[inum] = windows
     if stops:
         pit_stops[inum] = stops

--- a/ingest/test_pit.py
+++ b/ingest/test_pit.py
@@ -1,82 +1,137 @@
 """Unit tests for the pure pit-window / pit-stop derivation in ingest/pit.py.
 
-Needs pandas (to build laps-like DataFrames), which CI's fastf1-free contract
-job doesn't install — skip cleanly there, run for real wherever pandas exists.
+pit.py is deliberately pandas-free (issue #114), so this needs nothing beyond
+pytest and runs in CI's fastf1-free contract job like ghost.py/radio.py's tests.
 """
-import pytest
-
-pd = pytest.importorskip("pandas", reason="needs pandas for laps DataFrames; not installed in the fastf1-free contract job")
-
-from pit import build_pit_data  # noqa: E402
+from pit import build_pit_data
 
 
 def _laps(rows):
-    """Build a laps-like DataFrame from dicts of LapNumber/PitInTime/PitOutTime/LapStartTime
-    given as plain seconds (float) or None; converted to Timedelta like FastF1 laps."""
-    def td(v):
-        return pd.NaT if v is None else pd.Timedelta(seconds=v)
-
-    return pd.DataFrame([{
-        "LapNumber": r["LapNumber"],
-        "PitInTime": td(r.get("PitInTime")),
-        "PitOutTime": td(r.get("PitOutTime")),
-        "LapStartTime": td(r.get("LapStartTime")),
-    } for r in rows])
+    """Build the plain-tuple laps shape build_pit_data expects from dicts of
+    LapNumber/PitInTime/PitOutTime/LapStartTime given as plain seconds (float)
+    or None (or omitted, meaning None) — the shape record.py hands over after
+    converting FastF1's Timedelta columns."""
+    return [
+        (
+            r["LapNumber"],
+            r.get("PitInTime"),
+            r.get("PitOutTime"),
+            r.get("LapStartTime"),
+        )
+        for r in rows
+    ]
 
 
 def test_pit_lane_start_produces_a_window_but_no_stop():
     # Car starts the race from the pit lane: lap 1 has a PitOutTime but no
     # PitInTime. The backdated pit_in must flag the pit window but must NOT
     # be recorded as a pit stop.
-    drv = _laps([
+    laps = _laps([
         {"LapNumber": 1, "LapStartTime": 0.0, "PitOutTime": 25.0},
         {"LapNumber": 2, "LapStartTime": 90.0},
         {"LapNumber": 3, "LapStartTime": 180.0},
     ])
-    windows, stops = build_pit_data(drv)
+    windows, stops = build_pit_data(laps)
     assert windows == [(0.0, 25.0)]
     assert stops == []
 
 
 def test_real_pit_stop_mid_race_is_recorded():
-    drv = _laps([
+    laps = _laps([
         {"LapNumber": 1, "LapStartTime": 0.0},
         {"LapNumber": 10, "LapStartTime": 900.0, "PitInTime": 905.0},
         {"LapNumber": 11, "LapStartTime": 930.0, "PitOutTime": 927.0},
     ])
-    windows, stops = build_pit_data(drv)
+    windows, stops = build_pit_data(laps)
     assert windows == [(905.0, 927.0)]
     assert stops == [{"lap": 10, "durationS": 22.0}]
 
 
 def test_pit_lane_start_followed_by_a_real_stop_records_only_the_real_one():
-    drv = _laps([
+    laps = _laps([
         {"LapNumber": 1, "LapStartTime": 0.0, "PitOutTime": 25.0},
         {"LapNumber": 20, "LapStartTime": 1800.0, "PitInTime": 1805.0},
         {"LapNumber": 21, "LapStartTime": 1830.0, "PitOutTime": 1827.0},
     ])
-    windows, stops = build_pit_data(drv)
+    windows, stops = build_pit_data(laps)
     assert windows == [(0.0, 25.0), (1805.0, 1827.0)]
     assert stops == [{"lap": 20, "durationS": 22.0}]
 
 
 def test_no_pit_activity_yields_empty_windows_and_stops():
-    drv = _laps([
+    laps = _laps([
         {"LapNumber": 1, "LapStartTime": 0.0},
         {"LapNumber": 2, "LapStartTime": 90.0},
     ])
-    windows, stops = build_pit_data(drv)
+    windows, stops = build_pit_data(laps)
     assert windows == []
     assert stops == []
 
 
-def test_unfinished_stop_at_end_of_data_assumes_typical_duration_no_lap_dropped():
+def test_unfinished_stop_at_end_of_data_flags_window_but_records_no_stop():
     # PitInTime seen but no matching PitOutTime anywhere after (rare edge —
-    # session ended mid-stop). Still recorded as a real stop since a real
-    # PitInTime existed.
-    drv = _laps([
+    # session ended mid-stop). No real duration exists, so no pit_stops entry
+    # is fabricated (issue #110) — the window still flags the car as "in the
+    # pits" for a typical stop length.
+    laps = _laps([
         {"LapNumber": 5, "LapStartTime": 400.0, "PitInTime": 405.0},
     ])
-    windows, stops = build_pit_data(drv)
+    windows, stops = build_pit_data(laps)
     assert windows == [(405.0, 435.0)]
-    assert stops == [{"lap": 5, "durationS": 30.0}]
+    assert stops == []
+
+
+def test_driver_retires_mid_stop_gets_no_fabricated_pit_stop_entry():
+    # Same shape as above but explicitly modeling a mid-race retirement: the
+    # driver pits on lap 30 and the data simply ends there (car never leaves).
+    # Regression test for issue #110 — must not synthesize a plausible-looking
+    # 30.0s pit_stops entry for a stop that never actually completed.
+    laps = _laps([
+        {"LapNumber": 1, "LapStartTime": 0.0},
+        {"LapNumber": 29, "LapStartTime": 2600.0},
+        {"LapNumber": 30, "LapStartTime": 2700.0, "PitInTime": 2705.0},
+    ])
+    windows, stops = build_pit_data(laps)
+    assert windows == [(2705.0, 2735.0)]
+    assert stops == []
+
+
+def test_back_to_back_stops_on_consecutive_laps_are_both_recorded():
+    # Regression test for issue #100: two independent stops on consecutive
+    # laps (not a same-row double-stack) must both be recorded — the second
+    # PitInTime must not corrupt or drop the first stop's pending window.
+    laps = _laps([
+        {"LapNumber": 1, "LapStartTime": 0.0},
+        {"LapNumber": 10, "LapStartTime": 900.0, "PitInTime": 905.0},
+        {"LapNumber": 11, "LapStartTime": 930.0, "PitOutTime": 927.0},
+        {"LapNumber": 12, "LapStartTime": 960.0, "PitInTime": 965.0},
+        {"LapNumber": 13, "LapStartTime": 990.0, "PitOutTime": 987.0},
+    ])
+    windows, stops = build_pit_data(laps)
+    assert windows == [(905.0, 927.0), (965.0, 987.0)]
+    assert stops == [
+        {"lap": 10, "durationS": 22.0},
+        {"lap": 12, "durationS": 22.0},
+    ]
+
+
+def test_same_row_pit_out_and_pit_in_closes_the_pending_stop_first():
+    # Regression test for issue #100: a same-row PitOutTime (closing stop 1)
+    # and PitInTime (opening stop 2) — e.g. a double-stack or a stop-go right
+    # after leaving the pits. The PitOutTime branch must close stop 1 with
+    # THIS row's PitOutTime before the PitInTime branch opens stop 2, instead
+    # of stop 2's pit_in overwriting stop 1's pending state first.
+    laps = _laps([
+        {"LapNumber": 1, "LapStartTime": 0.0},
+        {"LapNumber": 10, "LapStartTime": 900.0, "PitInTime": 905.0},
+        # Lap 11: car leaves stop 1 (PitOutTime=927) and immediately pits
+        # again for stop 2 (PitInTime=929) on the same lap row.
+        {"LapNumber": 11, "LapStartTime": 930.0, "PitOutTime": 927.0, "PitInTime": 929.0},
+        {"LapNumber": 12, "LapStartTime": 960.0, "PitOutTime": 951.0},
+    ])
+    windows, stops = build_pit_data(laps)
+    assert windows == [(905.0, 927.0), (929.0, 951.0)]
+    assert stops == [
+        {"lap": 10, "durationS": 22.0},
+        {"lap": 11, "durationS": 22.0},
+    ]


### PR DESCRIPTION
## #100 — back-to-back pit stops corrupt each other

`build_pit_data` checked the PitInTime branch before the PitOutTime branch on the same lap row, so a same-row double-stack (out-lap of stop 1 + in-lap of stop 2) overwrote stop 1's pending window before it was closed, silently dropping the stop. Fixed by processing PitOutTime (closing any pending window) before PitInTime (opening a new one) within each row. Added tests for two stops on consecutive laps and for the same-row double-stack case.

## #110 — retiring mid-stop no longer fabricates a 30s pit stop

A driver who retires while stationary in the pits (PitInTime set, no PitOutTime ever follows) used to hit the tail fallback and get a `{"lap": N, "durationS": 30.0}` entry recorded — a plausible-looking stop that never happened. Now the pit window is still flagged (so the car reads as "in the pits"), but no `pit_stops` entry is recorded for an incomplete stop. Verified `StintChart.tsx` only reads real entries from `pitStops[driverNum]` and doesn't crash on a missing one. Left a `# ponytail:` comment noting this (omit the entry) is the simplest fix vs. threading an `incomplete` flag through the Go contract. Added a regression test.

## #114 — pit.py no longer imports pandas

`pit.py` was the only ingest helper importing pandas at module level, breaking the pandas-free convention the CI `contract` job relies on (it installs only `pytest`/`pytest-cov`/`redis`). `build_pit_data` now takes plain `(lap_number, pit_in_s, pit_out_s, lap_start_s)` tuples instead of a FastF1 laps DataFrame; `record.py` converts the Timedelta columns to floats/None before calling it. `test_pit.py` no longer needs `pytest.importorskip("pandas")` and now runs in the pandas-free job too.

Closes #100
Closes #110
Closes #114

## Test plan
- `cd ingest && python -m pytest -q` — 96 passed, 1 skipped→now runs (pre-existing `check_gap_estimator` failure is unrelated, tracked as #103)
- `python -c "import sys; sys.modules['pandas']=None; import pit"` — succeeds
- `python scripts/gen_file_map.py` — no changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)