### PR TITLE
Collapse Source's 9 session-constant getters into Baked()

### DIFF
--- a/cmd/bake-static/main.go
+++ b/cmd/bake-static/main.go
@@ -59,16 +59,9 @@ func run(clipPath, outPath, session string) error {
 // clip to a fresh Redis session — rather than trusting the file's own
 // (advisory, possibly-repeating) Rev values.
 func bake(src *replay.Source, session string, w *bufio.Writer) error {
-	snap := model.NewSnapshot(session, src.Mode(), src.Label())
-	snap.Track = src.Track()
-	snap.Corners = src.Corners()
-	snap.Radio = src.Radio()
-	snap.LapTrace = src.LapTrace()
-	snap.TotalLaps = src.TotalLaps()
-	snap.Stints = src.Stints()
-	snap.PitStops = src.PitStops()
-	snap.PedalTraces = src.PedalTraces()
-	snap.SectorDominance = src.SectorDominance()
+	snap := src.Baked()
+	snap.SessionKey = session
+	snap.Cars = make(map[int]model.CarState)
 
 	sb, err := ws.EncodeSnapshot(snap)
 	if err != nil {

--- a/internal/app/writer.go
+++ b/internal/app/writer.go
@@ -12,20 +12,12 @@ import (
 	"github.com/natcat38/f1-race-tracker/internal/model"
 )
 
-// Source is what the writer consumes (satisfied by replay.Source).
+// Source is what the writer consumes (satisfied by replay.Source). Baked returns
+// the session-constant fields (Track, Corners, Radio, ... — see replay.Source.Baked)
+// as a Snapshot; the writer stamps it with the per-invocation SessionKey, Cars and Rev.
 type Source interface {
 	Events(ctx context.Context) (<-chan model.Frame, error)
-	Track() []model.Point
-	Corners() []model.Corner
-	Radio() []model.RadioMessage
-	LapTrace() map[int][]int
-	TotalLaps() int
-	Stints() map[int][]model.Stint
-	PitStops() map[int][]model.PitStop
-	PedalTraces() map[int]model.PedalTrace
-	SectorDominance() []int
-	Label() string
-	Mode() string
+	Baked() *model.Snapshot
 }
 
 // Writer folds source frames into a snapshot and publishes snapshot+frame to Redis.
@@ -58,16 +50,9 @@ func (wr *Writer) Run(ctx context.Context, session string) error {
 	if existing != nil {
 		base = existing.Rev
 	}
-	snap := model.NewSnapshot(session, wr.src.Mode(), wr.src.Label())
-	snap.Track = wr.src.Track()
-	snap.Corners = wr.src.Corners()
-	snap.Radio = wr.src.Radio()
-	snap.LapTrace = wr.src.LapTrace()
-	snap.TotalLaps = wr.src.TotalLaps()
-	snap.Stints = wr.src.Stints()
-	snap.PitStops = wr.src.PitStops()
-	snap.PedalTraces = wr.src.PedalTraces()
-	snap.SectorDominance = wr.src.SectorDominance()
+	snap := wr.src.Baked()
+	snap.SessionKey = session
+	snap.Cars = make(map[int]model.CarState)
 	snap.Rev = base
 	rev := base
 	for {

--- a/internal/app/writer_test.go
+++ b/internal/app/writer_test.go
@@ -22,17 +22,14 @@ type fakeSource struct {
 	stints map[int][]model.Stint
 }
 
-func (f *fakeSource) Track() []model.Point                  { return []model.Point{{X: 0, Y: 0}} }
-func (f *fakeSource) Corners() []model.Corner               { return nil }
-func (f *fakeSource) Radio() []model.RadioMessage           { return nil }
-func (f *fakeSource) LapTrace() map[int][]int               { return nil }
-func (f *fakeSource) TotalLaps() int                        { return 0 }
-func (f *fakeSource) Stints() map[int][]model.Stint         { return f.stints }
-func (f *fakeSource) PitStops() map[int][]model.PitStop     { return nil }
-func (f *fakeSource) PedalTraces() map[int]model.PedalTrace { return nil }
-func (f *fakeSource) SectorDominance() []int                { return nil }
-func (f *fakeSource) Label() string                         { return "Fake" }
-func (f *fakeSource) Mode() string                          { return "replay" }
+func (f *fakeSource) Baked() *model.Snapshot {
+	return &model.Snapshot{
+		Mode:   model.ModeReplay,
+		Label:  "Fake",
+		Track:  []model.Point{{X: 0, Y: 0}},
+		Stints: f.stints,
+	}
+}
 func (f *fakeSource) Events(ctx context.Context) (<-chan model.Frame, error) {
 	ch := make(chan model.Frame)
 	go func() {
@@ -53,17 +50,9 @@ func (f *fakeSource) Events(ctx context.Context) (<-chan model.Frame, error) {
 // blocks on ctx after emitting) — exercising Writer.Run's frames-channel-closed branch.
 type closingSource struct{ frames []model.Frame }
 
-func (closingSource) Track() []model.Point                  { return nil }
-func (closingSource) Corners() []model.Corner               { return nil }
-func (closingSource) Radio() []model.RadioMessage           { return nil }
-func (closingSource) LapTrace() map[int][]int               { return nil }
-func (closingSource) TotalLaps() int                        { return 0 }
-func (closingSource) Stints() map[int][]model.Stint         { return nil }
-func (closingSource) PitStops() map[int][]model.PitStop     { return nil }
-func (closingSource) PedalTraces() map[int]model.PedalTrace { return nil }
-func (closingSource) SectorDominance() []int                { return nil }
-func (closingSource) Label() string                         { return "Closing" }
-func (closingSource) Mode() string                          { return "replay" }
+func (closingSource) Baked() *model.Snapshot {
+	return &model.Snapshot{Mode: model.ModeReplay, Label: "Closing"}
+}
 func (s closingSource) Events(ctx context.Context) (<-chan model.Frame, error) {
 	ch := make(chan model.Frame)
 	go func() {

--- a/internal/feed/replay/play.go
+++ b/internal/feed/replay/play.go
@@ -103,17 +103,30 @@ func Load(path string, speed float64) (*Source, error) {
 	}, nil
 }
 
-func (s *Source) Track() []model.Point                  { return s.track }
-func (s *Source) Corners() []model.Corner               { return s.corners }
-func (s *Source) Radio() []model.RadioMessage           { return s.radio }
-func (s *Source) LapTrace() map[int][]int               { return s.lapTrace }
-func (s *Source) TotalLaps() int                        { return s.totalLaps }
-func (s *Source) Stints() map[int][]model.Stint         { return s.stints }
-func (s *Source) PitStops() map[int][]model.PitStop     { return s.pitStops }
-func (s *Source) PedalTraces() map[int]model.PedalTrace { return s.pedalTraces }
-func (s *Source) SectorDominance() []int                { return s.sectorDominance }
-func (s *Source) Label() string                         { return s.label }
-func (s *Source) Mode() string                          { return "replay" }
+func (s *Source) Label() string { return s.label }
+func (s *Source) Mode() string  { return "replay" }
+
+// Baked returns the session-constant fields recorded in the clip header — Track,
+// Corners, Radio, LapTrace, TotalLaps, Stints, PitStops, PedalTraces,
+// SectorDominance, Mode and Label — as a Snapshot ready for a caller to stamp with
+// its own SessionKey, Cars and Rev (all per-invocation, not per-clip). Adding a new
+// baked field only touches clipHeader, the Source struct, and this method — writer.go
+// and bake-static no longer need a matching getter or assignment line.
+func (s *Source) Baked() *model.Snapshot {
+	return &model.Snapshot{
+		Mode:            model.ModeReplay,
+		Label:           s.label,
+		Track:           s.track,
+		Corners:         s.corners,
+		Radio:           s.radio,
+		LapTrace:        s.lapTrace,
+		TotalLaps:       s.totalLaps,
+		Stints:          s.stints,
+		PitStops:        s.pitStops,
+		PedalTraces:     s.pedalTraces,
+		SectorDominance: s.sectorDominance,
+	}
+}
 
 // Frames returns every frame in the clip, in file order, with each frame's Rev
 // exactly as recorded in the file (advisory — a caller publishing to a fresh

--- a/internal/feed/replay/play_test.go
+++ b/internal/feed/replay/play_test.go
@@ -62,8 +62,9 @@ func TestReplay_HeaderAndMonotonicRevAcrossLoop(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if src.Label() != "Lbl" || src.Mode() != "replay" || len(src.Track()) != 1 {
-		t.Fatalf("header wrong: label=%q mode=%q track=%d", src.Label(), src.Mode(), len(src.Track()))
+	baked := src.Baked()
+	if src.Label() != "Lbl" || src.Mode() != "replay" || len(baked.Track) != 1 {
+		t.Fatalf("header wrong: label=%q mode=%q track=%d", src.Label(), src.Mode(), len(baked.Track))
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
@@ -136,7 +137,7 @@ func TestLoadParsesRadioFromHeader(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	radio := src.Radio()
+	radio := src.Baked().Radio
 	if len(radio) != 1 || radio[0].DriverNum != 1 || radio[0].TimeMs != 3300500 || radio[0].Clip == "" {
 		t.Fatalf("radio not parsed: %+v", radio)
 	}
@@ -154,7 +155,7 @@ func TestLoadParsesLapTraceFromHeader(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	lt := src.LapTrace()
+	lt := src.Baked().LapTrace
 	// JSON object keys are strings on the wire; Go unmarshals them back to int map keys.
 	if len(lt) != 2 || len(lt[1]) != 3 || lt[1][0] != 0 || lt[1][2] != 200 || lt[16][1] != 90 {
 		t.Fatalf("lapTrace not parsed: %+v", lt)
@@ -194,7 +195,7 @@ func TestLoadParsesTotalLapsFromHeader(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := src.TotalLaps(); got != 53 {
+	if got := src.Baked().TotalLaps; got != 53 {
 		t.Fatalf("totalLaps = %d, want 53", got)
 	}
 }


### PR DESCRIPTION
## What

Before: `internal/app.Source` (the interface `Writer` consumes) required 9
separate getters — `Track()`, `Corners()`, `Radio()`, `LapTrace()`,
`TotalLaps()`, `Stints()`, `PitStops()`, `PedalTraces()`, `SectorDominance()`
— and both `internal/app/writer.go` and `cmd/bake-static/main.go` had a
matching `snap.X = src.X()` line for each one, duplicated byte-for-byte.

After: the interface has one method, `Baked() *model.Snapshot`, that
`replay.Source` populates once at `Load()` time from the clip header. Both
call sites collapse to:

```go
snap := src.Baked()
snap.SessionKey = session
snap.Cars = make(map[int]model.CarState)
```

(plus `snap.Rev = base` in the writer, which is per-invocation, not per-clip).

Adding a future baked field (e.g. a speed-trap widget) is now a one-file
change in `internal/feed/replay/play.go` (the `clipHeader` field, the
`Source` struct field, and one line in `Baked()`) instead of a lockstep edit
across `play.go`, `writer.go`, and `bake-static/main.go`.

## Why

Flagged in `reviews/2026-09-06/architecture.md` as the top refactor to do
before WS4 — PR #94 added 4 fields and had to touch all 4 files in lockstep,
with no compiler-enforced link between them.

## Notes

- Pure refactor, no behavior change. The JSON contract is untouched —
  `model.Snapshot`'s fields and tags are unchanged, only how `Source`
  populates them.
- `writer_test.go`'s `fakeSource`/`closingSource` and `play_test.go` are
  updated to use `Baked()` instead of the removed getters; their assertions
  are unchanged.
- `Label()` and `Mode()` stay on `replay.Source` (used directly by
  `cmd/server/main.go` for logging) but are no longer part of the `app.Source`
  interface, since `Baked()` already carries `Mode`/`Label`.

## Test plan

- [x] `gofmt -l .` — empty
- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean
- [x] `go test ./...` — all packages pass
- [x] `python scripts/gen_file_map.py` — no diff (no files added/removed)

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)