### PR TITLE
Fix pit-stop tick contrast and telemetry trace a11y/tests

### DIFF
--- a/FILE-MAP.md
+++ b/FILE-MAP.md
@@ -30,6 +30,8 @@ Repo root: module definition, container build, compose stack, and the top-level 
 | `CONTEXT.md` | The project glossary: the shared vocabulary every layer, issue and ADR is expected to use. |
 | `Dockerfile` | Multi-stage image for the single Go binary: builds the React SPA, embeds it, and ships the gateway/replay server. |
 | `FILE-MAP.md` | Where every directory and source file lives and why — the layout half of the repo's memory system, generated from the DIRS table and each file's own header comment. |
+| `FILE-MAP.md` | Where every directory and source file lives and why — the layout half of the repo's memory system, generated from the DIRS table and each file's own header comment. |
+| `FILE-MAP.md` | Where every directory and source file lives and why — the layout half of the repo's memory system, generated from the DIRS table and each file's own header comment. |
 | `README.md` | What this project is, what it looks like, and how to run it. |
 | `ROADMAP.md` | **Current stage: Review** |
 | `SECURITY.md` | Security posture and vulnerability-reporting policy for this self-hosted app. |
@@ -250,6 +252,7 @@ Presentational components — map, timing tower, telemetry, comms, race control,
 | `StintChart.render.test.tsx` | Render tests for the strategy timeline's stint segments and leader marker. |
 | `StintChart.tsx` | The full-race strategy timeline: one row per car, each stint a coloured segment on a lap axis. |
 | `TelemetryPanel.interaction.test.tsx` | Interaction coverage for the telemetry panel: picking and clearing a rival from the "Compare with" select, the one interaction it actually owns. |
+| `TelemetryPanel.trace.test.tsx` | Render tests for TelemetryPanel's distance-trace SVGs (throttle/brake/gear): covers the pickThrottle/pickBrake/pickGear + toPolyline path (#121) and the derived-summary aria-label that replaces the bare "<label> over lap distance" text alternative (#106). |
 | `TelemetryPanel.tsx` | The selected car's telemetry readout: speed, gear, pedal bars and lap/gap sparklines. |
 | `TimingTower.render.test.tsx` | Render tests for the timing tower's rows, columns and empty states. |
 | `TimingTower.test.ts` | Unit tests for the timing helpers: lap/gap/sector formatting, ordering and personal bests. |
@@ -520,4 +523,4 @@ The golden snapshot pinning the wire contract between Go, Python and the fronten
 
 ---
 
-46 directories, 194 files listed, 0 without a declared purpose.
+46 directories, 197 files listed, 0 without a declared purpose.

--- a/FILE-MAP.md
+++ b/FILE-MAP.md
@@ -30,8 +30,6 @@ Repo root: module definition, container build, compose stack, and the top-level 
 | `CONTEXT.md` | The project glossary: the shared vocabulary every layer, issue and ADR is expected to use. |
 | `Dockerfile` | Multi-stage image for the single Go binary: builds the React SPA, embeds it, and ships the gateway/replay server. |
 | `FILE-MAP.md` | Where every directory and source file lives and why — the layout half of the repo's memory system, generated from the DIRS table and each file's own header comment. |
-| `FILE-MAP.md` | Where every directory and source file lives and why — the layout half of the repo's memory system, generated from the DIRS table and each file's own header comment. |
-| `FILE-MAP.md` | Where every directory and source file lives and why — the layout half of the repo's memory system, generated from the DIRS table and each file's own header comment. |
 | `README.md` | What this project is, what it looks like, and how to run it. |
 | `ROADMAP.md` | **Current stage: Review** |
 | `SECURITY.md` | Security posture and vulnerability-reporting policy for this self-hosted app. |
@@ -523,4 +521,4 @@ The golden snapshot pinning the wire contract between Go, Python and the fronten
 
 ---
 
-46 directories, 197 files listed, 0 without a declared purpose.
+46 directories, 195 files listed, 0 without a declared purpose.

--- a/web/src/components/StintChart.render.test.tsx
+++ b/web/src/components/StintChart.render.test.tsx
@@ -51,3 +51,22 @@ describe('StintChart leader-lap marker', () => {
     expect(html).toContain('Leader is on lap 0');
   });
 });
+
+describe('StintChart pit-stop tick contrast (#105)', () => {
+  test('draws the tick with an asphalt casing outline instead of a fallback colour', () => {
+    const state = {
+      ...emptyState(),
+      totalLaps: 53,
+      cars: { 1: car({ driverNum: 1, pos: 1, lap: 12 }) },
+      stints: { 1: [{ compound: 'HARD', startLap: 1, endLap: 20 }] },
+      pitStops: { 1: [{ lap: 10, durationS: 22.4 }] },
+    };
+    const html = renderToStaticMarkup(<StintChart state={state} />);
+    // The dead `var(--amber, orange)` CSS-fallback must be gone; the tick now
+    // carries its own dark casing so it holds 3:1 contrast against any
+    // compound colour underneath it, not just the darker ones.
+    expect(html).not.toContain('orange');
+    expect(html).toContain('box-shadow:0 0 0 1px var(--asphalt)');
+    expect(html).toContain('pit stop on lap 10, 22.4 seconds');
+  });
+});

--- a/web/src/components/StintChart.tsx
+++ b/web/src/components/StintChart.tsx
@@ -80,7 +80,13 @@ function StintChartInner({ state, selected, rival }: {
                   left: `${((p.lap - 1) / total) * 100}%`,
                   top: -2, bottom: -2,
                   width: 2,
-                  background: 'var(--amber, orange)',
+                  background: 'var(--amber)',
+                  // Dark casing so the tick holds WCAG 1.4.11 3:1 non-text contrast
+                  // against every compound colour underneath it, not just the darker
+                  // ones — amber-on-HARD measured ~1.5:1, amber-on-MEDIUM ~1.1:1
+                  // without it (#105). Mirrors the leader-lap marker's fixed-background
+                  // contrast, but via an outline since this tick sits on a variable one.
+                  boxShadow: '0 0 0 1px var(--asphalt)',
                 }}
               />
             ))}

--- a/web/src/components/TelemetryPanel.trace.test.tsx
+++ b/web/src/components/TelemetryPanel.trace.test.tsx
@@ -1,0 +1,83 @@
+// Render tests for TelemetryPanel's distance-trace SVGs (throttle/brake/gear):
+// covers the pickThrottle/pickBrake/pickGear + toPolyline path (#121) and the
+// derived-summary aria-label that replaces the bare "<label> over lap
+// distance" text alternative (#106).
+
+import { describe, test, expect } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { TelemetryPanel } from './TelemetryPanel';
+import { emptyState, type RaceState } from '../state/race';
+import { car } from '../state/testCar';
+
+function stateWithTraces(pedalTraces: RaceState['pedalTraces']): RaceState {
+  return {
+    ...emptyState(),
+    cars: { 1: car({ driverNum: 1, code: 'VER' }) },
+    pedalTraces,
+  };
+}
+
+function render(state: RaceState) {
+  return renderToStaticMarkup(
+    <TelemetryPanel state={state} lapHistory={{}} gapHistory={{}} selected={1} rival={null} />,
+  );
+}
+
+describe('TelemetryPanel distance trace', () => {
+  test('draws throttle/brake/gear polylines and a summarised aria-label for equal-length samples', () => {
+    const html = render(stateWithTraces({
+      1: { throttle: [0, 50, 100], brake: [100, 50, 0], gear: [1, 4, 8] },
+    }));
+    expect(html).toContain('Throttle over lap distance: ranging 0 to 100, ending at 100');
+    expect(html).toContain('Brake over lap distance: ranging 0 to 100, ending at 0');
+    // Gear as integer steps: min/max/last should read as whole numbers, not 8.0.
+    expect(html).toContain('Gear over lap distance: ranging 1 to 8, ending at 8');
+    expect(html).toMatch(/<polyline[^>]*points="0\.00,28\.00 50\.00,14\.00 100\.00,0\.00"/);
+  });
+
+  test('does not crash when the two cars have mismatched trace lengths', () => {
+    const html = renderToStaticMarkup(
+      <TelemetryPanel
+        state={{
+          ...emptyState(),
+          cars: {
+            1: car({ driverNum: 1, code: 'VER' }),
+            16: car({ driverNum: 16, code: 'LEC' }),
+          },
+          pedalTraces: {
+            1: { throttle: [0, 50, 100], brake: [0, 0, 0], gear: [1, 2, 3] },
+            16: { throttle: [10, 90], brake: [0, 0], gear: [2, 2] },
+          },
+        }}
+        lapHistory={{}}
+        gapHistory={{}}
+        selected={1}
+        rival={16}
+      />,
+    );
+    expect(html).toContain('Throttle over lap distance');
+    expect(html).toContain('LEC');
+  });
+
+  test('does not crash on NaN/undefined samples, and excludes them from the summary', () => {
+    const html = render(stateWithTraces({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- deliberately malformed samples
+      1: { throttle: [0, NaN, undefined as any, 100], brake: [0, 0, 0, 0], gear: [1, 1, 1, 1] },
+    }));
+    expect(html).toContain('Throttle over lap distance: ranging 0 to 100, ending at 100');
+  });
+
+  test('renders "no data" summary and no crash for an empty trace array', () => {
+    const html = render(stateWithTraces({
+      1: { throttle: [], brake: [], gear: [] },
+    }));
+    expect(html).toContain('Throttle over lap distance: no data');
+    expect(html).toContain('Brake over lap distance: no data');
+    expect(html).toContain('Gear over lap distance: no data');
+  });
+
+  test('renders nothing distance-trace-related when the selected car has no pedal trace', () => {
+    const html = render(stateWithTraces({}));
+    expect(html).not.toContain('over lap distance');
+  });
+});

--- a/web/src/components/TelemetryPanel.tsx
+++ b/web/src/components/TelemetryPanel.tsx
@@ -145,6 +145,20 @@ function toPolyline(values: number[], max: number): string {
   return pts.join(' ');
 }
 
+// Text alternative for a distance-trace SVG: the label alone ("Throttle over
+// lap distance") names the picture but carries none of the up-to-200 plotted
+// points (#106, WCAG 1.1.1). ponytail: a range + endpoint is the smallest
+// summary that is still correct for all three channels (throttle/brake %,
+// integer gear steps) — no per-channel phrasing ("full throttle N% of the
+// lap") since that would need a distinct rule per channel for one aria-label.
+function distanceTraceSummary(label: string, values: number[]): string {
+  const known = values.filter((v): v is number => v != null && !Number.isNaN(v));
+  if (known.length === 0) return `${label} over lap distance: no data`;
+  const min = Math.min(...known), max = Math.max(...known);
+  const last = known[known.length - 1];
+  return `${label} over lap distance: ranging ${min} to ${max}, ending at ${last}`;
+}
+
 // DistanceTrace: throttle/brake/gear over lap distance (0-100%), for the
 // reference car (solid) and an optional rival (dashed) overlaid on the same
 // axes — the corner-by-corner telemetry compare. x is track-outline position
@@ -163,13 +177,14 @@ const DistanceTraceRow = memo(function DistanceTraceRow({ label, max, car, rival
     () => (rival ? toPolyline(pick(rival), max) : ''),
     [rival, max, pick],
   );
+  const summary = useMemo(() => distanceTraceSummary(label, pick(car)), [label, car, pick]);
   return (
     <div className="tele-row" style={{ alignItems: 'center' }}>
       <span className="tele-label">{label}</span>
       <svg
         viewBox={`0 0 100 ${TRACE_H}`} preserveAspectRatio="none"
         style={{ flex: 1, height: TRACE_H, width: '100%' }}
-        role="img" aria-label={`${label} over lap distance`}
+        role="img" aria-label={summary}
       >
         <polyline points={carPoints} fill="none" stroke="var(--good)" strokeWidth={1.5} vectorEffect="non-scaling-stroke" />
         {rival && (


### PR DESCRIPTION
## Summary

- **#105**: The pit-stop duration tick on the strategy timeline was drawn as a plain amber bar directly on top of the tyre-compound colour, so it disappeared against HARD/MEDIUM compounds (well under WCAG 1.4.11's 3:1 floor). It now gets a dark casing outline that holds contrast against any compound, and the dead `var(--amber, orange)` CSS fallback is gone.
- **#106**: The throttle/brake/gear distance-trace charts in the telemetry panel had a generic `aria-label` like "Throttle over lap distance" that named the picture but carried none of its ~200 plotted points. The label now folds in a range + endpoint summary (e.g. "Throttle over lap distance: ranging 0 to 100, ending at 100") so screen-reader users get actual trace data.
- **#121**: Added `TelemetryPanel.trace.test.tsx`, a render test covering the previously-untested `DistanceTrace` rendering path: equal-length samples, mismatched car/rival trace lengths, NaN/undefined samples, empty arrays, and gear's integer steps.

## Test plan

- [x] `npx eslint src --max-warnings 0`
- [x] `npx tsc -b`
- [x] `npx vitest run` (275 passed)
- [x] `python scripts/gen_file_map.py` (new test file added)

Closes #105
Closes #106
Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)