### PR TITLE
chore: pin floating version refs; add live-timing parser edge-case tests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -50,3 +50,21 @@ updates:
     groups:
       actions-minor-patch:
         update-types: ["minor", "patch"]
+
+  # Docker base images pinned to sha256 digests (Dockerfile, docker-compose.yml)
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+
+  # Docker base image pinned to a sha256 digest (ingest/Dockerfile.live)
+  - package-ecosystem: docker
+    directory: "/ingest"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: lycheeverse/lychee-action@v2
+      - uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
         with:
           args: "--no-progress --exclude-loopback README.md CONTEXT.md docs/*.md docs/adr/**/*.md"
           fail: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # and ships the gateway/replay server.
 
 # Build the React SPA
-FROM node:24 AS web
+FROM node:24@sha256:be23f54a88d34e8824c741b19b91064094f92c1c97b194144bfc8b50d67258e2 AS web
 WORKDIR /web
 COPY web/package*.json ./
 RUN npm ci
@@ -10,7 +10,7 @@ COPY web/ ./
 RUN npm run build   # outputs web/dist
 
 # Build the Go server, embedding the SPA
-FROM golang:1.26 AS build
+FROM golang:1.26@sha256:9d2f36f06329b2a141b9db99ffa32765cf695ee57b813ca29e245e8670bcbfff AS build
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
@@ -19,7 +19,7 @@ COPY --from=web /web/dist ./web/dist
 RUN CGO_ENABLED=0 go build -o /server ./cmd/server
 
 # Minimal runtime image — :nonroot runs as an unprivileged UID by default
-FROM gcr.io/distroless/static-debian12:nonroot
+FROM gcr.io/distroless/static-debian12:nonroot@sha256:afa5c872c891853ca7fcf1f12c3edb23f7eeef36189728842dd51042ff57f7ab
 COPY --from=build /server /server
 COPY --from=build /src/data /data
 ENV CLIP_FILE=/data/replays/monza-2024-race.jsonl

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   redis:
-    image: redis:7-alpine
+    image: redis:7-alpine@sha256:ff02b58f971e7d7d156a1267e283fcbbeee91773b6aa36c49dac28ecfe28eadf
     # No host port: services reach Redis over the compose network (redis://redis:6379).
     # Nothing outside the compose network needs it, so it isn't exposed to the host/LAN.
 

--- a/ingest/Dockerfile.live
+++ b/ingest/Dockerfile.live
@@ -1,6 +1,6 @@
 # Container image for the true-live SignalR ingest path (ingest/live.py).
 
-FROM python:3.11-slim
+FROM python:3.11-slim@sha256:9534e5a8e315485d4061ed659af0fd78a284c015f9b73661b41d6bab25604534
 WORKDIR /app
 COPY ingest/requirements-live.txt ./
 RUN pip install --no-cache-dir -r requirements-live.txt

--- a/ingest/requirements.txt
+++ b/ingest/requirements.txt
@@ -6,4 +6,4 @@ fastf1==3.8.3
 numpy==2.4.6
 # Transitive via fastf1's CacheControl / signalrcore — pinned up from the resolved
 # 1.1.2 to fix GHSA-6v7p-g79w-8964.
-msgpack>=1.2.1
+msgpack>=1.2.1,<2

--- a/ingest/test_live_parsers.py
+++ b/ingest/test_live_parsers.py
@@ -52,6 +52,14 @@ def test_parse_gap_str_lapped_suffix():
     assert _parse_gap_str("LAP") == (None, None)  # no digits to extract
 
 
+def test_parse_gap_str_lap_with_number_format():
+    # "LAP 12" (word, space, number) is a documented real payload shape
+    # (issue #122 / docs/adr/0007) distinct from the "1L"/"2 LAP" suffix
+    # forms already covered above.
+    # UNVERIFIED against a live session: pins current behaviour
+    assert _parse_gap_str("LAP 12") == (None, 12)
+
+
 def test_parse_laptime_str():
     cases = [
         ("1:25.633", 85633),
@@ -91,6 +99,19 @@ def test_parse_timing_line_missing_fields_returns_partial_dict():
     assert _parse_timing_line({"NumberOfLaps": "not-a-number"}) == {}
 
 
+def test_parse_timing_line_malformed_nested_fields_ignored():
+    # A driver line where the nested fields aren't the documented shape
+    # (IntervalToPositionAhead/LastLapTime as dicts, GapToLeader as a str)
+    # must degrade to a partial dict rather than raising.
+    # UNVERIFIED against a live session: pins current behaviour
+    drv_data = {
+        "GapToLeader": None,  # not a str -> ignored
+        "IntervalToPositionAhead": "0.512",  # not a dict -> ignored
+        "LastLapTime": ["1:25.633"],  # not a dict -> ignored
+    }
+    assert _parse_timing_line(drv_data) == {}
+
+
 def test_parse_tyre_line_dict_stints_picks_highest_index():
     app_data = {
         "Stints": {
@@ -110,6 +131,14 @@ def test_parse_tyre_line_no_stints_returns_empty():
     assert _parse_tyre_line({}) == {}
     assert _parse_tyre_line({"Stints": {}}) == {}
     assert _parse_tyre_line({"Stints": []}) == {}
+
+
+def test_parse_tyre_line_current_entry_not_dict_returns_empty():
+    # A malformed feed where the "current" stint entry isn't itself a dict
+    # (e.g. a bare string/number slipped into Stints) must not raise.
+    # UNVERIFIED against a live session: pins current behaviour
+    assert _parse_tyre_line({"Stints": {"0": "MEDIUM"}}) == {}
+    assert _parse_tyre_line({"Stints": [None]}) == {}
 
 
 def test_map_status():
@@ -176,13 +205,16 @@ if __name__ == "__main__":
     test_parse_gap_str_numeric()
     test_parse_gap_str_negative_clamped_to_zero()
     test_parse_gap_str_lapped_suffix()
+    test_parse_gap_str_lap_with_number_format()
     test_parse_laptime_str()
     test_parse_timing_line_full()
     test_parse_timing_line_lapped_gap()
     test_parse_timing_line_missing_fields_returns_partial_dict()
+    test_parse_timing_line_malformed_nested_fields_ignored()
     test_parse_tyre_line_dict_stints_picks_highest_index()
     test_parse_tyre_line_list_stints_picks_last()
     test_parse_tyre_line_no_stints_returns_empty()
+    test_parse_tyre_line_current_entry_not_dict_returns_empty()
     test_map_status()
     test_safe_int()
     test_decode_position_payload_dict_shapes()


### PR DESCRIPTION
## Summary

- Pins the remaining floating version references: `lychee-action` to a full commit SHA (matching the `okf.yml` pattern), all Docker base images (`node:24`, `golang:1.26`, the distroless runtime image, `python:3.11-slim`, `redis:7-alpine`) to their current `sha256` digests, and adds an upper bound to `msgpack` (`>=1.2.1,<2`). No versions were upgraded — only pinned.
- Adds a handful of edge-case unit tests to `ingest/test_live_parsers.py` for the UNVERIFIED live-timing parsers (`_parse_gap_str`, `_parse_timing_line`, `_parse_tyre_line`): the "LAP 12" gap format and malformed nested-field/stint shapes. Each new test is marked `# UNVERIFIED against a live session: pins current behaviour` since the parsers can't be semantically verified until WS5 (F1TV auth) lands a real session — these only convert "does it raise on realistic-shaped input" into a fast, offline-checkable assertion.
- `ingest/requirements-live-nodeps.txt` is untouched; its documented `--no-deps` install order (patched msgpack first, then signalrcore) still holds.

## Test plan

- [x] `cd ingest && python -m pytest -q` — 100 passed, 1 skipped (no regressions; the known `check_gap_estimator` failure from #103 did not reproduce)
- [x] `python scripts/gen_file_map.py` — no diff (no new files)
- [x] Manually reviewed `.github/workflows/ci.yml` YAML after edit

Closes #118
Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)