### PR TITLE
fix: NaN-safe pedal-trace casts and heatmap start/finish wraparound

### DIFF
--- a/ingest/ghost.py
+++ b/ingest/ghost.py
@@ -6,6 +6,18 @@ lap selection, and coordinate normalisation, then hands plain lists here.
 """
 
 
+def nan_safe_int(values):
+    """Cast a sequence of floats to ints, substituting 0 for NaN.
+
+    A dropped telemetry sample (a gap not backfilled by FastF1) shows up as NaN
+    in FastF1's car_data; NumPy's float->int cast on NaN doesn't raise, it
+    silently produces an implementation-defined garbage int (#111). `v != v` is
+    the NaN check that needs no numpy/math import, keeping this module free of
+    third-party deps (see module docstring).
+    """
+    return [0 if v != v else int(v) for v in values]
+
+
 def build_lap_trace(sample_ts, sample_xy, track_xy):
     """Cumulative lap time (ms from lap start) at each track-outline index.
 
@@ -104,7 +116,10 @@ def compute_sector_dominance(lap_traces, n_points, bin_size):
 
     Returns one driver number per bin — the driver with the least elapsed time
     across that bin's window — or 0 when no driver has a positive time delta
-    there (e.g. too few points, or no lap trace data at all).
+    there (e.g. too few points, or no lap trace data at all). An extra final
+    entry covers the start/finish wraparound (trace[0] back to trace[n-1]),
+    matching web/src/components/geometry.ts's trackSegmentPaths, which appends
+    the equivalent closing segment (#112).
     """
     out = []
     for start in range(0, n_points, bin_size):
@@ -117,4 +132,10 @@ def compute_sector_dominance(lap_traces, n_points, bin_size):
             if best_delta is None or delta < best_delta:
                 best_delta, best_driver = delta, dnum
         out.append(best_driver)
+    # The wraparound stretch (outline index n-1 back to 0) isn't covered by any
+    # bin above, and no lap trace carries a sample for "time to close the loop"
+    # past its own last index — there's nothing to compare there. Reuse the last
+    # bin's leader so the closing segment reads as a continuation of it rather
+    # than falling back to an unowned/neutral colour.
+    out.append(out[-1] if out else 0)
     return out

--- a/ingest/record.py
+++ b/ingest/record.py
@@ -45,7 +45,7 @@ from pathlib import Path
 from fastf1 import _api
 from radio import extract_radio
 from race_control import extract_race_control
-from ghost import build_lap_trace, build_pedal_trace, compute_sector_dominance
+from ghost import build_lap_trace, build_pedal_trace, compute_sector_dominance, nan_safe_int
 from resample import nearest_index, step_value, in_window_ms, reconcile_positions, UNKNOWN_POS, normalise_point
 from live_parsers import TEAM_MAP
 from geometry import (
@@ -356,9 +356,14 @@ for num in session.drivers:
             if len(cd_lap) >= 2:
                 cd_t = cd_lap['SessionTime'].dt.total_seconds().values
                 idx = np.array([nearest_index(cd_t, q) for q in sample_ts])
-                throttle_vals = cd_lap['Throttle'].values[idx].astype(int)
-                brake_vals = (cd_lap['Brake'].values[idx].astype(float) > 0).astype(int) * 100
-                gear_vals = cd_lap['nGear'].values[idx].astype(int)
+                # A dropped telemetry sample within the lap window (not backfilled by
+                # FastF1) leaves NaN here; casting straight to int (numpy's .astype(int))
+                # silently produces an implementation-defined garbage int instead of
+                # raising (#111). nan_safe_int zeroes those out first.
+                throttle_vals = nan_safe_int(cd_lap['Throttle'].values[idx].astype(float))
+                brake_raw = cd_lap['Brake'].values[idx].astype(float)
+                brake_vals = [100 if (v == v and v > 0) else 0 for v in brake_raw]
+                gear_vals = nan_safe_int(cd_lap['nGear'].values[idx].astype(float))
                 pedal_traces[inum] = build_pedal_trace(
                     sample_ts, sample_xy, _outline_xy, throttle_vals, brake_vals, gear_vals
                 )

--- a/ingest/test_ghost.py
+++ b/ingest/test_ghost.py
@@ -4,7 +4,7 @@ Collectable by pytest (`pytest ingest`) AND runnable directly
 (`python ingest/test_ghost.py`) for the CI contract job.
 """
 import sys
-from ghost import build_lap_trace, build_pedal_trace, compute_sector_dominance
+from ghost import build_lap_trace, build_pedal_trace, compute_sector_dominance, nan_safe_int
 
 
 def test_build_lap_trace_basic():
@@ -90,11 +90,30 @@ def test_compute_sector_dominance_picks_fastest_per_bin():
         2: [0, 2000, 2500, 2600],
     }
     out = compute_sector_dominance(lap_traces, n_points=4, bin_size=2)
-    assert out == [1, 2], out
+    # [1, 2] for the two real bins, plus one extra wraparound entry (#112).
+    assert out == [1, 2, 2], out
 
 
 def test_compute_sector_dominance_no_data_is_zero():
-    assert compute_sector_dominance({}, n_points=4, bin_size=2) == [0, 0]
+    assert compute_sector_dominance({}, n_points=4, bin_size=2) == [0, 0, 0]
+
+
+def test_compute_sector_dominance_wraparound_matches_frontend_segment_count():
+    # geometry.ts's trackSegmentPaths appends one closing segment (track[n-1] ->
+    # track[0]) on top of its ceil(n_points/bin_size) binned segments; this
+    # array must carry a matching extra entry so segment i still lines up with
+    # sectorDominance[i] on both sides of the contract (#112).
+    lap_traces = {1: [0, 1000, 1500, 3500]}
+    out = compute_sector_dominance(lap_traces, n_points=4, bin_size=2)
+    assert len(out) == 3  # 2 binned entries + 1 wraparound entry
+    assert out[-1] == out[-2]  # wraparound reuses the last bin's leader
+
+
+def test_nan_safe_int_zeroes_a_telemetry_gap():
+    # A dropped car_data sample surfaces as NaN (#111); nan_safe_int must not let
+    # NumPy's undefined float->int NaN cast (a garbage large-negative int) through.
+    nan = float("nan")
+    assert nan_safe_int([10.0, nan, 90.0]) == [10, 0, 90]
 
 
 def test_compute_sector_dominance_skips_non_positive_deltas():
@@ -114,6 +133,8 @@ if __name__ == "__main__":
     test_build_pedal_trace_carries_unvisited_index_forward()
     test_compute_sector_dominance_picks_fastest_per_bin()
     test_compute_sector_dominance_no_data_is_zero()
+    test_compute_sector_dominance_wraparound_matches_frontend_segment_count()
     test_compute_sector_dominance_skips_non_positive_deltas()
+    test_nan_safe_int_zeroes_a_telemetry_gap()
     print("ghost.build_lap_trace / build_pedal_trace / compute_sector_dominance self-check PASSED")
     sys.exit(0)

--- a/web/src/components/geometry.test.ts
+++ b/web/src/components/geometry.test.ts
@@ -1,7 +1,7 @@
 // Tests that track outlines are letterboxed into the square viewBox without distortion.
 
 import { describe, it, expect } from 'vitest';
-import { SIZE, fitViewBox, trackPathD } from './geometry';
+import { SIZE, fitViewBox, trackPathD, trackSegmentPaths } from './geometry';
 
 // A portrait outline shaped like the real thing: Monza's baked outline measures
 // roughly 348 × 600 inside the 600 unit square, letterboxed left and right.
@@ -23,6 +23,18 @@ describe('trackPathD', () => {
 
   it('is empty before the outline arrives, so TrackPath can bail out', () => {
     expect(trackPathD([])).toBe('');
+  });
+});
+
+describe('trackSegmentPaths', () => {
+  it('closes the start/finish wraparound like trackPathD does with its Z (#112)', () => {
+    const track = [{ x: 0, y: 0 }, { x: 1, y: 0 }, { x: 1, y: 1 }, { x: 0, y: 1 }];
+    const paths = trackSegmentPaths(track, 2);
+    const last = paths[paths.length - 1];
+    // The closing segment must run from the outline's last point (index 3:
+    // {0, 1}) back to its first ({0, 0}) — the exact stretch the plain path's
+    // ' Z' draws that the heatmap segments previously skipped.
+    expect(last).toBe(`M ${0 * SIZE},${1 * SIZE} L ${0 * SIZE},${0 * SIZE}`);
   });
 });
 

--- a/web/src/components/geometry.ts
+++ b/web/src/components/geometry.ts
@@ -37,6 +37,14 @@ export function trackSegmentPaths(track: Pt[], binSize: number = MINISECTOR_SIZE
     const pts = track.slice(start, end + 1);
     paths.push('M ' + pts.map((p) => `${p.x * SIZE},${p.y * SIZE}`).join(' L '));
   }
+  // The plain (non-heatmap) path closes the loop with an explicit ' Z' back to
+  // track[0]; the binned segments above stop at track[n-1], so the short
+  // start/finish stretch was never drawn by any stroke (#112). Append one more
+  // closing segment — matching compute_sector_dominance's extra wrap bin, so
+  // this array's length still lines up 1:1 with sectorDominance.
+  const last = track[n - 1];
+  const first = track[0];
+  paths.push(`M ${last.x * SIZE},${last.y * SIZE} L ${first.x * SIZE},${first.y * SIZE}`);
   return paths;
 }
 


### PR DESCRIPTION
## #111 — telemetry gaps produced garbage throttle/gear ints

`ingest/record.py` cast `Throttle`/`Brake`/`nGear` straight to `int` after
picking samples near the reference lap. When FastF1's `car_data` has a
dropped sample, that value is `NaN`, and NumPy's float->int cast on `NaN`
doesn't raise — it silently writes an implementation-defined garbage integer
onto the wire contract. Added `ghost.nan_safe_int`, a small pure helper (no
numpy/pandas, matching the rest of `ghost.py`) that zeroes NaN out before the
cast, and used it for throttle/gear (brake's boolean comparison already
happened to read a NaN sample as "off"). Added a pytest that feeds it a NaN
gap.

## #112 — sector-dominance heatmap missing the start/finish segment

The plain-path outline closes the loop with a trailing `' Z'`, but the
sector-dominance heatmap's per-minisector segments (`trackSegmentPaths` in
`web/src/components/geometry.ts`) stopped at the last outline point, and the
backend's `compute_sector_dominance` (`ingest/ghost.py`) had the identical
gap in its binning — so the short stretch of track right at the start/finish
line was never drawn by any stroke. Both now emit one extra closing
entry (`track[n-1]` back to `track[0]`), keeping the two arrays the same
length so segment *i* still lines up with `sectorDominance[i]`. Added a
vitest asserting the last segment reaches the first point, and a pytest
asserting the backend's array grows by the matching one entry.

## Tests
- `ingest`: `python -m pytest -q` — 99 passed, 1 skipped
- `web`: `npx eslint src --max-warnings 0`, `npx tsc -b`, `npx vitest run` — all clean, 277 tests passed

Closes #111
Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)